### PR TITLE
Fix 11 bugs: security, UI, backend, and recommender fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,10 +10,12 @@
 # Business logic, recommendation scoring, and data loading all live in
 # the utils/ and routes/ packages, not here.
 
-from flask import Flask, render_template
+from flask import Flask, render_template, jsonify
 from routes.main_routes import main
+import os
 
 app = Flask(__name__)
+app.secret_key = os.environ.get("SECRET_KEY", os.urandom(24).hex())
 
 # Register all routes defined in the main Blueprint
 app.register_blueprint(main)
@@ -27,6 +29,15 @@ def add_security_headers(response):
     response.headers["Permissions-Policy"] = (
         "geolocation=(), microphone=(), camera=()"
     )
+    response.headers["Content-Security-Policy"] = (
+        "default-src 'self'; "
+        "script-src 'self' https://fonts.googleapis.com; "
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+        "font-src 'self' https://fonts.gstatic.com; "
+        "img-src 'self' data:; "
+        "connect-src 'self' https://api.github.com; "
+        "frame-ancestors 'none'"
+    )
     return response
 
 # ---- Error handlers ----
@@ -39,7 +50,9 @@ def page_not_found(error):
 
 @app.errorhandler(500)
 def internal_server_error(error):
-    """Render a friendly 500 page for unexpected server errors."""
+    """Render a friendly 500 page for unexpected server errors.
+    Never expose the original exception or file paths.
+    """
     return render_template("500.html"), 500
 
 @app.errorhandler(405)
@@ -54,6 +67,5 @@ def forbidden(error):
 
 
 if __name__ == "__main__":
-    # debug=True is only for local development.
-    # Never run with debug=True in a production deployment.
-    app.run(debug=True)
+    debug = os.environ.get("FLASK_DEBUG", "0") == "1"
+    app.run(debug=debug)

--- a/routes/main_routes.py
+++ b/routes/main_routes.py
@@ -10,19 +10,6 @@ from utils.data_loader import find_project_by_id, load_all_projects, get_project
 from utils.file_server import read_starter_code, resolve_starter_file, get_starter_code_dir
 import os
 
-# Interest categories that currently have no project recommendations available
-NO_PROJECT_INTERESTS = {
-    "machine learning/ai",
-    "devops",
-    "mobile",
-    "artificial intelligence",
-    "cloud computing",
-    "mobile app development",
-}
-
-def interest_has_no_projects(interest):
-    return interest and interest.strip().lower() in NO_PROJECT_INTERESTS
-
 # Create the Blueprint that app.py will register
 main = Blueprint("main", __name__)
 
@@ -71,13 +58,13 @@ def recommend():
         # Return only the first error to keep the UI message clean
         return jsonify({"error": errors[0]}), 400
 
-    if interest_has_no_projects(interest):
+    try:
+        results = get_recommendations(skills, level, interest, time_availability)
+    except Exception:
         return jsonify({
             "projects": [],
-            "message": "No projects are currently available for this interest area. Please check back later."
-        }), 200
-
-    results = get_recommendations(skills, level, interest, time_availability)
+            "message": "An unexpected error occurred. Please try again."
+        }), 500
 
     if not results:
         return jsonify({

--- a/static/script.js
+++ b/static/script.js
@@ -412,12 +412,9 @@ if (clearFiltersBtn) {
   }
 
   function syncSkillsHiddenInput() {
-    if (!skillsHidden){
-      var skillsHidden = document.getElementById("skills");
-    }
-    // Keep the hidden <input> in sync for form serialisation
-    // The API expects a comma-separated string, so join the array that way
-    skillsHidden.value = selectedSkills.join(", ");
+    var hiddenInput = skillsHidden || document.getElementById("skills");
+    if (!hiddenInput) return;
+    hiddenInput.value = selectedSkills.join(", ");
   }
 
   updateQuickPickState();
@@ -526,17 +523,12 @@ if (clearFiltersBtn) {
           renderResults(data.projects || [], data.message);
         })
         .catch(function () {
-
           setLoadingState(false);
-    //combine form values into an object to send to server/api
-    var payload = {
-      // Prefer the hidden input value; fall back to raw text box if hidden input is empty
-      skills: skillsHidden.value.trim() || skillsTextInput.value.trim(),
-      level: document.getElementById("level").value,
-      interest: document.getElementById("interest").value,
-      time: document.getElementById("time").value
-    };  
-  });
+          var generalErr = document.getElementById("form-error-general");
+          if (generalErr) {
+            generalErr.textContent = "Something went wrong. Please try again.";
+          }
+        });
 
   // Manages the loading state of the form and results section(whats visible or not)
   function setLoadingState(isLoading) {
@@ -570,28 +562,13 @@ if (clearFiltersBtn) {
   function renderResults(projects, message) {
     resultsSection.style.display = "block";
     resultsLoadingEl.style.display = "none";
-    // Clear out any cards from a previous search before showing new ones
     resultsGrid.innerHTML = "";
 
     if (!projects || projects.length === 0) {
-      resultsGrid.style.display     = "none";
-      resultsEmptyEl.style.display  = "block";
       resultsGrid.style.display = "none";
       resultsEmptyEl.style.display = "block";
-      if (message && emptyMessageEl) emptyMessageEl.textContent = message;
-    if (!projects || projects.length === 0) { //if no projects returned from api, show the "no results" message and hide the grid
-      resultsGrid.style.display    = "none";
-      resultsEmptyEl.style.display = "block";
 
-      // Show a friendly custom message when the user selected an interest
-      var selectedInterest = document.getElementById("interest")?.value;
-      if (selectedInterest) {
-        emptyMessageEl.textContent = "No projects are currently available for this interest. Please check back later or try a different area.";
-      } else if (message) {
-        emptyMessageEl.textContent = message;
-      } else {
-        emptyMessageEl.textContent = "Try adjusting your skills or choosing a different interest area.";
-      }
+      if (message && emptyMessageEl) emptyMessageEl.textContent = message;
 
       resultsSection.scrollIntoView({ behavior: "smooth" });
       return;
@@ -600,7 +577,6 @@ if (clearFiltersBtn) {
     resultsEmptyEl.style.display = "none";
     resultsGrid.style.display = "grid";
 
-    //build a card for each project and add it to the grid
     projects.forEach(function (project) {
       resultsGrid.appendChild(buildProjectCard(project));
     });
@@ -879,14 +855,38 @@ if (
       fetchBtn.textContent = 'Syncing...';
 
       try {
-          const response = await fetch(`https://api.github.com/users/${username}/repos`);
-          if (!response.ok) throw new Error();
-          
-          const repos = await response.json();
-          const langs = [...new Set(repos.map(r => r.language).filter(Boolean))];
+          // Paginate through all repos
+          const allLangs = new Set();
+          let page = 1;
+          let hasMore = true;
 
-          if (langs.length > 0) {
-              langs.forEach(lang => {
+          while (hasMore) {
+              const response = await fetch(
+                  `https://api.github.com/users/${username}/repos?per_page=100&page=${page}`
+              );
+              if (!response.ok) throw new Error('Failed to fetch repos');
+
+              const repos = await response.json();
+              if (repos.length === 0) {
+                  hasMore = false;
+                  break;
+              }
+
+              // Collect primary languages from each repo
+              repos.forEach(r => {
+                  if (r.language) allLangs.add(r.language);
+              });
+
+              // Check if there are more pages
+              const linkHeader = response.headers.get('Link');
+              if (!linkHeader || !linkHeader.includes('rel="next"')) {
+                  hasMore = false;
+              }
+              page++;
+          }
+
+          if (allLangs.size > 0) {
+              allLangs.forEach(lang => {
                   if (typeof addSkill === 'function') addSkill(lang);
               });
               closeGithubModal();

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -158,11 +158,29 @@ def test_get_recommendations_max_three():
     assert len(results) <= 3, f"Expected at most 3 results, got {len(results)}"
 
 
-def test_get_recommendations_no_match_returns_empty():
-    """A very unlikely skill/interest combo should return an empty list."""
-    results = get_recommendations("Rust", "Advanced", "Games", "High")
-    # Rust and Games are not in the dataset so this should be empty or minimal
+def test_get_recommendations_returns_list():
+    """The engine should always return a list."""
+    results = get_recommendations("Python", "Beginner", "Data", "Low")
     assert isinstance(results, list)
+
+
+def test_score_single_project_no_match_at_all():
+    """A project with no overlap should score zero, even when time is in valid range."""
+    project = {
+        "skills": ["Python"],
+        "level": "Beginner",
+        "interest": "Web",
+        "time": "Low"
+    }
+    score = score_single_project(
+        project,
+        user_skills=["Rust"],
+        level="Intermediate",
+        interest="Games",
+        time_availability="High"
+    )
+    # 0 skill match (0) + no level (0) + no interest (0) + no time match (0) = 0
+    assert score == 0, f"Expected 0 but got {score}"
 
 
 def test_get_recommendations_result_format():
@@ -240,6 +258,7 @@ def test_security_headers_present():
         response.headers["Permissions-Policy"]
         == "geolocation=(), microphone=(), camera=()"
     )
+    assert "Content-Security-Policy" in response.headers
 
 
 def test_recommend_api_valid():
@@ -256,20 +275,19 @@ def test_recommend_api_valid():
     assert len(data["projects"]) > 0
 
 
-def test_recommend_api_interest_not_available():
-    """The API should return no projects for blocked interest categories."""
+def test_recommend_api_returns_valid_response():
+    """The API should return a valid response with projects key."""
     client = get_client()
     response = client.post("/api/recommend", json={
-        "skills": "Python, JavaScript",
+        "skills": "Python",
         "level": "Beginner",
-        "interest": "Machine Learning/AI",
+        "interest": "Data",
         "time": "Low"
     })
     assert response.status_code == 200
     data = response.get_json()
-    assert data["projects"] == []
-    assert "message" in data
-    assert "no projects are currently available" in data["message"].lower()
+    assert "projects" in data
+    assert len(data["projects"]) > 0
 
 
 def test_recommend_api_missing_field():

--- a/utils/recommender.py
+++ b/utils/recommender.py
@@ -69,7 +69,10 @@ def score_single_project(
     """
     # Compare time availability, return results with the same time availibity or lower.
     TIME_AVAILABILITY = ['low', 'medium', 'high']
-    time_availability_index =   TIME_AVAILABILITY.index(time_availability.strip().lower())
+    try:
+        time_availability_index = TIME_AVAILABILITY.index(time_availability.strip().lower())
+    except (ValueError, AttributeError):
+        return 0
     valid_time = TIME_AVAILABILITY[ : time_availability_index + 1 ]
     
     score = 0


### PR DESCRIPTION
## Summary

This PR fixes 11 bugs across the DevPath codebase: security hardening, UI interaction fixes, backend validation, recommendation engine reliability, and test cleanup.

## Bugs Fixed

### #656 — ValueError in recommender.py
- **File:** `utils/recommender.py:72`
- **Fix:** Wrapped `TIME_AVAILABILITY.index()` in try/except (ValueError, AttributeError). When time_availability is empty or not in the list, the function safely returns 0 instead of crashing with a 500 error.

### #654 — Missing Content-Security-Policy header
- **File:** `app.py:32`
- **Fix:** Added `Content-Security-Policy` header to `add_security_headers` with restrictive defaults: `default-src 'self'`, script/style/font/img/connect-src restrictions, and `frame-ancestors 'none'`.

### #653 — Recommendation API leaks internal server file paths
- **File:** `routes/main_routes.py:61-67`, `app.py:69-71`
- **Fix:** Wrapped `get_recommendations()` call in try/except so exceptions return a safe JSON error instead of an HTML traceback. Made `app.run(debug=...)` env-driven via `FLASK_DEBUG` environment variable.

### #652 — Hardcoded NO_PROJECT_INTERESTS bypass
- **Files:** `routes/main_routes.py:14-24`, `routes/main_routes.py:74-78`
- **Fix:** Removed the `NO_PROJECT_INTERESTS` set and `interest_has_no_projects()` function, which prevented the recommender from ever running for interest categories like "machine learning/ai", "devops", "mobile", etc. The recommender now evaluates all interest areas equally.

### #651 — GitHub skill import silently discards most languages
- **File:** `static/script.js:874-903`
- **Fix:** Added pagination to the GitHub API call (up to `per_page=100`, iterating via `Link` header). Previously only the first 30 repos were fetched, silently discarding languages from the rest.

### #650 — Test suite has false-positive assertions
- **File:** `tests/test_basic.py`
- **Fixes:**
  - Renamed `test_get_recommendations_no_match_returns_empty` to `test_get_recommendations_returns_list` (test name did not match assertion)
  - Added `test_score_single_project_no_match_at_all` — a true no-match test at the scoring function level
  - Updated `test_recommend_api_interest_not_available` to work without the removed bypass
  - Added CSP header assertion to `test_security_headers_present`

### #646 — Missing secret_key, hardcoded debug=True
- **File:** `app.py:18`, `app.py:69-71`
- **Fix:** Set `app.secret_key` from `SECRET_KEY` env var (fallback to `os.urandom(24).hex()`). Made `debug` mode env-driven via `FLASK_DEBUG`.

### #641 — 'Import from GitHub' button non-functional
- **File:** `static/script.js`
- **Fix:** The GitHub modal code relied on functions (`addSkill`) defined inside the `if (isIndexPage)` block. The `renderResults` function had a brace mismatch from duplicate `if` conditions, causing downstream function definitions to be scoped incorrectly. Fixed the brace structure.

### #640 — 'Generate My Projects' button fails to redirect
- **File:** `static/script.js:528-538`
- **Fix:** Removed dead code in `.catch()` handler that redeclared `payload` without using it. Fixed to show a meaningful error message instead.

### #638 — Skill chips non-functional
- **File:** `static/script.js:414-421`
- **Fix:** Fixed `syncSkillsHiddenInput()` which redeclared `skillsHidden` with `var` inside the inner scope (shadowing the outer variable), causing the hidden input to never be updated.

### #631 — Skill selection buttons non-functional
- **File:** `static/script.js:576-609`
- **Fix:** Removed duplicate `if (!projects || projects.length === 0)` condition block in `renderResults()` that created a brace mismatch, causing subsequent helper functions to fall inside the wrong scope.
