### PR TITLE
fix: remove duplicate SVG icons in hero visual cards

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -83,10 +83,7 @@
       <!-- Hero visual loads after main content for performance -->
       <div class="hero-visual">
         <div class="hero-visual-card hero-visual-card--top">
-          <div class="hvc-icon hvc-icon--blue">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" 
-  stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6" />
-  <polyline points="8 6 2 12 8 18" /></svg>
+          <div class="hvc-icon hvc-icon--blue">            
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
               stroke-linecap="round" stroke-linejoin="round">
               <polyline points="16 18 22 12 16 6" />
@@ -120,17 +117,11 @@
         </div>
 
         <div class="hero-visual-card hero-visual-card--bottom">
-          <div class="hvc-icon hvc-icon--green">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-
-  width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6
-  12 2 12" /></svg>
+          <div class="hvc-icon hvc-icon--green">            
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
               stroke-linecap="round" stroke-linejoin="round">
               <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
-            </svg>
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
-  stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
-  </svg>
+            </svg>            
           </div>
           <div class="hvc-text">
             <span class="hvc-title">7-Step Roadmap</span>


### PR DESCRIPTION
Fixes #557 

**Problem**
The hero visual cards in templates/index.html had 
duplicate SVG icons:

Blue card (Starter Code Ready):
- Had 2 identical SVG icons stacked
- First was a broken inline version
- Second was the clean properly formatted version

Green card (7-Step Roadmap):
- Had 3 identical SVG icons stacked
- First and third were broken inline versions
- Second was the clean properly formatted version

This caused:
- Duplicate icons rendering in the hero section
- Extra unnecessary DOM elements
- Broken inline SVGs with incorrect formatting

**Fix**
Removed the duplicate broken SVG icons keeping only 
the clean properly formatted version in each card.

**Testing**
- Blue hero card shows single correct icon ✅
- Green hero card shows single correct icon ✅
- Hero section renders correctly ✅
- No duplicate SVG elements in DOM ✅