### PR TITLE
Add favicon support across site

### DIFF
--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="DevPath — top project matches">
+  <rect width="32" height="32" rx="7" fill="#2335c2"/>
+
+  <!-- Top 3 matched projects (core recommender output) -->
+  <rect x="8" y="7" width="16" height="5" rx="2" fill="#fbbf24" opacity="0.45"/>
+  <rect x="8" y="13.5" width="16" height="5" rx="2" fill="#fbbf24" opacity="0.7"/>
+  <rect x="8" y="20" width="16" height="5" rx="2" fill="#fbbf24"/>
+
+  <!-- #1 match highlight -->
+  <circle cx="22" cy="9.5" r="2.2" fill="#fbbf24"/>
+  <path
+    d="M21.1 9.5 21.9 10.3 23.2 8.7"
+    fill="none"
+    stroke="#2335c2"
+    stroke-width="1.2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/templates/404.html
+++ b/templates/404.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Page Not Found — DevPath</title>
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml" />
   <link rel="stylesheet" href="/static/style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@400;500&display=swap" rel="stylesheet" />
 </head>

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="DevPath recommends real coding projects based on your skills, level, and interests — with full roadmaps and starter code." />
   <title>DevPath — Find Projects Based On Your Skills</title>
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml" />
   <link rel="stylesheet" href="/static/style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
 </head>

--- a/templates/project.html
+++ b/templates/project.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- Page title uses the project title injected by Flask's Jinja2 template engine -->
   <title>{{ project.title }} — DevPath</title>
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml" />
   <link rel="stylesheet" href="/static/style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
 </head>


### PR DESCRIPTION
## Summary

Added a custom SVG favicon for DevPath to improve browser tab branding and remove the default blank icon. The favicon uses the project brand colors and is now applied across the main pages of the site.

Closes #77

---

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Data
- [ ] Documentation
- [x] Style
- [x] Refactor
- [ ] Test

---

## What Was Changed

| File | Change made |
|------|-------------|
| `static/favicon.svg` | Added new SVG favicon using DevPath brand colors |
| `templates/index.html` | Added favicon link tag in `<head>` |
| `templates/project.html` | Added favicon link tag in `<head>` |
| `templates/404.html` | Added favicon link tag in `<head>` |

---

## How to Test

1. Run the app:
```bash
python app.py