### PR TITLE
Fix Navbar and Footer Github links

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -25,7 +25,7 @@
         <a href="#how-it-works" class="nav-link">How It Works</a>
         <a href="#features" class="nav-link">Features</a>
         <a href="#find-project" class="nav-link">Find Project</a>
-        <a href="https://github.com/komalharshita/DevPath" target="_blank" rel="noopener noreferrer" class="nav-btn-outline">GitHub</a>
+        <a href="https://github.com/komalharshita" target="_blank" rel="noopener noreferrer" class="nav-btn-outline">GitHub</a>
       </div>
       <!-- Mobile hamburger toggle -->
       <button class="nav-mobile-toggle" id="nav-mobile-toggle" aria-label="Toggle navigation">
@@ -37,7 +37,7 @@
       <a href="#how-it-works" class="nav-mobile-link">How It Works</a>
       <a href="#features" class="nav-mobile-link">Features</a>
       <a href="#find-project" class="nav-mobile-link">Find Project</a>
-      <a href="https://github.com/komalharshita/DevPath" target="_blank" rel="noopener noreferrer" class="nav-mobile-link">GitHub</a>
+      <a href="https://github.com/komalharshita"target="_blank" rel="noopener noreferrer" class="nav-mobile-link">GitHub</a>
     </div>
   </nav>
 
@@ -595,7 +595,7 @@
         <h4 class="footer-col-title">About Us</h4>
         <ul class="footer-links-list">
           <li><a href="#our-story">Our Story</a></li>
-          <li><a href="https://github.com/komalharshita/DevPath" target="_blank" rel="noopener noreferrer">Open Source</a></li>
+          <li><a href="https://gssoc.girlscript.org/projects" target="_blank" rel="noopener noreferrer">Open Source</a></li>
           <li><a href="https://github.com/komalharshita/DevPath/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">License</a></li>
         </ul>
       </div>

--- a/templates/project.html
+++ b/templates/project.html
@@ -28,7 +28,7 @@
       <a href="/" class="nav-logo">DevPath</a>
       <div class="nav-links">
         <a href="/" class="nav-link">Back to Search</a>
-        <a href="https://github.com/komalharshita/DevPath" target="_blank" rel="noopener noreferrer" class="nav-link nav-link-gh">GitHub</a>
+        <a href="https://github.com/komalharshita" target="_blank" rel="noopener noreferrer" class="nav-link nav-link-gh">GitHub</a>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
Summary
This PR fixes navigation and footer links in the DevPath project. Added mentor GitHub profile links in the navbar and updated the footer resources section and there are GitHub that remain unchanged and About Us section there are Open source with the GSSOC projects link to improve navigation and accessibility.


Related Issue
close #246

Type of Change 
 Bug fix — resolves GitHub links that redirect to the repos.

What Was Changed 

File| Change made
"templates/index.html"| Added mentor GitHub profile link in navbar
"templates/index.html"| Added GSSOC projects link in footer About Us section
"templates/project.html"| Updated navigation 

details:
1.in navbar 
GitHub button now open mentor profile id.
2. in footer
there were resources section and there are GitHub that open now this project repository 
and there were about us section and there are open sources that open now projects.

How to Test This PR 
1.Open index.html in the browser.
2.Check the navbar GitHub you will see mentor profile id.
3.Scroll to the footer section.
4Click the GitHub in the Resources section you will see repository.
5.Click the Open Source in the About us section you will see GSSOC projects.
6.Verify both links redirect correctly.

Test Results 
Navbar and footer links tested successfully.
All updated links redirect correctly.

Self-Review Checklist [required]
- [x] I have read CONTRIBUTING.md and followed all guidelines
- [x] I have tested the updated links locally
- [x] I have not introduced any debug statements
- [x] I have not modified files outside the scope of the linked issue

Notes for Reviewer

This PR only updates navigation and footer links in the index and project HTML files. No CSS changes were made. While testing locally, I verified the updated links through "index.html". CSS styling was not fully loaded in the local preview environment, but no CSS files were modified in this PR.





