### PR TITLE
fix(starter-code): repair expense tracker syntax error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- No fixes recorded yet
+- Fixed the Personal Expense Tracker starter code so it compiles and runs without a syntax error.

--- a/starter_code/expense_tracker.py
+++ b/starter_code/expense_tracker.py
@@ -1,3 +1,4 @@
+"""
 Project:    Personal Expense Tracker
 Difficulty: Beginner
 Skills:     Python, CSV module, datetime module

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -12,6 +12,7 @@
 
 import sys
 import os
+import py_compile
 
 # Allow imports from the project root when running tests directly
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -54,6 +55,16 @@ def test_each_project_has_required_fields():
     for project in load_all_projects():
         for field in required:
             assert field in project, f"Project '{project.get('title')}' is missing field: {field}"
+
+
+def test_python_starter_code_files_compile():
+    """Python starter files must be syntactically valid for users to run."""
+    starter_code_dir = os.path.join(os.path.dirname(__file__), "..", "starter_code")
+
+    for filename in os.listdir(starter_code_dir):
+        if filename.endswith(".py"):
+            path = os.path.join(starter_code_dir, filename)
+            py_compile.compile(path, doraise=True)
 
 
 def test_find_project_by_id_found():

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -13,6 +13,7 @@
 import sys
 import os
 import py_compile
+import tempfile
 
 # Allow imports from the project root when running tests directly
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -61,10 +62,15 @@ def test_python_starter_code_files_compile():
     """Python starter files must be syntactically valid for users to run."""
     starter_code_dir = os.path.join(os.path.dirname(__file__), "..", "starter_code")
 
-    for filename in os.listdir(starter_code_dir):
-        if filename.endswith(".py"):
-            path = os.path.join(starter_code_dir, filename)
-            py_compile.compile(path, doraise=True)
+    with tempfile.TemporaryDirectory() as bytecode_dir:
+        for root, _, files in os.walk(starter_code_dir):
+            for filename in sorted(files):
+                if filename.endswith(".py"):
+                    path = os.path.join(root, filename)
+                    relative_path = os.path.relpath(path, starter_code_dir)
+                    cfile = os.path.join(bytecode_dir, f"{relative_path}c")
+                    os.makedirs(os.path.dirname(cfile), exist_ok=True)
+                    py_compile.compile(path, doraise=True, cfile=cfile)
 
 
 def test_find_project_by_id_found():


### PR DESCRIPTION
## What
Fixes the Personal Expense Tracker starter file so users can run or compile the downloaded starter code without hitting a Python syntax error. The file had a closing module docstring delimiter but no opening delimiter, so its introductory metadata was parsed as executable Python.

## How
Added the missing opening triple-quote to make the starter-code metadata a valid module docstring. Added a regression test that compiles every Python file in starter_code with py_compile, and recorded the user-facing fix in CHANGELOG.md per the contribution guide.

## Testing
- .venv/bin/python tests/test_basic.py
- .venv/bin/python -m py_compile starter_code/*.py
- git diff --check

## Risks / Notes
No linked issue number yet. Scope is limited to starter-code syntax validity, one regression test, and the changelog entry.