### PR TITLE
fix: resolve missing pytest fixture in test_health_check

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -280,7 +280,8 @@ def test_download_code_found():
     response = client.get("/project/1/download")
     assert response.status_code == 200
     
-def test_health_check(client):
+def test_health_check():
+    client = get_client()
     response = client.get("/health")
     assert response.status_code == 200
     data = response.get_json()


### PR DESCRIPTION
Closes #273

## What was wrong

`test_health_check(client)` declared `client` as a parameter, expecting a pytest fixture that was never defined anywhere in the test file. Every other test uses the local `get_client()` helper directly. This caused pytest to report an `ERROR` on every run, meaning the `/health` endpoint was never actually tested.

## What changed

Removed the `client` parameter and added `client = get_client()` inside the function body, consistent with all other tests in the file.

## Tests

```
pytest tests/ -v
# 30 passed  (was: 29 passed, 1 error)
```

## Type of change

- [x] Bug fix (test infrastructure)