### PR TITLE
feat: personalise <title> tag on project detail page with level and skill

### DIFF
--- a/templates/project.html
+++ b/templates/project.html
@@ -4,9 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- Page title uses the project title injected by Flask's Jinja2 template engine -->
-  <title>{{ project.title }} — DevPath</title>
+  
   <link rel="icon" href="/static/favicon.svg" type="image/svg+xml" />
-
+  <title>{{ project.title }} — {{ project.level }}{% if project.skills %} {{ project.skills[0] }}{% endif %} Project | DevPath</title>
+  
   <meta property="og:title" content="{{ project.title }} — DevPath" />
   <meta property="og:description" content="{{ project.description[:155] }}" />
   <meta property="og:type" content="article" />


### PR DESCRIPTION
## Summary

The project detail page `<title>` tag previously rendered as 
`Project Name — DevPath`, which is functional but misses an SEO 
opportunity. This PR updates the title in `templates/project.html` 
to include the project's difficulty level and primary skill/interest 
area, making pages more discoverable for users searching for specific 
project ideas (e.g. "Beginner Python projects"). A Jinja2 `{% if %}` 
guard is included to handle projects with an empty skills list safely.

## Related Issue

Closes #84 

## Type of Change

- [ ] Bug fix — resolves a broken behaviour
- [x] Feature — adds new functionality
- [ ] Data — adds new projects to `data/projects.json`
- [ ] Documentation — updates docs, README, or code comments only
- [ ] Style — CSS or visual changes only, no logic change
- [ ] Refactor — restructures code without changing behaviour
- [ ] Test — adds or updates tests

## What Was Changed

| File | Change made |
|------|-------------|
| `templates/project.html` | Updated `<title>` tag to include `project.level` and `project.skills[0]` with an `{% if project.skills %}` guard |

## How to Test This PR

1. Clone this branch: `git checkout feat/personalise-project-detail-title`
2. Install dependencies: `pip install -r requirements.txt`
3. Run the app: `python app.py`
4. Open `http://127.0.0.1:5000` and navigate to any project detail page
5. Check the browser tab — title should now read:  
   `Personal Expense Tracker — Beginner Python Project | DevPath`  
   instead of `Personal Expense Tracker — DevPath`
6. Run the tests: `python tests/test_basic.py`

Expected test output:
30 passed, 0 failed out of 30 tests

## Test Results  

<img width="432" height="376" alt="image" src="https://github.com/user-attachments/assets/2e9584fa-eaeb-40c0-bab4-585a4ede96e9" />
                                          
| Before | After |
|--------|-------|
| 
<img width="1912" height="1018" alt="image" src="https://github.com/user-attachments/assets/a8fdb21b-cb1d-43da-989b-f4f488cd7ab6" />
 | 
<img width="1912" height="1018" alt="image" src="https://github.com/user-attachments/assets/c71b7663-49f7-466b-8c5a-dcd3cf6401d9" />
 |

## Self-Review Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed all guidelines
- [x] My branch name follows the convention: `feat/personalise-project-detail-title`
- [x] I have run `python tests/test_basic.py` and all 30 tests pass
- [x] I have run `flake8 .` locally and there are no errors
- [x] I have not introduced any `print()` or `console.log()` debug statements
- [x] Every new function I wrote has a docstring
- [x] I have not modified files outside the scope of the linked issue
- [x] If I changed the UI, I tested it at 375px (mobile) and 1280px (desktop)

## Notes for Reviewer

The only file changed is `templates/project.html` — one line. No Python 
logic, no routes, no data files were touched. The `{% if project.skills %}` 
guard ensures the title renders gracefully even if a project entry has an 
empty or missing skills list.