### PR TITLE
Implement in-memory caching for projects.json

### DIFF
--- a/utils/data_loader.py
+++ b/utils/data_loader.py
@@ -9,9 +9,11 @@ DATA_FILE = os.path.join(os.path.dirname(__file__), "..", "data", "projects.json
 
 
 def load_all_projects():
-    """Read and return the full list of projects from the JSON file."""
-    with open(DATA_FILE, "r", encoding="utf-8") as f:
-        return json.load(f)
+    global _projects_cache
+    if _projects_cache is None:
+        with open(DATA_FILE, "r", encoding="utf-8") as f:
+            _projects_cache = json.load(f)
+    return _projects_cache
 
 
 def find_project_by_id(project_id):


### PR DESCRIPTION
## Summary  
- Make load_all_projects() actually use the _projects_cache instead of reading from disk every call  
- Cache is populated on first call and reused until clear_cache() is invoked (fixes #673, #472)