### PR TITLE
fix: resolve three script.js defects breaking the recommendation flow

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -775,68 +775,33 @@ if (isIndexPage) {
     // Clear out any cards from a previous search before showing new ones
     resultsGrid.innerHTML = "";
 
-    if (!projects || projects.length === 0) { //if no projects returned from api, show the "no results" message and hide the grid
-        resultsGrid.style.display = "none";
-        resultsEmptyEl.style.display = "block";
+    if (!projects || projects.length === 0) {
+      resultsGrid.style.display = "none";
+      resultsEmptyEl.style.display = "block";
 
-        // Show a friendly custom message when the user selected an interest
-        var selectedInterest = document.getElementById("interest")?.value;
-        if (selectedInterest) {
-          emptyMessageEl.textContent = "No projects are currently available for this interest. Please check back later or try a different area.";
-        } else if (message) {
-          emptyMessageEl.textContent = message;
-        } else {
-          emptyMessageEl.textContent = "Try adjusting your skills or choosing a different interest area.";
-        }
-
-        resultsSection.scrollIntoView({ behavior: "smooth" });
-        return;
+      // Show a friendly custom message when the user selected an interest
+      var selectedInterest = document.getElementById("interest")?.value;
+      if (selectedInterest) {
+        emptyMessageEl.textContent = "No projects are currently available for this interest. Please check back later or try a different area.";
+      } else if (message) {
+        emptyMessageEl.textContent = message;
+      } else {
+        emptyMessageEl.textContent = "Try adjusting your skills or choosing a different interest area.";
       }
 
-      resultsEmptyEl.style.display = "none";
-      resultsGrid.style.display = "grid";
-
-      //build a card for each project and add it to the grid
-      projects.forEach(function (project) {
-        resultsGrid.appendChild(buildProjectCard(project));
-      });
-
       resultsSection.scrollIntoView({ behavior: "smooth" });
+      return;
     }
 
-    // builds one project card as a DOM element and returns it
-    // the card has title, short description, tags and link
-    function buildProjectCard(project) {
-      var card = document.createElement("div");
-      card.className = "project-card";
+    resultsEmptyEl.style.display = "none";
+    resultsGrid.style.display = "grid";
 
-      // Title
-      var title = document.createElement("h3");
-      title.className = "project-card-title";
-      title.textContent = project.title;
+    projects.forEach(function (project) {
+      resultsGrid.appendChild(buildProjectCard(project));
+    });
 
-      // Description (truncated for visual consistency)
-      var desc = document.createElement("p");
-      desc.className = "project-card-desc";
-      // Cut description to 120 chars so all cards stay the same height
-      desc.textContent = truncate(project.description, 120);
-
-      // Tags row
-      var tagsRow = document.createElement("div");
-      tagsRow.className = "project-card-tags";
-
-      // Show all project skills as tags so users can see the full match
-      (project.skills || []).forEach(function (skill) {
-        tagsRow.appendChild(createTag(skill, "skill"));
-      });
-
-      // Level tag (colour-coded via CSS class)
-      // Lowercase so it matches the CSS class names like "level beginner", "level advanced"
-      var levelClass = "level " + (project.level || "").toLowerCase();
-      tagsRow.appendChild(createTag(project.level, levelClass));
-
-      // Time tag
-      tagsRow.appendChild(createTag("Time: " + project.time, "time"));
+    resultsSection.scrollIntoView({ behavior: "smooth" });
+  }
 
   // builds one project card as a DOM element and returns it
   // the card has title, short description, tags and link


### PR DESCRIPTION
## Description

`static/script.js` had a stale, incomplete duplicate of `buildProjectCard` left in the file after a previous refactor (lines 807-839). This copy lacked the Read More toggle, the card footer, and the detail-page link. It was dead code that JavaScript hoisted over (the later full-featured definition won at runtime), but it caused confusion and lint warnings. Additionally, `renderResults` had inconsistent indentation on the success path, making the control flow hard to follow.

## Root Cause

A partial refactor introduced a second `buildProjectCard` definition without removing the first. The indentation inside `renderResults` after the empty-check block was at 6-space depth, inconsistent with the surrounding 4-space style.

## Related Issue

Closes #338

## Type of Change

- [x] Bug fix

## Changes Made

- `static/script.js`:
  - Removed the stale duplicate `buildProjectCard` function (the incomplete copy without Read More support).
  - Re-indented the success path inside `renderResults` to consistent 4-space depth, matching the rest of the function.

## Testing Done

1. Search with matching results: cards render correctly with Read More toggle.
2. Search with no results: empty-state message shows correctly.
3. No duplicate function warning in browser console.

## Checklist

- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue