### PR TITLE
perf: implement in-memory project caching for data loader

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -16,7 +16,7 @@ import os
 # Allow imports from the project root when running tests directly
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from utils.data_loader import load_all_projects, find_project_by_id, clear_cache
+from utils.data_loader import load_all_projects, find_project_by_id, clear_cache, get_read_count
 from utils.recommender import (
     get_recommendations,
     validate_recommendation_inputs,
@@ -378,6 +378,39 @@ def test_project_links_have_noopener():
     assert response.status_code == 200
     assert b'target="_blank"' in response.data
     assert b'rel="noopener noreferrer"' in response.data
+
+
+# ============================================================
+# Caching Tests (Issue 12)
+# ============================================================
+
+def test_data_loader_caching():
+    """Verify that projects are cached in memory after the first read."""
+    clear_cache()
+    
+    assert get_read_count() == 0
+    
+    # First load - triggers file read
+    projects_first = load_all_projects()
+    assert get_read_count() == 1
+    
+    # Second load - should read from cache (no new file read)
+    projects_second = load_all_projects()
+    assert get_read_count() == 1
+    
+    # Third load - verifying that we received identical data
+    assert len(projects_first) == len(projects_second)
+    
+    # Verify that mutating the returned list does NOT mutate the cache (defensive copying)
+    projects_first.append({"id": 9999, "title": "Malicious Mutator"})
+    projects_third = load_all_projects()
+    assert not any(p.get("id") == 9999 for p in projects_third), "Accidental cache mutation detected"
+    
+    # Clear cache and verify it is reloaded fresh from disk
+    clear_cache()
+    assert get_read_count() == 0
+    projects_fourth = load_all_projects()
+    assert get_read_count() == 1
 
 
 

--- a/utils/data_loader.py
+++ b/utils/data_loader.py
@@ -3,15 +3,27 @@
 
 import json
 import os
+import copy
 
 # Build the path to projects.json relative to this file's location
 DATA_FILE = os.path.join(os.path.dirname(__file__), "..", "data", "projects.json")
 
+# Module-level project cache and tracking states
+_projects_cache = None
+_read_count = 0
+
 
 def load_all_projects():
-    """Read and return the full list of projects from the JSON file."""
-    with open(DATA_FILE, "r", encoding="utf-8") as f:
-        return json.load(f)
+    """
+    Read and return the full list of projects from the JSON file.
+    Returns a deep copy of the cache to prevent callers from mutating the state.
+    """
+    global _projects_cache, _read_count
+    if _projects_cache is None:
+        with open(DATA_FILE, "r", encoding="utf-8") as f:
+            _projects_cache = json.load(f)
+            _read_count += 1
+    return copy.deepcopy(_projects_cache)
 
 
 def find_project_by_id(project_id):
@@ -48,11 +60,15 @@ def get_project_stats():
         "beginner_friendly": beginner_friendly
     }
 
-# Cache for loaded projects
-_projects_cache = None
+
+def get_read_count():
+    """Return the total number of times projects.json was read from disk."""
+    global _read_count
+    return _read_count
 
 
 def clear_cache():
-    """Reset the in-memory project cache."""
-    global _projects_cache
+    """Reset the in-memory project cache and reset read tracking."""
+    global _projects_cache, _read_count
     _projects_cache = None
+    _read_count = 0


### PR DESCRIPTION
This PR implements an invalidatable in-memory project data cache in `utils/data_loader.py` to prevent repetitive disk access on queries. It also includes an automated unit test `test_data_loader_caching` to assert correct caching and clearing behavior.