### PR TITLE
fix: support nested starter code paths and block path traversal

### DIFF
--- a/routes/main_routes.py
+++ b/routes/main_routes.py
@@ -125,9 +125,9 @@ def download_code(project_id):
     if not full_path:
         abort(404)
 
-    import os
     filename = os.path.basename(full_path)
-    return send_from_directory(get_starter_code_dir(), filename, as_attachment=True)
+    file_dir = os.path.dirname(full_path)
+    return send_from_directory(file_dir, filename, as_attachment=True)
 
 
 @main.route("/sitemap.xml")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -330,6 +330,31 @@ def test_download_code_found():
     client = get_client()
     response = client.get("/project/1/download")
     assert response.status_code == 200
+
+
+def test_view_code_nested_path():
+    """Project 9 has a nested starter_code path; /code should still return 200."""
+    client = get_client()
+    response = client.get("/project/9/code")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert "code" in data
+    assert "filename" in data
+    assert len(data["code"]) > 0
+
+
+def test_download_code_nested_path():
+    """Project 9 has a nested starter_code path; /download should still return 200."""
+    client = get_client()
+    response = client.get("/project/9/download")
+    assert response.status_code == 200
+
+
+def test_resolve_starter_file_path_traversal():
+    """resolve_starter_file must return None for path traversal attempts."""
+    from utils.file_server import resolve_starter_file
+    malicious = {"starter_code": "starter_code/../../routes/main_routes.py"}
+    assert resolve_starter_file(malicious) is None
     
 def test_health_check():
     client = get_client()

--- a/utils/file_server.py
+++ b/utils/file_server.py
@@ -12,15 +12,27 @@ STARTER_CODE_DIR = os.path.abspath(
 def resolve_starter_file(project):
     """
     Given a project dict, return the absolute path to its starter code file.
+    Supports nested paths within the starter_code directory (e.g. survey_form/index.html).
     Returns None if the project has no starter_code field or the file does not exist.
+    Path traversal attempts (e.g. ../../etc/passwd) are blocked by verifying the
+    resolved path stays inside STARTER_CODE_DIR.
     """
     raw_path = project.get("starter_code", "")
     if not raw_path:
         return None
 
-    # Only use the filename portion — never trust a full path from the data file
-    filename = os.path.basename(raw_path)
-    full_path = os.path.join(STARTER_CODE_DIR, filename)
+    # Normalize to the local OS separator and strip any leading "starter_code/" prefix
+    # so values like "starter_code/survey_form/index.html" and "survey_form/index.html"
+    # are both handled correctly.
+    relative = raw_path.replace("/", os.sep)
+    prefix = "starter_code" + os.sep
+    if relative.startswith(prefix):
+        relative = relative[len(prefix):]
+
+    # Resolve to an absolute path and confirm it stays within STARTER_CODE_DIR
+    full_path = os.path.normpath(os.path.join(STARTER_CODE_DIR, relative))
+    if not full_path.startswith(STARTER_CODE_DIR + os.sep):
+        return None
 
     if not os.path.exists(full_path):
         return None


### PR DESCRIPTION
## Summary [required]

Projects whose `starter_code` value contains a subdirectory (e.g. `starter_code/survey_form/index.html`) were returning 404 for both the View Code and Download endpoints. The root cause was a two-part bug:

1. `resolve_starter_file` in `utils/file_server.py` called `os.path.basename` on the raw path, stripping the subdirectory completely. `survey_form/index.html` became just `index.html`, which does not exist at the root of the `starter_code` directory.

2. Even after fixing (1), the download route in `routes/main_routes.py` passed `get_starter_code_dir()` (the root `starter_code` folder) to `send_from_directory` together with only the basename, so Flask still could not locate nested files.

This PR fixes both layers. `resolve_starter_file` now strips any leading `starter_code/` prefix, resolves the relative subpath inside `STARTER_CODE_DIR`, and uses `os.path.normpath` plus a prefix check to block path traversal attempts. The download route derives the serving directory from `os.path.dirname(full_path)` so Flask serves the file from its actual location regardless of nesting depth.

## Related Issue [required]

Closes #407

## Type of Change [required]

- [x] Bug fix — resolves a broken behaviour
- [x] Test — adds or updates tests

## What Was Changed [required]

| File | Change made |
|------|-------------|
| `utils/file_server.py` | Rewrote `resolve_starter_file` to support nested paths with a path traversal guard |
| `routes/main_routes.py` | Fixed `download_code` to serve from the file's actual directory, not the starter_code root |
| `tests/test_basic.py` | Added three tests: nested `/code`, nested `/download`, and path traversal rejection |

## How to Test This PR [required]

1. Clone this branch: `git checkout fix/nested-starter-code-resolution`
2. Install dependencies: `pip install -r requirements.txt`
3. Run the app: `python app.py`
4. Navigate to http://127.0.0.1:5000/project/9 and click View Code. The survey form HTML should render.
5. Click Download File. The `index.html` file should download successfully.
6. Run the tests: `python tests/test_basic.py`

Expected test output:
```
33 passed, 0 failed out of 33 tests
```

## Test Results [required]

```
  PASS  test_projects_json_loads
  PASS  test_each_project_has_required_fields
  PASS  test_find_project_by_id_found
  PASS  test_find_project_by_id_missing
  PASS  test_parse_skills_basic
  PASS  test_parse_skills_empty_string
  PASS  test_parse_skills_single_entry
  PASS  test_score_single_project_full_match
  PASS  test_score_single_project_no_match
  PASS  test_get_recommendations_returns_results
  PASS  test_get_recommendations_max_three
  PASS  test_get_recommendations_no_match_returns_empty
  PASS  test_get_recommendations_result_format
  PASS  test_validate_all_valid
  PASS  test_validate_missing_skills
  PASS  test_validate_missing_level
  PASS  test_validate_missing_interest
  PASS  test_validate_missing_time
  PASS  test_validate_all_missing
  PASS  test_home_route
  PASS  test_recommend_api_valid
  PASS  test_recommend_api_missing_field
  PASS  test_recommend_api_empty_body
  PASS  test_project_detail_found
  PASS  test_project_detail_not_found
  PASS  test_internal_server_error_page
  PASS  test_view_code_found
  PASS  test_download_code_found
  PASS  test_view_code_nested_path
  PASS  test_download_code_nested_path
  PASS  test_resolve_starter_file_path_traversal
  PASS  test_health_check
  PASS  test_scoring_weights_has_all_keys

33 passed, 0 failed out of 33 tests
```

## Self-Review Checklist [required]

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed all guidelines
- [x] My branch name follows the convention: `feat/`, `fix/`, `docs/`, `data/`, `style/`, `test/`
- [x] I have run `python tests/test_basic.py` and all tests pass
- [x] I have not introduced any `print()` or `console.log()` debug statements
- [x] Every new function I wrote has a docstring
- [x] I have not modified files outside the scope of the linked issue

## Notes for Reviewer

The path traversal guard works by normalising the joined path with `os.path.normpath` and confirming it starts with `STARTER_CODE_DIR + os.sep`. Without the trailing separator the check could be bypassed by a directory name that shares the same prefix (e.g. `starter_code_evil/`), so the separator is included intentionally.

The download route change is minimal: the resolved `full_path` from `resolve_starter_file` is already validated, so deriving `file_dir` from it adds no new trust surface.