### PR TITLE
Fix duplicate placeholder bug in skills input field

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -361,7 +361,7 @@
               </div>
               <div class="skill-input-wrap" id="skill-input-wrap">
                 <div class="skill-chips-selected" id="skill-chips-selected"></div>
-                <input type="text" id="skills-input" placeholder="Type a skill and press Enter..." autocomplete="off" />
+                
                 <input
                   type="text"
                   id="skills-input"


### PR DESCRIPTION
## Summary [required]

Fixed the duplicate placeholder text issue in the skills input field. Removed the redundant placeholder rendering to improve UI clarity and user experience.

## Related Issue [required]

Closes #267

## Type of Change [required]

- [x] Bug fix — resolves a broken behaviour

## What Was Changed [required]

| File | Change made |
|------|-------------|
| templates/index.html | Removed duplicate placeholder rendering in skills input field |

## Screenshots (if UI change)

| Before | After |
|--------|-------|
| 
<img width="892" height="822" alt="image" src="https://github.com/user-attachments/assets/f5de0d7d-c84b-49b8-8583-7d2b6a41c8f1" />
 | 
<img width="908" height="738" alt="image" src="https://github.com/user-attachments/assets/b60e9118-17e4-458d-883d-3cec6c575125" />
 |

## How to Test This PR [required]

1. Checkout this branch:
git checkout duplicate-placeholder-ui

2. Install dependencies:
pip install -r requirements.txt

3. Run the application:
python app.py

4. Open:
http://127.0.0.1:5000

5. Navigate to the skills input section and verify the placeholder appears only once.

## Test Results [required]

Application runs successfully and duplicate placeholder issue is fixed.

## Self-Review Checklist [required]

- [x] I have read CONTRIBUTING.md and followed all guidelines
- [x] I tested the fix locally
- [x] I have not introduced debug statements
- [x] I have not modified unrelated files

## Notes for Reviewer

None.