### PR TITLE
feat: add dynamic Open Graph and Twitter Card meta tags to project pages

### DIFF
--- a/templates/project.html
+++ b/templates/project.html
@@ -5,6 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- Page title uses the project title injected by Flask's Jinja2 template engine -->
   <title>{{ project.title }} — DevPath</title>
+  <meta property="og:title" content="{{ project.title }} — DevPath" />
+<meta property="og:description" content="{{ project.description[:155] }}" />
+<meta property="og:type" content="article" />
+<meta property="og:url" content="https://mydevpath-github.vercel.app/project/{{ project.id }}" />
+
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:title" content="{{ project.title }} — DevPath" />
+<meta name="twitter:description" content="{{ project.description[:155] }}" />
   <link rel="stylesheet" href="/static/style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
 </head>


### PR DESCRIPTION
## Description

Added dynamic Open Graph and Twitter Card meta tags to `templates/project.html` for project detail pages.

The tags now dynamically render:

* project title
* project description
* project URL

This improves social media sharing previews for individual project pages when shared on platforms like LinkedIn, WhatsApp, Discord, and Twitter/X.

## Changes Made

* Added `og:title`
* Added `og:description`
* Added `og:type`
* Added `og:url`
* Added `twitter:card`
* Added `twitter:title`
* Added `twitter:description`

## Testing

* Ran the Flask app locally using `python app.py`
* Verified tags using page source inspection (`Ctrl + U`)
* Tested across multiple project pages to confirm dynamic rendering

## Related Issue

Fixes #94

## Screenshots

Added dynamic OG and Twitter meta tags visible in the page source for different project pages.
<img width="1817" height="336" alt="Screenshot 2026-05-16 124304" src="https://github.com/user-attachments/assets/ef655de8-10a7-4dc8-a60e-96e449f1db42" />
