### PR TITLE
fix: remove duplicate fetch call in form submit handler

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -535,40 +535,7 @@ if (clearFiltersBtn) {
       level: document.getElementById("level").value,
       interest: document.getElementById("interest").value,
       time: document.getElementById("time").value
-    };
-
-    //post the data to backend api as JSON, then handle the response
-    fetch("/api/recommend", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body:    JSON.stringify(payload) //convert object to json string
-    })
-      .then(function (res) { return res.json(); }) //parse the response as JSON
-      .then(function (data) {
-        setLoadingState(false);
-
-          var generalErr = document.getElementById("form-error-general");
-
-          if (generalErr) {
-            generalErr.textContent =
-              "Something went wrong. Please try again.";
-          }
-        });
-    });
-        if (data.error) {
-          var generalErr = document.getElementById("form-error-general");
-          if (generalErr) generalErr.textContent = data.error;
-          return;
-        }
-        renderResults(data.projects || [], data.message);
-      })
-      .catch(function (err) {
-        // this runs if the network request itself fails 
-        setLoadingState(false);
-        var generalErr = document.getElementById("form-error-general");
-        if (generalErr) generalErr.textContent = "Something went wrong. Please try again.";
-        console.error("API request failed:", err);
-      });
+    };  
   });
 
   // Manages the loading state of the form and results section(whats visible or not)


### PR DESCRIPTION
Fixes #532 

**Problem**
The form submit handler in static/script.js had the 
fetch("/api/recommend") call written twice:
- First call inside requestAnimationFrame (correct)
- Second call as dead/unreachable code below it

This caused:
- Broken syntax with mismatched brackets
- Unreachable code after the first fetch's catch block
- Confusing code structure that could mislead contributors

**Fix**
Removed the duplicate fetch block including the duplicate
payload variable declaration and the unreachable
if (data.error) and renderResults() calls.

**Testing**
- Form submission works correctly ✅
- Results render correctly ✅
- Error handling works correctly ✅
- No duplicate API calls ✅