### PR TITLE
fix: resolve duplicate form field ids in homepage form

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -349,7 +349,7 @@
               </label>
               <div class="skill-input-wrap" id="skill-input-wrap">
                 <div class="skill-chips-selected" id="skill-chips-selected"></div>
-                <input type="text" id="skills-input" placeholder="Type a skill and press Enter..." autocomplete="off" />
+                
                 <input
                   type="text"
                   id="skills-input"


### PR DESCRIPTION

## Description

Resolved duplicate form field ID issues in the homepage project recommendation form.

## Related Issue

Closes #231

## Changes Made

* Removed duplicate `skills-input` field from the form
* Kept the accessible input version with ARIA attributes
* Fixed browser console warning related to duplicate form field IDs
* Improved form accessibility and browser autofill behavior

## Testing

* Tested locally in browser
* Verified form functionality works correctly
* Confirmed duplicate ID warning no longer appears in DevTools console
