### PR TITLE
style: add helper text for experience level

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -375,6 +375,9 @@
                     <option value="Advanced">Advanced</option>
                   </select>
                 </div>
+                <span class="form-hint">
+                    Select your current proficiency level such as Beginner, Intermediate, or Advanced.
+                </span>
                 <div class="form-error-msg" id="level-error"></div>
               </div>
 


### PR DESCRIPTION
## Summary 

This PR adds helper text below the “Experience Level” dropdown in the project recommendation form. The change improves UI consistency and provides better guidance to users, matching the behaviour of other fields such as Skills, Area of Interest, and Time Availability.

## Related Issue 

Closes #264

## Type of Change

- [ ] Bug fix — resolves a broken behaviour
- [ ] Feature — adds new functionality
- [ ] Data — adds new projects to `data/projects.json`
- [ ] Documentation — updates docs, README, or code comments only
- [x] Style — CSS or visual changes only, no logic change
- [ ] Refactor — restructures code without changing behaviour
- [ ] Test — adds or updates tests

## What Was Changed 
| File | Change made |
|------|-------------|
|templates/index.html | Added helper text below the Experience Level dropdown using the existing form-hint style for consistency |

## How to Test This PR

1. 1.Clone this branch: `git checkout fix-experience-label`
2. Install dependencies:
3. Run the app: python app.py
4. Open: http://127.0.0.1:5000
5. Scroll to the “Find Your Next Project” form section
6. Verify that helper text appears below the “Experience Level” dropdown
7. Run tests: python tests/test_basic.py

Expected test output:
```
28 passed, 0 failed out of 28 tests
```

## Test Results 
```text
PASS test_projects_json_loads
PASS test_each_project_has_required_fields 
PASS test_find_project_by_id_found 
PASS test_find_project_by_id_missing 
PASS test_parse_skills_basic 
PASS test_parse_skills_empty_string 
PASS test_parse_skills_single_entry 
PASS test_score_single_project_full_match 
PASS test_score_single_project_no_match 
PASS test_get_recommendations_returns_results 
PASS test_get_recommendations_max_three 
PASS test_get_recommendations_no_match_returns_empty 
PASS test_get_recommendations_result_format 
PASS test_validate_all_valid 
PASS test_validate_missing_skills 
PASS test_validate_missing_level 
PASS test_validate_missing_interest 
PASS test_validate_missing_time 
PASS test_validate_all_missing 
PASS test_home_route 
PASS test_recommend_api_valid 
PASS test_recommend_api_missing_field 
PASS test_recommend_api_empty_body 
PASS test_project_detail_found 
PASS test_project_detail_not_found 
PASS test_internal_server_error_page 
PASS test_view_code_found 
PASS test_download_code_found 

28 passed, 0 failed out of 28 tests
```
## Screenshots (if UI change)

Before:
<img width="913" height="841" alt="Screenshot 2026-05-18 095942" src="https://github.com/user-attachments/assets/4d0d28c6-01a0-4807-a265-922b6664bbb0" />
After:
<img width="550" height="860" alt="Screenshot 2026-05-19 114359" src="https://github.com/user-attachments/assets/dc73ebcd-ee14-4bef-9d55-3b9c931444e7" />
<img width="893" height="797" alt="Screenshot 2026-05-19 114411" src="https://github.com/user-attachments/assets/9c3bc0c4-67db-4558-85b8-0e1ce3ecee51" />


## Self-Review Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed all guidelines
- [ ] My branch name follows the convention: `feat/`, `fix/`, `docs/`, `data/`, `style/`, `test/`
- [x] I have run `python tests/test_basic.py` and all 27 tests pass
- [ ] I have run `flake8 .` locally and there are no errors
- [x] I have not introduced any `print()` or `console.log()` debug statements
- [x] Every new function I wrote has a docstring
- [x] I have not modified files outside the scope of the linked issue
- [x] If I changed the UI, I tested it at 375px (mobile) and 1280px (desktop)
- [ ] If I added a project to the dataset, it has all required JSON fields

## Notes for Reviewer
None