### PR TITLE
fix: implement thread-safe in-memory cache in data_loader.py

### DIFF
--- a/utils/data_loader.py
+++ b/utils/data_loader.py
@@ -1,58 +1,58 @@
-# utils/data_loader.py
-# Handles all reading and lookup of project data from the JSON file.
-
 import json
 import os
+import threading
 
-# Build the path to projects.json relative to this file's location
 DATA_FILE = os.path.join(os.path.dirname(__file__), "..", "data", "projects.json")
+
+_projects_cache = None
+_cache_lock = threading.Lock()
 
 
 def load_all_projects():
-    """Read and return the full list of projects from the JSON file."""
-    with open(DATA_FILE, "r", encoding="utf-8") as f:
-        return json.load(f)
+    """Read and return the full list of projects from the JSON file.
+
+    Results are cached in memory after the first read so subsequent calls
+    do not hit the filesystem.
+    """
+    global _projects_cache
+    if _projects_cache is not None:
+        return _projects_cache
+    with _cache_lock:
+        if _projects_cache is None:
+            with open(DATA_FILE, "r", encoding="utf-8") as f:
+                _projects_cache = json.load(f)
+    return _projects_cache
 
 
 def find_project_by_id(project_id):
-    """
-    Return the project dict whose 'id' matches the given integer.
-    Returns None if no match is found.
-    """
+    """Return the project whose 'id' matches project_id, or None."""
     for project in load_all_projects():
         if project.get("id") == project_id:
             return project
     return None
 
-def get_project_stats():
-    """
-    Calculate and return statistics about the projects.
-    Returns: { total_projects, unique_skills, beginner_friendly }
-    """
-    projects = load_all_projects()
-    total_projects = len(projects)
 
-    # Collect all unique skills
+def get_project_stats():
+    """Return total_projects, unique_skills, and beginner_friendly counts."""
+    projects = load_all_projects()
+
     all_skills = set()
+    beginner_friendly = 0
     for p in projects:
         for s in p.get("skills", []):
             all_skills.add(s)
-    unique_skills = len(all_skills)
-
-    # Count beginner projects
-    beginner_friendly = len([p for p in projects if p.get("level") == "Beginner"])
+        if p.get("level") == "Beginner":
+            beginner_friendly += 1
 
     return {
-        "total_projects": total_projects,
-        "unique_skills": unique_skills,
-        "beginner_friendly": beginner_friendly
+        "total_projects": len(projects),
+        "unique_skills": len(all_skills),
+        "beginner_friendly": beginner_friendly,
     }
-
-# Cache for loaded projects
-_projects_cache = None
 
 
 def clear_cache():
-    """Reset the in-memory project cache."""
+    """Reset the in-memory project cache (used in tests)."""
     global _projects_cache
-    _projects_cache = None
+    with _cache_lock:
+        _projects_cache = None


### PR DESCRIPTION
Closes #271

## What was wrong

`utils/data_loader.py` declared `_projects_cache = None` and `clear_cache()`, but `load_all_projects()` never read or wrote the cache. Every HTTP request to `/`, `/api/recommend`, and `/project/<id>` caused at least one redundant `open()` + `json.load()` on the same static file.

## What changed

- `load_all_projects()` now populates `_projects_cache` on the first call and returns the cached list on every subsequent call.
- A `threading.Lock` with double-checked locking prevents a race condition where two concurrent requests during cold start could both read the file.
- `clear_cache()` now acquires the same lock before resetting, making it safe in threaded test environments.
- Minor: collapsed the two-pass loop in `get_project_stats()` into one pass, no behaviour change.

## Tests

All 29 existing tests pass with no changes required:

```
pytest tests/ -v
# 29 passed, 1 error (pre-existing broken fixture in test_health_check, unrelated to this PR)
```

## Type of change

- [x] Bug fix
- [x] Performance improvement