### PR TITLE
feat: add /health endpoint for server status check

### DIFF
--- a/routes/main_routes.py
+++ b/routes/main_routes.py
@@ -8,6 +8,7 @@ from flask import Blueprint, render_template, request, jsonify, send_from_direct
 from utils.recommender import get_recommendations, validate_recommendation_inputs
 from utils.data_loader import find_project_by_id
 from utils.file_server import read_starter_code, resolve_starter_file, get_starter_code_dir
+import os
 
 # Create the Blueprint that app.py will register
 main = Blueprint("main", __name__)
@@ -17,6 +18,17 @@ main = Blueprint("main", __name__)
 def index():
     """Render the homepage with the skill input form."""
     return render_template("index.html")
+
+@main.route("/health")
+def health_check():
+    """
+    Returns server status. Useful for uptime monitors and Docker health checks.
+    """
+    import os
+    return jsonify({
+        "status": "ok",
+        "version": os.getenv("APP_VERSION", "1.0.0")
+    }), 200
 
 
 @main.route("/api/recommend", methods=["POST"])


### PR DESCRIPTION
Added a `/health` endpoint to the Flask app that returns the server status and app version. This is useful for uptime monitors, Docker health checks, and CI pipelines. It required no changes to business logic and is fully self-contained in the routes file.

## Related Issue

Closes #126 

## Type of Change

- [x] Feature — adds new functionality

## What Was Changed

| File | Change made |
|------|-------------|
| `routes/main_routes.py` | Added `/health` route that returns `{"status": "ok", "version": "..."}` |

## How to Test This PR

1. Clone this branch: `git checkout feat/health-check-endpoint`
2. Install dependencies: `pip install -r requirements.txt`
3. Run the app: `python app.py`
4. Visit http://127.0.0.1:5000/health in your browser

Expected response:
{ "status": "ok", "version": "1.0.0" }

5. Run the tests: `python tests/test_basic.py`

## Test Results

{ "status": "ok", "version": "1.0.0" }

## Self-Review Checklist

- [x] I have read CONTRIBUTING.md and followed all guidelines
- [x] My branch name follows the convention: `feat/health-check-endpoint`
- [x] I have run `python tests/test_basic.py` and all 27 tests pass
- [ ] I have run `flake8 .` locally and there are no errors
- [ ] I have not introduced any `print()` debug statements
- [ ] Every new function I wrote has a docstring
- [ ] I have not modified files outside the scope of the linked issue

## Notes for Reviewer

The `APP_VERSION` is read from an environment variable, defaulting to `"1.0.0"` if not set.