### PR TITLE
fix: remove duplicate skills input field in templates/index.html

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -361,7 +361,6 @@
               </div>
               <div class="skill-input-wrap" id="skill-input-wrap">
                 <div class="skill-chips-selected" id="skill-chips-selected"></div>
-                <input type="text" id="skills-input" placeholder="Type a skill and press Enter..." autocomplete="off" />
                 <input
                   type="text"
                   id="skills-input"


### PR DESCRIPTION
## Summary

Removed a duplicate <input> element with id="skills-input" from 
templates/index.html. Two input fields with the same ID is invalid 
HTML and causes accessibility issues.

## Related Issue

Closes #258

## Type of Change 

- [x] Bug fix — resolves a broken behaviour
- [ ] Feature — adds new functionality
- [ ] Data — adds new projects to `data/projects.json`
- [ ] Documentation — updates docs, README, or code comments only
- [ ] Style — CSS or visual changes only, no logic change
- [ ] Refactor — restructures code without changing behaviour
- [ ] Test — adds or updates tests

## What Was Changed 

| File | Change made |
|------|-------------|
| `templates/index.html` | Removed duplicate skills input element |

## How to Test This PR 

1. Clone this branch: `git checkout feat/autocomplete-off-skills-input`
2. Install dependencies: `pip install -r requirements.txt`
3. Run the app: `python app.py`
4. Open http://127.0.0.1:5000
5. Inspect the skills input field using browser DevTools
6. Verify only one input with id="skills-input" exists in the DOM
7. Run the tests: `python tests/test_basic.py`

Expected test output:
```
30 passed, out of 30 tests
```

## Test Results [required]

<img width="432" height="376" alt="image" src="https://github.com/user-attachments/assets/bf59a340-8c4f-47b4-8f29-23cd365545b9" />

## Screenshots 

| Before | After |
|--------|-------|
| 
<img width="939" height="635" alt="Screenshot 2026-05-18 150053" src="https://github.com/user-attachments/assets/111be2d7-7171-4683-acc0-20bdad4e05ee" />
 | 
<img width="941" height="593" alt="Screenshot 2026-05-18 150145" src="https://github.com/user-attachments/assets/a8e91f57-f045-4584-a71d-c7d75cbd2f3f" />
 |

## Self-Review Checklist 

- [x] I have read CONTRIBUTING.md and followed all guidelines
- [x]  I have run python tests/test_basic.py and all  tests pass
- [x]  I have not introduced any print() or console.log() debug statements
- [x]  I have not modified files outside the scope of the linked issue
- [x]  If I changed the UI, I tested it at 375px mobile and 1280px desktop

## Notes for Reviewer

The skills input field had two identical id="skills-input" elements. 
Duplicate IDs are invalid HTML per W3C specification. The incomplete 
duplicate was removed, keeping the complete input that includes 
aria-haspopup, aria-expanded, and aria-controls attributes.
