### PR TITLE
Remove duplicate SVG icon and fix skill strip overflow

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1000,9 +1000,8 @@ html[data-entry-anim="true"] .form-card form > .btn-submit { animation-delay: 39
 .skill-strip-items {
   display: flex;
   align-items: center;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   gap: 0;
-  white-space: nowrap;
 }
 
 .ss-item-indigo {

--- a/templates/index.html
+++ b/templates/index.html
@@ -524,9 +524,6 @@
       <div id="results-empty" style="display:none;">
         <div class="empty-state">
           <div class="empty-icon">
-            <svg width="52" height="52" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" 
-  stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8" /><line 
-  x1="21" y1="21" x2="16.65" y2="16.65" /></svg>
             <svg width="52" height="52" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"
               stroke-linecap="round" stroke-linejoin="round">
               <circle cx="11" cy="11" r="8" />


### PR DESCRIPTION
## Summary  
- Remove duplicate SVG icon in empty state section (fixes #618)  
- Allow skill strip items to wrap instead of overflowing (fixes #600, #568)