### PR TITLE
Fix: Resolved duplicate placeholder text rendering in Skills input field

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -357,7 +357,6 @@
               </div>
               <div class="skill-input-wrap" id="skill-input-wrap">
                 <div class="skill-chips-selected" id="skill-chips-selected"></div>
-                <input type="text" id="skills-input" placeholder="Type a skill and press Enter..." autocomplete="off" />
                 <input
                   type="text"
                   id="skills-input"


### PR DESCRIPTION
This PR fixes a UI bug in the "Your Skills" section where the placeholder text `"Type a skill and press Enter..."` was rendering twice/overlapping inside the input container. 

The duplicate rendering issues have been resolved, ensuring that only a single placeholder element is displayed and formatting/readability is restored

 Changes Made

- Located and removed duplicate input components/nested placeholder elements in the Skills input section.
- Fixed the layout/rendering alignment of the skills placeholder text.
- Verified that the UI matches the expected clean appearance

Closes #267 