### PR TITLE
Add autofocus to skills input field

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -257,6 +257,7 @@
                 <input
                   type="text"
                   id="skills-input"
+                  autofocus
                   placeholder="Type a skill and press Enter..."
                   autocomplete="off"
                   aria-haspopup="listbox"


### PR DESCRIPTION
## Summary [required]

Added the `autofocus` attribute to the `#skills-input` field in `templates/index.html` so users can start typing immediately when the homepage loads. This improves the overall user experience by automatically focusing the primary input field without changing any existing functionality, JavaScript logic, or styling.

## Related Issue [required]

Closes #83

## Type of Change [required]

- [x] Bug fix — resolves a broken behaviour
- [ ] Feature — adds new functionality
- [ ] Data — adds new projects to `data/projects.json`
- [ ] Documentation — updates docs, README, or code comments only
- [ ] Style — CSS or visual changes only, no logic change
- [ ] Refactor — restructures code without changing behaviour
- [ ] Test — adds or updates tests

## What Was Changed [required]

| File | Change made |
|------|-------------|
| `templates/index.html` | Added the `autofocus` attribute to the `#skills-input` element |

## How to Test This PR [required]

1. Clone this branch:
   ```bash
   git checkout autofocus-clean