### PR TITLE
docs: add .flake8 config to enforce consistent linting for contributors

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+max-line-length = 88
+exclude =
+    venv,
+    .git,
+    __pycache__,
+    starter_code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Initial CHANGELOG.md setup for tracking project history
 - Documentation structure for future contributor updates
+- Added .flake8 config file to enforce consistent 88-character line limit for all contributors
 
 ### Changed
 


### PR DESCRIPTION
## Summary 

Adds a .flake8 config file to enforce the 88-character line limit 
specified in CONTRIBUTING.md. Without this file contributors get 
inconsistent linting results based on their local flake8 defaults.

## Related Issue

Closes #261

## Type of Change

- [ ] Bug fix — resolves a broken behaviour
- [ ] Feature — adds new functionality
- [ ] Data — adds new projects to `data/projects.json`
- [x] Documentation — updates docs, README, or code comments only
- [ ] Style — CSS or visual changes only, no logic change
- [ ] Refactor — restructures code without changing behaviour
- [ ] Test — adds or updates tests

## What Was Changed 

| File | Change made |
|------|-------------|
| `.flake8` | New config file added |
| `CHANGELOG.md` | Updated unreleased section |

## How to Test This PR 

1. Clone this branch: `docs/add-flask8-config`
2. Install dependencies: `pip install -r requirements.txt`
3. Verify that the `.flake8` file exists in the project root
4. Run flake8: `flake8 .`
5. Confirm that the 88-character line limit and excluded folders are applied correctly
6. Run the tests: `python tests/test_basic.py`
`
Expected test output:
```
30 passed, 0 failed out of 30 tests
```

## Test Results 

<img width="442" height="397" alt="image" src="https://github.com/user-attachments/assets/908a745a-7955-4686-be93-820cc2ead128" />

## Screenshots 

<img width="1102" height="732" alt="image" src="https://github.com/user-attachments/assets/9b9f19e8-6a1b-45b6-9fe5-521d5a52c01a" />

## Self-Review Checklist 

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed all guidelines
- [x] My branch name follows the convention: `feat/`, `fix/`, `docs/`, `data/`, `style/`, `test/`
- [x] I have run `python tests/test_basic.py` and all 30 tests pass
- [x] I have run `flake8 .` locally and there are no errors
- [x] I have not introduced any `print()` or `console.log()` debug statements
- [x] Every new function I wrote has a docstring
- [x] I have not modified files outside the scope of the linked issue

## Notes for Reviewer

None