### PR TITLE
feat: add 403 forbidden error handler

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,6 +37,11 @@ def method_not_allowed(error):
     """Render a friendly 405 page when the wrong HTTP method is used."""
     return render_template("405.html"), 405
 
+@app.errorhandler(403)
+def forbidden(error):
+    """Render a friendly 403 page when access is denied."""
+    return render_template("403.html"), 403
+
 
 if __name__ == "__main__":
     # debug=True is only for local development.

--- a/templates/403.html
+++ b/templates/403.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Forbidden — DevPath</title>
+  <link rel="stylesheet" href="/static/style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@400;500&display=swap" rel="stylesheet" />
+</head>
+<body>
+  <nav class="navbar">
+    <div class="nav-inner">
+      <a href="/" class="nav-logo">DevPath</a>
+    </div>
+  </nav>
+  <div class="error-page">
+    <div class="error-page-inner">
+      <div class="error-code">403</div>
+      <h1>Forbidden</h1>
+      <p>You do not have permission to access this page.</p>
+      <a href="/" class="btn-primary" style="display:inline-block;text-decoration:none;padding:14px 32px;">Back to Home</a>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Added a 403 Forbidden error handler to match the existing 404, 405 and 500 handlers in `app.py`. Also added a styled `templates/403.html` page consistent with the rest of the error pages in the app.

## Related Issue

Closes #347 

## Type of Change

- [x] Feature — adds new functionality

## What Was Changed

| File | Change made |
|------|-------------|
| `app.py` | Added `forbidden` error handler for 403 |
| `templates/403.html` | Added styled 403 error page |

## How to Test This PR

1. Clone this branch: `git checkout feat/403-error-handler`
2. Install dependencies: `pip install -r requirements.txt`
3. Run the app: `python app.py`
4. In terminal run: `curl -X GET http://127.0.0.1:5000/forbidden`
5. Run the tests: `python tests/test_basic.py`

## Test Results

(.venv) PS C:\Users\AKM\OneDrive\Desktop\new\DevPath> python tests/test_basic.py
  PASS  test_projects_json_loads
  PASS  test_each_project_has_required_fields
  PASS  test_find_project_by_id_found
  PASS  test_find_project_by_id_missing
  PASS  test_parse_skills_basic
  PASS  test_parse_skills_empty_string
  PASS  test_parse_skills_single_entry
  PASS  test_score_single_project_full_match
  PASS  test_score_single_project_no_match
  PASS  test_get_recommendations_returns_results
  PASS  test_get_recommendations_max_three
  PASS  test_get_recommendations_no_match_returns_empty
  PASS  test_get_recommendations_result_format
  PASS  test_validate_all_valid
  PASS  test_validate_missing_skills
  PASS  test_validate_missing_level
  PASS  test_validate_missing_interest
  PASS  test_validate_missing_time
  PASS  test_validate_all_missing
  PASS  test_home_route
  PASS  test_recommend_api_valid
  PASS  test_recommend_api_missing_field
  PASS  test_recommend_api_empty_body
  PASS  test_project_detail_found
  PASS  test_project_detail_not_found
  PASS  test_internal_server_error_page
  PASS  test_view_code_found
  PASS  test_download_code_found
  PASS  test_health_check
  PASS  test_scoring_weights_has_all_keys

30 passed, 0 failed out of 30 tests

## Self-Review Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed all guidelines
- [x] My branch name follows the convention: `feat/403-error-handler`
- [x] I have run `flake8 .` locally and there are no errors
- [x] I have not introduced any `print()` or `console.log()` debug statements
- [x] Every new function I wrote has a docstring
- [x] I have not modified files outside the scope of the linked issue

## Notes for Reviewer

Follows the exact same pattern as the existing 404, 405 and 500 handlers. The 403.html template reuses the same CSS classes as 404.html, only the error code and message differ.