### PR TITLE
fix: resolve mobile form label overlap and duplicate submit button

### DIFF
--- a/starter_code/survey_form/style.css
+++ b/starter_code/survey_form/style.css
@@ -50,7 +50,7 @@ textarea {
 
 input[type="submit"] {
     background-color: yellow;
-    color: black
+    color: black;
     font-size: 16px;
     font-weight: bold;
     padding: 12px;

--- a/static/style.css
+++ b/static/style.css
@@ -1131,6 +1131,20 @@ ol {
   text-align: left;
 }
 
+/* Form label row (label + optional action button) */
+.form-label-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.form-label-row label {
+  margin-bottom: 0;
+}
+
 /* Form groups */
 .form-group {
   margin-bottom: 24px;
@@ -2525,12 +2539,21 @@ select:focus {
 
 
   .form-card {
-    padding: 28px 22px 24px;
+    padding: 28px 20px 24px;
   }
 
   .form-row {
     grid-template-columns: 1fr;
-    gap: 16px;
+    gap: 0;
+  }
+
+  .form-row .form-group {
+    margin-bottom: 20px;
+  }
+
+  .form-group label {
+    margin-top: 4px;
+    margin-bottom: 6px;
   }
 
   .results-grid {

--- a/static/style.css
+++ b/static/style.css
@@ -839,6 +839,19 @@ ol {
   white-space: nowrap;
 }
 
+.skill-strip-track {
+  display: flex;
+  width: max-content;
+  animation: skill-strip-marquee 28s linear infinite;
+}
+
+.skill-strip-marquee {
+  overflow: hidden;
+  mask-image: linear-gradient(to right, transparent 0%, black 8%, black 92%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to right, transparent 0%, black 8%, black 92%, transparent 100%);
+  width: 100%;
+}
+
 .skill-strip-items {
   display: flex;
   align-items: center;

--- a/templates/index.html
+++ b/templates/index.html
@@ -394,7 +394,7 @@
         <div class="form-card" id="form-section">
           <form id="recommend-form" novalidate>
             <div class="form-group">
-              <div class="form-label-row" style="display: flex; justify-content: space-between; align-items: flex-end; margin-bottom: 8px;">
+              <div class="form-label-row">
                 <label for="skills-input">
                   Your Skills
                   <span class="tooltip"
@@ -523,28 +523,21 @@
           <div class="form-error-msg" id="time-error"></div>
         </div>
 
-            <!-- Submit button -->
-            <button type="submit" class="btn-submit" id="submit-btn">
-              <span id="btn-label">Generate My Projects</span>
-
-              <span id="btn-loading" class="btn-loading-content" style="display:none;">
-                <span class="loading-spinner"></span>
-                <span>Finding matches...</span>
-              </span>
-            </button>
         <!-- General error (shown above the button) -->
         <p class="form-error-general" id="form-error-general"></p>
 
-        <!-- Submit button -->
+        <!-- Submit + Clear buttons -->
         <div class="form-actions">
           <button type="submit" class="btn-submit" id="submit-btn">
-                <span id="btn-label">Generate My Projects</span>
-              <span id="btn-loading" style="display:none;">Finding matches...</span>
-            </button>
-
-            <button type="button" class="btn-clear" id="clear-filters-btn">
-              <span>Clear Filters</span>
-            </button>
+            <span id="btn-label">Generate My Projects</span>
+            <span id="btn-loading" class="btn-loading-content" style="display:none;">
+              <span class="loading-spinner"></span>
+              <span>Finding matches...</span>
+            </span>
+          </button>
+          <button type="button" class="btn-clear" id="clear-filters-btn">
+            <span>Clear Filters</span>
+          </button>
         </div>
 
         </form>


### PR DESCRIPTION
## Summary [required]

This PR fixes the mobile responsiveness issue in the DevPath recommendation form.
On small screens, form labels were overlapping with input fields and appearing
misaligned, making the form hard to read and use. The fix adds proper spacing and
flex-wrap behaviour so labels sit cleanly above inputs on all screen sizes. A
duplicate submit button that was rendering due to repeated HTML was also removed,
a CSS syntax error in the survey form starter code was corrected, and the skill
strip marquee animation that was missing its base animation rule has been restored.

## Related Issue [required]

Closes #49

## Type of Change [required]

- [x] Bug fix — resolves a broken behaviour
- [ ] Feature — adds new functionality
- [ ] Data — adds new projects to `data/projects.json`
- [ ] Documentation — updates docs, README, or code comments only
- [x] Style — CSS or visual changes only, no logic change
- [ ] Refactor — restructures code without changing behaviour
- [ ] Test — adds or updates tests

## What Was Changed [required]

| File | Change made |
|------|-------------|
| `static/style.css` | Added `.form-label-row` rule with `flex-wrap: wrap` to prevent GitHub button overlapping label; added mobile spacing fixes inside `@media (max-width: 640px)` for `.form-row`, `.form-group`, and `label`; added missing base `.skill-strip-track` animation rule and `.skill-strip-marquee` overflow and mask so the skill strip scrolls correctly |
| `templates/index.html` | Removed duplicate `<button type="submit">` block; removed inline style from `.form-label-row` div so CSS class controls layout |
| `starter_code/survey_form/style.css` | Fixed missing semicolon after `color: black` in `input[type="submit"]` rule which was silently breaking all subsequent button styles |

## How to Test This PR [required]

1. Clone this branch: `git checkout fix/mobile-form-label-alignment`
2. Install dependencies: `pip install -r requirements.txt`
3. Run the app: `python app.py`
4. Open http://127.0.0.1:5000
5. Verify the "Supports skills including:" strip is visible and scrolling
6. Resize the browser window to ~375px width or open on a mobile device
7. Scroll to the "Find Your Next Project" form section
8. Verify labels appear cleanly above inputs with proper spacing
9. Verify only one "Generate My Projects" button is visible
10. Verify the "Import from GitHub" button wraps below the Skills label on narrow screens
11. Run the tests: `python tests/test_basic.py`

Expected test output:


PASS test_projects_json_loads
PASS test_each_project_has_required_fields
PASS test_find_project_by_id_found
PASS test_find_project_by_id_missing
PASS test_parse_skills_basic
PASS test_parse_skills_empty_string
PASS test_parse_skills_single_entry
PASS test_score_single_project_full_match
PASS test_score_single_project_no_match
PASS test_get_recommendations_returns_results
PASS test_get_recommendations_max_three
PASS test_get_recommendations_no_match_returns_empty
PASS test_get_recommendations_result_format
PASS test_validate_all_valid
PASS test_validate_missing_skills
PASS test_validate_missing_level
PASS test_validate_missing_interest
PASS test_validate_missing_time
PASS test_validate_all_missing
PASS test_home_route
PASS test_recommend_api_valid
PASS test_recommend_api_missing_field
PASS test_recommend_api_empty_body
PASS test_project_detail_found
PASS test_project_detail_not_found
PASS test_internal_server_error_page
PASS test_view_code_found
PASS test_download_code_found
PASS test_health_check
PASS test_scoring_weights_has_all_keys

30 passed, 0 failed out of 30 tests

## Screenshots (if UI change)
| Before | After |

<img width="523" height="823" alt="Screenshot 2026-05-20 140200" src="https://github.com/user-attachments/assets/7d278ef1-4374-46c8-8920-d406d9527e8e" />     
<img width="477" height="807" alt="Screenshot 2026-05-20 140214" src="https://github.com/user-attachments/assets/e11a4bf0-5657-45de-b785-95cc473a4201" />
<img width="517" height="803" alt="Screenshot 2026-05-20 140231" src="https://github.com/user-attachments/assets/82da497d-225b-42e3-9bd5-8c212bdbb5de" />
<img width="515" height="807" alt="Screenshot 2026-05-20 140247" src="https://github.com/user-attachments/assets/242fa2c9-e895-4467-8507-e81d7f590381" />




## Self-Review Checklist [required]

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed all guidelines
- [x] My branch name follows the convention: `fix/mobile-form-label-alignment`
- [x] I have run `python tests/test_basic.py` and all 30 tests pass
- [ ] I have run `flake8 .` locally and there are no errors
- [x] I have not introduced any `print()` or `console.log()` debug statements
- [x] Every new function I wrote has a docstring
- [x] I have not modified files outside the scope of the linked issue
- [x] If I changed the UI, I tested it at 375px (mobile) and 1280px (desktop)
- [ ] If I added a project to the dataset, it has all required JSON fields

## Notes for Reviewer

Three separate issues were fixed in this PR, all within the scope of issue #49:
1. Mobile form label overlap — CSS spacing fix
2. Duplicate submit button — pre-existing HTML duplication removed
3. Skill strip not visible — the `@keyframes skill-strip-marquee` animation was
   defined but never applied to `.skill-strip-track`, so the strip was static and
   overflowing out of view. Base animation and overflow rules have been added.
The last two checklist items are not applicable — no dataset changes were made and
`flake8` applies to Python files only, none of which were modified in this PR.