### PR TITLE
Add regression test and contributor guidance for external links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,6 +208,13 @@ def score_single_project(project, user_skills, level, interest, time_availabilit
 
 ---
 
+### External Links
+
+- External URLs added to `projects.json` are rendered using `target="_blank"`
+- Only include trustworthy, safe, and relevant links
+- Avoid shortened or obfuscated URLs
+- Verify that all links are accessible before submitting a PR
+
 ## Commit Message Format
 
 Use the same `type/scope: description` format as branch names for commit messages.

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -270,6 +270,16 @@ def test_download_code_found():
     response = client.get("/project/1/download")
     assert response.status_code == 200
 
+def test_project_links_have_noopener():
+    client = app.test_client()
+
+    response = client.get("/project/1")
+
+    assert response.status_code == 200
+    assert b'target="_blank"' in response.data
+    assert b'rel="noopener noreferrer"' in response.data
+
+
 
 # ============================================================
 # Run tests directly (no pytest required)


### PR DESCRIPTION
## Summary

Audited dynamically rendered external links in `project.html` and confirmed that links using `target="_blank"` already include:

```html id="gm6wwf"
rel="noopener noreferrer"
```

## Changes

* Added regression test to ensure external resource links continue including `noopener noreferrer`
* Added contributor guidance for external URLs in `CONTRIBUTING.md`

## Testing

```bash id="7e8b57"
python tests/test_basic.py
```

Result:

```text id="uxmt7j"
28 passed, 0 failed
```

## Why

This helps prevent accidental regressions and reminds contributors to submit trustworthy external links.
