### PR TITLE
Add category badges to project detail page (Fixes #22)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -128,6 +128,48 @@ ul, ol { list-style: none; }
   line-height: 1.75;
 }
 
+/* ---- Badges ------------------------------------------------ */
+.badge-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+  margin-bottom: 24px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 12px;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: var(--gray-100);
+  color: var(--gray-600);
+}
+
+.badge--beginner {
+  background: var(--green-100);
+  color: var(--green-500);
+}
+
+.badge--web {
+  background: var(--indigo-100);
+  color: var(--indigo-600);
+}
+
+.badge--python {
+  background: var(--yellow-100);
+  color: var(--orange-500);
+}
+
+.badge--data {
+  background: var(--purple-100);
+  color: var(--purple-600);
+}
+
 /* ---- Navigation ------------------------------------------- */
 .navbar {
   position: fixed;

--- a/templates/project.html
+++ b/templates/project.html
@@ -37,14 +37,16 @@
 
       <div class="detail-hero-content">
         <div class="detail-hero-left">
-          <!-- Difficulty and interest tags -->
-          <div class="detail-tags">
-            <span class="detail-tag detail-tag--level">{{ project.level }}</span>
-            <span class="detail-tag detail-tag--interest">{{ project.interest }}</span>
-            <span class="detail-tag detail-tag--time">{{ project.time }} effort</span>
-          </div>
-
           <h1 class="detail-title">{{ project.title }}</h1>
+          <!-- Difficulty, interest, and skill badges -->
+          <div class="badge-group">
+            <span class="badge badge--{{ project.level | lower }}">{{ project.level }}</span>
+            <span class="badge badge--{{ project.interest | lower }}">{{ project.interest }}</span>
+            {% for skill in project.skills %}
+            <span class="badge badge--{{ skill | lower }}">{{ skill }}</span>
+            {% endfor %}
+            <span class="badge badge--time">{{ project.time }} effort</span>
+          </div>
           <p class="detail-description">{{ project.description }}</p>
         </div>
 


### PR DESCRIPTION
Hey! This PR tackles #22. 

I've added the new category badges to the project detail page so the difficulty, skills, and effort levels are much easier to scan at a glance. 

**What changed:**
- Added a `.badge` base class and a few modifier classes (like `.badge--beginner`, `.badge--python`, etc.) to `style.css` so we can reuse them on other pages if needed.
- Swapped out the old `.detail-tags` block for a new `.badge-group` flex container right under the project title.
- Updated the HTML template to automatically pull the project level, interest, time, and skills into these badges.

Let me know if the colors or spacing need any tweaking. Thanks!

