### PR TITLE
fix: add missing 500 error template

### DIFF
--- a/templates/500.html
+++ b/templates/500.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Internal Server Error - DevPath</title>
+  <link rel="stylesheet" href="/static/style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@400;500&display=swap" rel="stylesheet" />
+</head>
+<body>
+  <nav class="navbar">
+    <div class="nav-inner">
+      <a href="/" class="nav-logo">DevPath</a>
+    </div>
+  </nav>
+  <div class="error-page">
+    <div class="error-page-inner">
+      <div class="error-code">500</div>
+      <h1>Internal Server Error</h1>
+      <p>Something went wrong on our side. Please try again in a moment.</p>
+      <a href="/" class="btn-primary" style="display:inline-block;text-decoration:none;padding:14px 32px;">Back to Home</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -23,7 +23,7 @@ from utils.recommender import (
     parse_skills,
     score_single_project,
 )
-from app import app
+from app import app, internal_server_error
 
 
 # ============================================================
@@ -253,6 +253,16 @@ def test_project_detail_not_found():
     client = get_client()
     response = client.get("/project/99999")
     assert response.status_code == 404
+
+
+def test_internal_server_error_page():
+    """The 500 handler should render the friendly internal error template."""
+    with app.app_context():
+        rendered_page, status_code = internal_server_error(Exception("Test error"))
+
+    assert status_code == 500
+    assert "Internal Server Error" in rendered_page
+    assert "Back to Home" in rendered_page
 
 
 def test_view_code_found():


### PR DESCRIPTION
## Summary [required]

This PR fixes the registered internal server error handler by adding the missing `templates/500.html` page. Without this template, Flask can raise a secondary `TemplateNotFound: 500.html` error when handling an unexpected server error. The new page follows the same structure as the existing `404.html` template and includes a regression test for the 500 handler.

## Related Issue [required]

Closes #66

## Type of Change [required]

- [x] Bug fix - resolves a broken behaviour
- [ ] Feature - adds new functionality
- [ ] Data - adds new projects to `data/projects.json`
- [ ] Documentation - updates docs, README, or code comments only
- [ ] Style - CSS or visual changes only, no logic change
- [ ] Refactor - restructures code without changing behaviour
- [x] Test - adds or updates tests

## What Was Changed [required]

| File | Change made |
|------|-------------|
| `templates/500.html` | Added a friendly internal server error page matching the existing error-page structure. |
| `tests/test_basic.py` | Added a regression test confirming the 500 handler renders the template and returns status 500. |

## How to Test This PR [required]

1. Clone this branch: `git checkout fix/missing-500-template`
2. Install dependencies: `pip install -r requirements.txt`
3. Run the tests: `python tests/test_basic.py`
4. Optionally run the app with `python app.py` and trigger an unhandled server-side exception locally to confirm the friendly 500 page renders.

Expected test output:
```text
28 passed, 0 failed out of 28 tests
```

## Test Results [required]

```text
  PASS  test_projects_json_loads
  PASS  test_each_project_has_required_fields
  PASS  test_find_project_by_id_found
  PASS  test_find_project_by_id_missing
  PASS  test_parse_skills_basic
  PASS  test_parse_skills_empty_string
  PASS  test_parse_skills_single_entry
  PASS  test_score_single_project_full_match
  PASS  test_score_single_project_no_match
  PASS  test_get_recommendations_returns_results
  PASS  test_get_recommendations_max_three
  PASS  test_get_recommendations_no_match_returns_empty
  PASS  test_get_recommendations_result_format
  PASS  test_validate_all_valid
  PASS  test_validate_missing_skills
  PASS  test_validate_missing_level
  PASS  test_validate_missing_interest
  PASS  test_validate_missing_time
  PASS  test_validate_all_missing
  PASS  test_home_route
  PASS  test_recommend_api_valid
  PASS  test_recommend_api_missing_field
  PASS  test_recommend_api_empty_body
  PASS  test_project_detail_found
  PASS  test_project_detail_not_found
  PASS  test_internal_server_error_page
  PASS  test_view_code_found
  PASS  test_download_code_found

28 passed, 0 failed out of 28 tests
```

## Screenshots (if UI change)

No screenshot attached. This adds the missing error template and verifies it through the regression test.

## Self-Review Checklist [required]

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed all guidelines
- [x] My branch name follows the convention: `feat/`, `fix/`, `docs/`, `data/`, `style/`, `test/`
- [x] I have run `python tests/test_basic.py` and all 27 tests pass
- [ ] I have run `flake8 .` locally and there are no errors
- [x] I have not introduced any `print()` or `console.log()` debug statements
- [x] Every new function I wrote has a docstring
- [x] I have not modified files outside the scope of the linked issue
- [ ] If I changed the UI, I tested it at 375px (mobile) and 1280px (desktop)
- [ ] If I added a project to the dataset, it has all required JSON fields

## Notes for Reviewer

`python -m flake8 .` currently reports pre-existing lint issues across unrelated files such as `routes/main_routes.py`, `starter_code/*`, and existing tests. I did not modify those files to keep this PR scoped to issue #66.