### PR TITLE
fix: resolve duplicate project IDs in projects.json

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -364,7 +364,7 @@
 
   ,
   {
-    "id": 8,
+    "id": 12,
     "title": "Number Guessing Game",
     "skills": ["Python"],
     "level": "Beginner",
@@ -395,7 +395,7 @@
     "starter_code": "starter_code/number_guessing.py"
   },
   {
-    "id": 9,
+    "id": 13,
     "title": "Simple Email Automation",
     "skills": ["Python"],
     "level": "Beginner",
@@ -426,7 +426,7 @@
     "starter_code": "starter_code/email_automation.py"
   },
   {
-    "id": 10,
+    "id": 14,
     "title": "Quiz App",
     "skills": ["HTML", "CSS", "JavaScript"],
     "level": "Beginner",


### PR DESCRIPTION
## What does this PR do?
Fixes duplicate project IDs in `data/projects.json` where IDs 8, 9, and 10 were each assigned to two different projects, causing incorrect project lookups in the recommender engine.

## Changes Made
- Renumbered "Number Guessing Game" from ID 8 → 12
- Renumbered "Simple Email Automation" from ID 9 → 13
- Renumbered "Quiz App" from ID 10 → 14
- All project IDs are now unique (1 through 14)

## Type of Change
- [x] Bug fix

## Testing
- [x] Tested locally with `python app.py`
- [x] All projects load correctly with unique IDs
- [x] Recommender engine returns correct projects
- [x] No existing functionality broken

## Related Issue
Closes #623 