### PR TITLE
Feat: Inject dynamic SEO meta tags and JSON-LD schema

### DIFF
--- a/templates/project.html
+++ b/templates/project.html
@@ -21,6 +21,8 @@
   <link
     href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
     rel="stylesheet" />
+  <meta property="og:title" content="{{ project.title }}" />
+  <meta property="og:description" content="{{ project.description }}" />
 </head>
 
 <body class="detail-page">


### PR DESCRIPTION
Closed #597 

**Problem**: 
The `project.html` template does not feature dynamic Open Graph (OG) meta tags or JSON-LD schema markup. When a specific project is shared on social media or crawled by search engines, it falls back to generic site metadata.
**Acceptance Criteria**:
- Inject Open Graph (`og:title`, `og:description`) `<meta>` tags into the document `<head>`.
- Dynamically populate these tags using Jinja2 variables specific to the requested project.