### PR TITLE
fix: remove duplicate display assignments in setLoadingState function

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -578,8 +578,6 @@ if (clearFiltersBtn) {
     submitBtn.setAttribute("aria-busy", isLoading);
     btnLabel.style.display = isLoading ? "none" : "inline";
     btnLoading.style.display = isLoading ? "inline-flex" : "none";
-    btnLabel.style.display = isLoading ? "none" : "inline";
-    btnLoading.style.display = isLoading ? "inline" : "none";
 
     if (isLoading) {
       // Show the results section with only the loading indicator visible


### PR DESCRIPTION
Fixes #534 

**Problem**
The setLoadingState() function in static/script.js had 
btnLabel and btnLoading display properties set twice:

btnLabel.style.display = isLoading ? "none" : "inline";
btnLoading.style.display = isLoading ? "inline-flex" : "none";
btnLabel.style.display = isLoading ? "none" : "inline";   // duplicate
btnLoading.style.display = isLoading ? "inline" : "none"; // duplicate + wrong value

The second pair was not only duplicate but also had an 
inconsistent value — "inline" instead of "inline-flex" 
for btnLoading which could cause layout issues with 
the loading spinner.

**Fix**
Removed the two duplicate lines keeping only the first 
correct pair with proper "inline-flex" value for btnLoading.

**Testing**
- Loading spinner shows correctly on form submit ✅
- Button label hides correctly during loading ✅
- Button label shows correctly after loading ✅
- No duplicate display assignments ✅