### PR TITLE
Fix missing opening triple-quote in docstring

### DIFF
--- a/starter_code/expense_tracker.py
+++ b/starter_code/expense_tracker.py
@@ -1,3 +1,4 @@
+"""
 Project:    Personal Expense Tracker
 Difficulty: Beginner
 Skills:     Python, CSV module, datetime module


### PR DESCRIPTION
## Summary  
- Add missing opening triple-quote to the module docstring (fixes #670)