### PR TITLE
Implement skill proficiency levels with backward compatibility and we…

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -424,12 +424,11 @@ if (clearFiltersBtn) {
   }
 
   function syncSkillsHiddenInput() {
-    if (!skillsHidden){
-      var skillsHidden = document.getElementById("skills");
-    }
     // Keep the hidden <input> in sync for form serialisation
     // Serialize as JSON string for the backend
-    skillsHidden.value = JSON.stringify(selectedSkills);
+    if (skillsHidden) {
+      skillsHidden.value = JSON.stringify(selectedSkills);
+    }
   }
 
   updateQuickPickState();
@@ -537,17 +536,15 @@ if (clearFiltersBtn) {
 
           renderResults(data.projects || [], data.message);
         })
-        .catch(function () {
-
+        .catch(function (err) {
           setLoadingState(false);
-    //combine form values into an object to send to server/api
-    var payload = {
-      // Prefer the hidden input value; fall back to raw text box if hidden input is empty
-      skills: skillsHidden.value.trim() || skillsTextInput.value.trim(),
-      level: document.getElementById("level").value,
-      interest: document.getElementById("interest").value,
-      time: document.getElementById("time").value
-    };  
+          var generalErr = document.getElementById("form-error-general");
+          if (generalErr) {
+            generalErr.textContent = "Something went wrong. Please try again.";
+          }
+          console.error("Recommendation error:", err);
+        });
+    });
   });
 
   // Manages the loading state of the form and results section(whats visible or not)
@@ -568,7 +565,6 @@ if (clearFiltersBtn) {
       resultsSection.scrollIntoView({ behavior: "smooth" });
     } else {
       resultsLoadingEl.style.display  = "none";
-      resultsGrid.style.display       = "grid"; //switch back to gird layout 
     }
   }
 
@@ -586,17 +582,11 @@ if (clearFiltersBtn) {
     resultsGrid.innerHTML = "";
 
     if (!projects || projects.length === 0) {
-      resultsGrid.style.display     = "none";
-      resultsEmptyEl.style.display  = "block";
       resultsGrid.style.display = "none";
-      resultsEmptyEl.style.display = "block";
-      if (message && emptyMessageEl) emptyMessageEl.textContent = message;
-    if (!projects || projects.length === 0) { //if no projects returned from api, show the "no results" message and hide the grid
-      resultsGrid.style.display    = "none";
       resultsEmptyEl.style.display = "block";
 
       // Show a friendly custom message when the user selected an interest
-      var selectedInterest = document.getElementById("interest")?.value;
+      var selectedInterest = document.getElementById("interest") ? document.getElementById("interest").value : "";
       if (selectedInterest) {
         emptyMessageEl.textContent = "No projects are currently available for this interest. Please check back later or try a different area.";
       } else if (message) {

--- a/static/script.js
+++ b/static/script.js
@@ -73,6 +73,7 @@ if (isIndexPage) {
   var quickPickChips    = document.querySelectorAll(".skill-chip"); // predefined skills user can click
 
   // Tracks currently selected skills to prevent duplicates
+  // Each entry is an object: { name: "Python", level: "Intermediate" }
   var selectedSkills = [];
   // Clear Filters Button Functionality
 var clearFiltersBtn = document.getElementById("clear-filters-btn");
@@ -104,6 +105,10 @@ if (clearFiltersBtn) {
                     chip.classList.remove("active", "selected");
                 });
             }
+
+            // 6. Reset proficiency dropdown
+            var profSelect = document.getElementById("skill-proficiency");
+            if (profSelect) profSelect.value = "Intermediate";
         }
     });
 }
@@ -163,13 +168,16 @@ if (clearFiltersBtn) {
   initSkillStripMarquee();
 
   function normalizeSkill(skill) {
+    if (typeof skill === 'object' && skill !== null) {
+      return skill.name.trim().toLowerCase();
+    }
     return skill.trim().toLowerCase();
   }
 
-  function isSkillSelected(skill) {
-    var normalizedSkill = normalizeSkill(skill);
-    return selectedSkills.some(function (selectedSkill) {
-      return normalizeSkill(selectedSkill) === normalizedSkill;
+  function isSkillSelected(skillName) {
+    var normalizedName = normalizeSkill(skillName);
+    return selectedSkills.some(function (skill) {
+      return normalizeSkill(skill.name) === normalizedName;
     });
   }
 
@@ -306,9 +314,7 @@ if (clearFiltersBtn) {
   quickPickChips.forEach(function (chip) {
     chip.addEventListener("click", function () {
       var skill = chip.getAttribute("data-skill");
-      var isAlreadySelected = selectedSkills.some(function (s) {
-        return s.toLowerCase() === skill.toLowerCase();
-      });
+      var isAlreadySelected = isSkillSelected(skill);
 
       if (isAlreadySelected) {
         removeSkill(skill);
@@ -342,8 +348,11 @@ if (clearFiltersBtn) {
   });
 
   if (skillWrap) {
-    skillWrap.addEventListener("click", function () {
-      skillsTextInput.focus();
+    skillWrap.addEventListener("click", function (evt) {
+        // Only focus if clicking the wrap itself or elements that aren't inputs/selects
+        if (evt.target === skillWrap || evt.target === chipsSelectedEl) {
+            skillsTextInput.focus();
+        }
     });
   }
 
@@ -355,16 +364,18 @@ if (clearFiltersBtn) {
   });
 
   //add a skill to the list if it's not empty or a duplicate
-  function addSkill(rawSkill) {
+  function addSkill(rawSkill, profLevel) {
     // Clean up any extra spaces and match to canonical skill name
-    var skill = getCanonicalSkill(rawSkill);
+    var skillName = getCanonicalSkill(rawSkill);
     // Nothing to add if string is empty after trimming
-    if (!skill) return;
+    if (!skillName) return;
 
     // Block duplicate entries (case-insensitive)
-    if (isSkillSelected(skill)) return;
+    if (isSkillSelected(skillName)) return;
 
-    selectedSkills.push(skill);
+    var level = profLevel || document.getElementById("skill-proficiency").value || "Intermediate";
+
+    selectedSkills.push({ name: skillName, level: level });
     renderSelectedChips();
     syncSkillsHiddenInput();
     updateQuickPickState();
@@ -373,10 +384,11 @@ if (clearFiltersBtn) {
   }
 
   // remove a skill from the list and update the UI accordingly
-  function removeSkill(skill) {
+  function removeSkill(skillName) {
+    var normalizedToRemove = normalizeSkill(skillName);
     // Rebuild the array without the skill that was just removed
-    selectedSkills = selectedSkills.filter(function (selectedSkill) {
-      return normalizeSkill(selectedSkill) !== normalizeSkill(skill);
+    selectedSkills = selectedSkills.filter(function (skill) {
+      return normalizeSkill(skill.name) !== normalizedToRemove;
     });
     renderSelectedChips();
     syncSkillsHiddenInput();
@@ -392,18 +404,28 @@ if (clearFiltersBtn) {
       // Create a new chip element for each selected skill
       var chipEl = document.createElement("span");
       chipEl.className = "skill-chip-selected";
-      chipEl.textContent = skill;
+      
+      var nameSpan = document.createElement("span");
+      nameSpan.className = "skill-name";
+      nameSpan.textContent = skill.name;
+      
+      var profSpan = document.createElement("span");
+      profSpan.className = "proficiency-tag";
+      profSpan.textContent = skill.level;
+
+      chipEl.appendChild(nameSpan);
+      chipEl.appendChild(profSpan);
 
       // Remove button for each chip (create lil "x" button)
       var removeBtn = document.createElement("button");
       removeBtn.type = "button";
       removeBtn.className = "skill-chip-remove";
       removeBtn.innerHTML = "&times;"; //'x' symbol
-      removeBtn.setAttribute("aria-label", "Remove " + skill); 
+      removeBtn.setAttribute("aria-label", "Remove " + skill.name); 
       removeBtn.addEventListener("click", function (e) {
         // Stop click from bubbling up to the chip wrap's click listener
         e.stopPropagation();
-        removeSkill(skill);
+        removeSkill(skill.name);
       });
 
       chipEl.appendChild(removeBtn); // put x button inside the chip
@@ -416,8 +438,8 @@ if (clearFiltersBtn) {
       var skillsHidden = document.getElementById("skills");
     }
     // Keep the hidden <input> in sync for form serialisation
-    // The API expects a comma-separated string, so join the array that way
-    skillsHidden.value = selectedSkills.join(", ");
+    // Store as JSON string so the backend can easily parse it
+    skillsHidden.value = JSON.stringify(selectedSkills);
   }
 
   updateQuickPickState();

--- a/static/script.js
+++ b/static/script.js
@@ -73,7 +73,6 @@ if (isIndexPage) {
   var quickPickChips    = document.querySelectorAll(".skill-chip"); // predefined skills user can click
 
   // Tracks currently selected skills to prevent duplicates
-  // Each entry is an object: { name: "Python", level: "Intermediate" }
   var selectedSkills = [];
   // Clear Filters Button Functionality
 var clearFiltersBtn = document.getElementById("clear-filters-btn");
@@ -105,10 +104,6 @@ if (clearFiltersBtn) {
                     chip.classList.remove("active", "selected");
                 });
             }
-
-            // 6. Reset proficiency dropdown
-            var profSelect = document.getElementById("skill-proficiency");
-            if (profSelect) profSelect.value = "Intermediate";
         }
     });
 }
@@ -168,16 +163,13 @@ if (clearFiltersBtn) {
   initSkillStripMarquee();
 
   function normalizeSkill(skill) {
-    if (typeof skill === 'object' && skill !== null) {
-      return skill.name.trim().toLowerCase();
-    }
     return skill.trim().toLowerCase();
   }
 
-  function isSkillSelected(skillName) {
-    var normalizedName = normalizeSkill(skillName);
-    return selectedSkills.some(function (skill) {
-      return normalizeSkill(skill.name) === normalizedName;
+  function isSkillSelected(skill) {
+    var normalizedSkill = normalizeSkill(skill);
+    return selectedSkills.some(function (selectedSkill) {
+      return normalizeSkill(selectedSkill) === normalizedSkill;
     });
   }
 
@@ -314,7 +306,9 @@ if (clearFiltersBtn) {
   quickPickChips.forEach(function (chip) {
     chip.addEventListener("click", function () {
       var skill = chip.getAttribute("data-skill");
-      var isAlreadySelected = isSkillSelected(skill);
+      var isAlreadySelected = selectedSkills.some(function (s) {
+        return s.toLowerCase() === skill.toLowerCase();
+      });
 
       if (isAlreadySelected) {
         removeSkill(skill);
@@ -348,11 +342,8 @@ if (clearFiltersBtn) {
   });
 
   if (skillWrap) {
-    skillWrap.addEventListener("click", function (evt) {
-        // Only focus if clicking the wrap itself or elements that aren't inputs/selects
-        if (evt.target === skillWrap || evt.target === chipsSelectedEl) {
-            skillsTextInput.focus();
-        }
+    skillWrap.addEventListener("click", function () {
+      skillsTextInput.focus();
     });
   }
 
@@ -364,18 +355,16 @@ if (clearFiltersBtn) {
   });
 
   //add a skill to the list if it's not empty or a duplicate
-  function addSkill(rawSkill, profLevel) {
+  function addSkill(rawSkill) {
     // Clean up any extra spaces and match to canonical skill name
-    var skillName = getCanonicalSkill(rawSkill);
+    var skill = getCanonicalSkill(rawSkill);
     // Nothing to add if string is empty after trimming
-    if (!skillName) return;
+    if (!skill) return;
 
     // Block duplicate entries (case-insensitive)
-    if (isSkillSelected(skillName)) return;
+    if (isSkillSelected(skill)) return;
 
-    var level = profLevel || document.getElementById("skill-proficiency").value || "Intermediate";
-
-    selectedSkills.push({ name: skillName, level: level });
+    selectedSkills.push(skill);
     renderSelectedChips();
     syncSkillsHiddenInput();
     updateQuickPickState();
@@ -384,11 +373,10 @@ if (clearFiltersBtn) {
   }
 
   // remove a skill from the list and update the UI accordingly
-  function removeSkill(skillName) {
-    var normalizedToRemove = normalizeSkill(skillName);
+  function removeSkill(skill) {
     // Rebuild the array without the skill that was just removed
-    selectedSkills = selectedSkills.filter(function (skill) {
-      return normalizeSkill(skill.name) !== normalizedToRemove;
+    selectedSkills = selectedSkills.filter(function (selectedSkill) {
+      return normalizeSkill(selectedSkill) !== normalizeSkill(skill);
     });
     renderSelectedChips();
     syncSkillsHiddenInput();
@@ -404,28 +392,18 @@ if (clearFiltersBtn) {
       // Create a new chip element for each selected skill
       var chipEl = document.createElement("span");
       chipEl.className = "skill-chip-selected";
-      
-      var nameSpan = document.createElement("span");
-      nameSpan.className = "skill-name";
-      nameSpan.textContent = skill.name;
-      
-      var profSpan = document.createElement("span");
-      profSpan.className = "proficiency-tag";
-      profSpan.textContent = skill.level;
-
-      chipEl.appendChild(nameSpan);
-      chipEl.appendChild(profSpan);
+      chipEl.textContent = skill;
 
       // Remove button for each chip (create lil "x" button)
       var removeBtn = document.createElement("button");
       removeBtn.type = "button";
       removeBtn.className = "skill-chip-remove";
       removeBtn.innerHTML = "&times;"; //'x' symbol
-      removeBtn.setAttribute("aria-label", "Remove " + skill.name); 
+      removeBtn.setAttribute("aria-label", "Remove " + skill); 
       removeBtn.addEventListener("click", function (e) {
         // Stop click from bubbling up to the chip wrap's click listener
         e.stopPropagation();
-        removeSkill(skill.name);
+        removeSkill(skill);
       });
 
       chipEl.appendChild(removeBtn); // put x button inside the chip
@@ -438,8 +416,8 @@ if (clearFiltersBtn) {
       var skillsHidden = document.getElementById("skills");
     }
     // Keep the hidden <input> in sync for form serialisation
-    // Store as JSON string so the backend can easily parse it
-    skillsHidden.value = JSON.stringify(selectedSkills);
+    // The API expects a comma-separated string, so join the array that way
+    skillsHidden.value = selectedSkills.join(", ");
   }
 
   updateQuickPickState();

--- a/static/script.js
+++ b/static/script.js
@@ -169,7 +169,7 @@ if (clearFiltersBtn) {
   function isSkillSelected(skill) {
     var normalizedSkill = normalizeSkill(skill);
     return selectedSkills.some(function (selectedSkill) {
-      return normalizeSkill(selectedSkill) === normalizedSkill;
+      return normalizeSkill(selectedSkill.name) === normalizedSkill;
     });
   }
 
@@ -306,9 +306,7 @@ if (clearFiltersBtn) {
   quickPickChips.forEach(function (chip) {
     chip.addEventListener("click", function () {
       var skill = chip.getAttribute("data-skill");
-      var isAlreadySelected = selectedSkills.some(function (s) {
-        return s.toLowerCase() === skill.toLowerCase();
-      });
+      var isAlreadySelected = isSkillSelected(skill);
 
       if (isAlreadySelected) {
         removeSkill(skill);
@@ -364,7 +362,10 @@ if (clearFiltersBtn) {
     // Block duplicate entries (case-insensitive)
     if (isSkillSelected(skill)) return;
 
-    selectedSkills.push(skill);
+    var proficiencySelect = document.getElementById("skill-proficiency");
+    var proficiency = proficiencySelect ? proficiencySelect.value : "Intermediate";
+
+    selectedSkills.push({ name: skill, level: proficiency });
     renderSelectedChips();
     syncSkillsHiddenInput();
     updateQuickPickState();
@@ -376,7 +377,7 @@ if (clearFiltersBtn) {
   function removeSkill(skill) {
     // Rebuild the array without the skill that was just removed
     selectedSkills = selectedSkills.filter(function (selectedSkill) {
-      return normalizeSkill(selectedSkill) !== normalizeSkill(skill);
+      return normalizeSkill(selectedSkill.name) !== normalizeSkill(skill);
     });
     renderSelectedChips();
     syncSkillsHiddenInput();
@@ -388,11 +389,22 @@ if (clearFiltersBtn) {
   function renderSelectedChips() {
     // Wipe out old chips first so we don't end up with duplicates in the UI
     chipsSelectedEl.innerHTML = "";
-    selectedSkills.forEach(function (skill) {
+    selectedSkills.forEach(function (skillObj) {
+      var skill = skillObj.name;
+      var level = skillObj.level;
+
       // Create a new chip element for each selected skill
       var chipEl = document.createElement("span");
       chipEl.className = "skill-chip-selected";
-      chipEl.textContent = skill;
+      
+      // Proficiency badge
+      var badge = document.createElement("span");
+      badge.className = "skill-proficiency-badge";
+      badge.textContent = level.substring(0, 3); // BEG, INT, ADV
+      chipEl.appendChild(badge);
+
+      var textNode = document.createTextNode(skill);
+      chipEl.appendChild(textNode);
 
       // Remove button for each chip (create lil "x" button)
       var removeBtn = document.createElement("button");
@@ -416,8 +428,8 @@ if (clearFiltersBtn) {
       var skillsHidden = document.getElementById("skills");
     }
     // Keep the hidden <input> in sync for form serialisation
-    // The API expects a comma-separated string, so join the array that way
-    skillsHidden.value = selectedSkills.join(", ");
+    // Serialize as JSON string for the backend
+    skillsHidden.value = JSON.stringify(selectedSkills);
   }
 
   updateQuickPickState();

--- a/static/style.css
+++ b/static/style.css
@@ -1318,36 +1318,19 @@ label {
   flex-wrap: wrap;
   gap: 6px;
   align-items: center;
-  margin-bottom: 4px;
 }
 
 .skill-chip-selected {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  background-color: var(--indigo-50);
-  color: var(--indigo-700);
-  padding: 4px 10px;
-  border-radius: var(--r-xs);
-  font-size: 0.85rem;
-  font-weight: 500;
-  border: 1px solid var(--indigo-100);
-  transition: all var(--t);
-}
-
-.skill-chip-selected .proficiency-tag {
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.02em;
-  opacity: 0.7;
-  background-color: var(--indigo-100);
-  padding: 1px 4px;
-  border-radius: 3px;
+  gap: 5px;
+  font-size: 0.8rem;
   font-weight: 600;
-}
-
-.skill-chip-selected .skill-name {
-  white-space: nowrap;
+  color: var(--indigo-700);
+  background: var(--indigo-100);
+  border: 1px solid rgba(79, 110, 247, 0.2);
+  border-radius: var(--r-full);
+  padding: 3px 10px 3px 12px;
 }
 
 .skill-chip-remove {
@@ -1355,7 +1338,7 @@ label {
   border: none;
   cursor: pointer;
   color: var(--indigo-500);
-  font-size: 1.1rem;
+  font-size: 1rem;
   line-height: 1;
   padding: 0;
   display: flex;
@@ -1368,34 +1351,10 @@ label {
 }
 
 /* Text input inside the skill wrap */
-.skill-input-row {
-  display: flex;
-  gap: 8px;
-  width: 100%;
-}
-
-.skill-proficiency-select {
-  width: auto !important;
-  min-width: 120px;
-  padding: 0 12px !important;
-  height: 40px;
-  border-radius: var(--r-xs);
-  border: 1px solid var(--border);
-  background-color: var(--white);
-  color: var(--text-body);
-  font-family: var(--font-body);
-  font-size: 0.85rem;
-  cursor: pointer;
-  transition: border-color var(--t);
-  outline: none;
-  appearance: auto !important;
-}
-
 .skill-input-wrap input[type="text"] {
-  border: 1px solid var(--border) !important;
-  background: var(--white) !important;
-  border-radius: var(--r-xs);
-  padding: 8px 12px !important;
+  border: none;
+  background: transparent;
+  padding: 4px 6px;
   flex: 1;
   min-width: 140px;
   box-shadow: none;
@@ -1406,18 +1365,8 @@ label {
 
 .skill-input-wrap input[type="text"]:focus {
   outline: none;
-  border-color: var(--indigo-500) !important;
+  box-shadow: none;
 }
-
-@media (max-width: 600px) {
-  .skill-input-row {
-    flex-direction: column;
-  }
-  .skill-proficiency-select {
-    width: 100% !important;
-  }
-}
-
 
 /*suggestions dropdown*/
 .skills-suggestions {

--- a/static/style.css
+++ b/static/style.css
@@ -1333,6 +1333,41 @@ label {
   padding: 3px 10px 3px 12px;
 }
 
+.skill-proficiency-badge {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  background: rgba(0, 0, 0, 0.08);
+  color: var(--indigo-800);
+  padding: 1px 6px;
+  border-radius: 4px;
+  margin-right: 2px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.skill-proficiency-select {
+  border: none;
+  background: var(--indigo-50);
+  color: var(--indigo-700);
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 2px 24px 2px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-right: 6px;
+  outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%233347e0' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'%3E%3C/path%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  transition: background var(--t);
+}
+
+.skill-proficiency-select:hover {
+  background-color: var(--indigo-100);
+}
+
 .skill-chip-remove {
   background: none;
   border: none;

--- a/static/style.css
+++ b/static/style.css
@@ -1318,19 +1318,36 @@ label {
   flex-wrap: wrap;
   gap: 6px;
   align-items: center;
+  margin-bottom: 4px;
 }
 
 .skill-chip-selected {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  font-size: 0.8rem;
-  font-weight: 600;
+  gap: 6px;
+  background-color: var(--indigo-50);
   color: var(--indigo-700);
-  background: var(--indigo-100);
-  border: 1px solid rgba(79, 110, 247, 0.2);
-  border-radius: var(--r-full);
-  padding: 3px 10px 3px 12px;
+  padding: 4px 10px;
+  border-radius: var(--r-xs);
+  font-size: 0.85rem;
+  font-weight: 500;
+  border: 1px solid var(--indigo-100);
+  transition: all var(--t);
+}
+
+.skill-chip-selected .proficiency-tag {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  opacity: 0.7;
+  background-color: var(--indigo-100);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-weight: 600;
+}
+
+.skill-chip-selected .skill-name {
+  white-space: nowrap;
 }
 
 .skill-chip-remove {
@@ -1338,7 +1355,7 @@ label {
   border: none;
   cursor: pointer;
   color: var(--indigo-500);
-  font-size: 1rem;
+  font-size: 1.1rem;
   line-height: 1;
   padding: 0;
   display: flex;
@@ -1351,10 +1368,34 @@ label {
 }
 
 /* Text input inside the skill wrap */
+.skill-input-row {
+  display: flex;
+  gap: 8px;
+  width: 100%;
+}
+
+.skill-proficiency-select {
+  width: auto !important;
+  min-width: 120px;
+  padding: 0 12px !important;
+  height: 40px;
+  border-radius: var(--r-xs);
+  border: 1px solid var(--border);
+  background-color: var(--white);
+  color: var(--text-body);
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: border-color var(--t);
+  outline: none;
+  appearance: auto !important;
+}
+
 .skill-input-wrap input[type="text"] {
-  border: none;
-  background: transparent;
-  padding: 4px 6px;
+  border: 1px solid var(--border) !important;
+  background: var(--white) !important;
+  border-radius: var(--r-xs);
+  padding: 8px 12px !important;
   flex: 1;
   min-width: 140px;
   box-shadow: none;
@@ -1365,8 +1406,18 @@ label {
 
 .skill-input-wrap input[type="text"]:focus {
   outline: none;
-  box-shadow: none;
+  border-color: var(--indigo-500) !important;
 }
+
+@media (max-width: 600px) {
+  .skill-input-row {
+    flex-direction: column;
+  }
+  .skill-proficiency-select {
+    width: 100% !important;
+  }
+}
+
 
 /*suggestions dropdown*/
 .skills-suggestions {

--- a/templates/index.html
+++ b/templates/index.html
@@ -532,9 +532,6 @@
       <div id="results-empty" style="display:none;">
         <div class="empty-state">
           <div class="empty-icon">
-            <svg width="52" height="52" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" 
-  stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8" /><line 
-  x1="21" y1="21" x2="16.65" y2="16.65" /></svg>
             <svg width="52" height="52" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"
               stroke-linecap="round" stroke-linejoin="round">
               <circle cx="11" cy="11" r="8" />

--- a/templates/index.html
+++ b/templates/index.html
@@ -347,10 +347,18 @@
               </div>
               <div class="skill-input-wrap" id="skill-input-wrap">
                 <div class="skill-chips-selected" id="skill-chips-selected"></div>
+                
+                <!-- Skill Proficiency Selector -->
+                <select id="skill-proficiency" class="skill-proficiency-select" aria-label="Skill Proficiency">
+                  <option value="Beginner">Beginner</option>
+                  <option value="Intermediate" selected>Intermediate</option>
+                  <option value="Advanced">Advanced</option>
+                </select>
+
                 <input
                   type="text"
                   id="skills-input" 
-                  placeholder="Type a skill and press Enter..."
+                  placeholder="Type a skill..."
                   autocomplete="off"
                   aria-haspopup="listbox"
                   aria-expanded="false"

--- a/templates/index.html
+++ b/templates/index.html
@@ -347,15 +347,22 @@
               </div>
               <div class="skill-input-wrap" id="skill-input-wrap">
                 <div class="skill-chips-selected" id="skill-chips-selected"></div>
-                <input
-                  type="text"
-                  id="skills-input" 
-                  placeholder="Type a skill and press Enter..."
-                  autocomplete="off"
-                  aria-haspopup="listbox"
-                  aria-expanded="false"
-                  aria-controls="skills-suggestions"
-                />
+                <div class="skill-input-row">
+                  <input
+                    type="text"
+                    id="skills-input" 
+                    placeholder="Type a skill..."
+                    autocomplete="off"
+                    aria-haspopup="listbox"
+                    aria-expanded="false"
+                    aria-controls="skills-suggestions"
+                  />
+                  <select id="skill-proficiency" class="skill-proficiency-select" title="Skill proficiency level">
+                    <option value="Beginner">Beginner</option>
+                    <option value="Intermediate" selected>Intermediate</option>
+                    <option value="Advanced">Advanced</option>
+                  </select>
+                </div>
                 <div id="skills-suggestions" class="skills-suggestions"></div>
               </div>
               <!-- Hidden field holds the final comma-separated value -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -347,22 +347,15 @@
               </div>
               <div class="skill-input-wrap" id="skill-input-wrap">
                 <div class="skill-chips-selected" id="skill-chips-selected"></div>
-                <div class="skill-input-row">
-                  <input
-                    type="text"
-                    id="skills-input" 
-                    placeholder="Type a skill..."
-                    autocomplete="off"
-                    aria-haspopup="listbox"
-                    aria-expanded="false"
-                    aria-controls="skills-suggestions"
-                  />
-                  <select id="skill-proficiency" class="skill-proficiency-select" title="Skill proficiency level">
-                    <option value="Beginner">Beginner</option>
-                    <option value="Intermediate" selected>Intermediate</option>
-                    <option value="Advanced">Advanced</option>
-                  </select>
-                </div>
+                <input
+                  type="text"
+                  id="skills-input" 
+                  placeholder="Type a skill and press Enter..."
+                  autocomplete="off"
+                  aria-haspopup="listbox"
+                  aria-expanded="false"
+                  aria-controls="skills-suggestions"
+                />
                 <div id="skills-suggestions" class="skills-suggestions"></div>
               </div>
               <!-- Hidden field holds the final comma-separated value -->

--- a/utils/recommender.py
+++ b/utils/recommender.py
@@ -32,13 +32,30 @@ SKILL_ALIASES = {
 
 def parse_skills(skills_string):
     """
-    Convert a raw comma-separated skills string into
-    a normalized lowercase list.
+    Convert a raw skills input into a list of skill objects.
+    Supports both new JSON format and legacy comma-separated strings.
 
-    Example:
-    "JS, HTML5, CSS3" -> ["javascript", "html", "css"]
+    New format: '[{"name": "Python", "level": "Advanced"}]'
+    Legacy format: "Python, JavaScript"
     """
+    import json
+    
+    # Try parsing as JSON first (new format)
+    try:
+        data = json.loads(skills_string)
+        if isinstance(data, list):
+            return [
+                {
+                    "name": SKILL_ALIASES.get(s["name"].strip().lower(), s["name"].strip().lower()),
+                    "level": s.get("level", "Intermediate")
+                }
+                for s in data
+                if s.get("name")
+            ]
+    except (json.JSONDecodeError, TypeError, KeyError):
+        pass
 
+    # Fallback to legacy comma-separated string
     raw_skills = [
         s.strip().lower()
         for s in skills_string.split(",")
@@ -46,7 +63,7 @@ def parse_skills(skills_string):
     ]
 
     normalized_skills = [
-        SKILL_ALIASES.get(skill, skill)
+        {"name": SKILL_ALIASES.get(skill, skill), "level": "Intermediate"}
         for skill in raw_skills
     ]
 
@@ -59,29 +76,42 @@ def score_single_project(
     """
     Calculate a numeric relevance score for one project.
 
-    Each matching criterion adds points:
-      - Each matching skill:  +3
-      - Level match:          +2
+    user_skills is a list of dicts: [{"name": "python", "level": "Advanced"}, ...]
+
+    Scoring:
+      - Base skill match:     +3
+      - Proficiency bonus:    +2 (matches project level) or +1 (near match)
+      - Experience match:     +2 (user overall level match)
       - Interest match:       +2
       - Time match:           +1
-
-    Returns an integer score (0 means no match at all).
     """
     # Compare time availability, return results with the same time availibity or lower.
     TIME_AVAILABILITY = ['low', 'medium', 'high']
-    time_availability_index =   TIME_AVAILABILITY.index(time_availability.strip().lower())
+    time_availability_index = TIME_AVAILABILITY.index(time_availability.strip().lower())
     valid_time = TIME_AVAILABILITY[ : time_availability_index + 1 ]
     
     score = 0
 
-    # Compare user's skills against the project's required skills
+    # Project skills for matching
     project_skills = [SKILL_ALIASES.get(s.lower(), s.lower()) for s in project.get("skills", [])]
-    # Count how many user skills overlap with the
-    # skills required by the current project.
-    matched_skills = sum(1 for skill in user_skills if skill in project_skills)
-    # Add weighted points based on the number of matching skills.
-    # More overlapping skills result in a higher recommendation score.
-    score += matched_skills * SCORING_WEIGHTS["skill"]
+    project_level = project.get("level", "Intermediate").lower()
+
+    # Match each user skill
+    for u_skill in user_skills:
+        u_name = u_skill["name"]
+        u_prof = u_skill["level"].lower()
+        
+        if u_name in project_skills:
+            # Base match
+            score += SCORING_WEIGHTS["skill"]
+            
+            # Proficiency steering
+            # Reward matching the user's specific skill proficiency with the project complexity
+            if u_prof == project_level:
+                score += 2 # Perfect alignment
+            elif (u_prof == "advanced" and project_level == "intermediate") or \
+                 (u_prof == "intermediate" and project_level == "beginner"):
+                score += 1 # Overqualified/Growth alignment
 
     # Award points for each additional matching criterion
     if project.get("level", "").lower() == level.lower():

--- a/utils/recommender.py
+++ b/utils/recommender.py
@@ -32,30 +32,13 @@ SKILL_ALIASES = {
 
 def parse_skills(skills_string):
     """
-    Convert a raw skills input into a list of skill objects.
-    Supports both new JSON format and legacy comma-separated strings.
+    Convert a raw comma-separated skills string into
+    a normalized lowercase list.
 
-    New format: '[{"name": "Python", "level": "Advanced"}]'
-    Legacy format: "Python, JavaScript"
+    Example:
+    "JS, HTML5, CSS3" -> ["javascript", "html", "css"]
     """
-    import json
-    
-    # Try parsing as JSON first (new format)
-    try:
-        data = json.loads(skills_string)
-        if isinstance(data, list):
-            return [
-                {
-                    "name": SKILL_ALIASES.get(s["name"].strip().lower(), s["name"].strip().lower()),
-                    "level": s.get("level", "Intermediate")
-                }
-                for s in data
-                if s.get("name")
-            ]
-    except (json.JSONDecodeError, TypeError, KeyError):
-        pass
 
-    # Fallback to legacy comma-separated string
     raw_skills = [
         s.strip().lower()
         for s in skills_string.split(",")
@@ -63,7 +46,7 @@ def parse_skills(skills_string):
     ]
 
     normalized_skills = [
-        {"name": SKILL_ALIASES.get(skill, skill), "level": "Intermediate"}
+        SKILL_ALIASES.get(skill, skill)
         for skill in raw_skills
     ]
 
@@ -76,42 +59,29 @@ def score_single_project(
     """
     Calculate a numeric relevance score for one project.
 
-    user_skills is a list of dicts: [{"name": "python", "level": "Advanced"}, ...]
-
-    Scoring:
-      - Base skill match:     +3
-      - Proficiency bonus:    +2 (matches project level) or +1 (near match)
-      - Experience match:     +2 (user overall level match)
+    Each matching criterion adds points:
+      - Each matching skill:  +3
+      - Level match:          +2
       - Interest match:       +2
       - Time match:           +1
+
+    Returns an integer score (0 means no match at all).
     """
     # Compare time availability, return results with the same time availibity or lower.
     TIME_AVAILABILITY = ['low', 'medium', 'high']
-    time_availability_index = TIME_AVAILABILITY.index(time_availability.strip().lower())
+    time_availability_index =   TIME_AVAILABILITY.index(time_availability.strip().lower())
     valid_time = TIME_AVAILABILITY[ : time_availability_index + 1 ]
     
     score = 0
 
-    # Project skills for matching
+    # Compare user's skills against the project's required skills
     project_skills = [SKILL_ALIASES.get(s.lower(), s.lower()) for s in project.get("skills", [])]
-    project_level = project.get("level", "Intermediate").lower()
-
-    # Match each user skill
-    for u_skill in user_skills:
-        u_name = u_skill["name"]
-        u_prof = u_skill["level"].lower()
-        
-        if u_name in project_skills:
-            # Base match
-            score += SCORING_WEIGHTS["skill"]
-            
-            # Proficiency steering
-            # Reward matching the user's specific skill proficiency with the project complexity
-            if u_prof == project_level:
-                score += 2 # Perfect alignment
-            elif (u_prof == "advanced" and project_level == "intermediate") or \
-                 (u_prof == "intermediate" and project_level == "beginner"):
-                score += 1 # Overqualified/Growth alignment
+    # Count how many user skills overlap with the
+    # skills required by the current project.
+    matched_skills = sum(1 for skill in user_skills if skill in project_skills)
+    # Add weighted points based on the number of matching skills.
+    # More overlapping skills result in a higher recommendation score.
+    score += matched_skills * SCORING_WEIGHTS["skill"]
 
     # Award points for each additional matching criterion
     if project.get("level", "").lower() == level.lower():

--- a/utils/recommender.py
+++ b/utils/recommender.py
@@ -30,52 +30,25 @@ SKILL_ALIASES = {
 }
 
 
-def parse_skills(skills_data):
+def parse_skills(skills_string):
     """
-    Convert raw skills data into a deduplicated, normalized list.
-    Supports both legacy comma-separated strings and newer JSON array formats
-    (including objects with proficiency levels).
+    Convert a raw comma-separated skills string into
+    a normalized lowercase list.
+
+    Example:
+    "JS, HTML5, CSS3" -> ["javascript", "html", "css"]
     """
-    import json
-    raw_skills = []
 
-    # Attempt to parse as JSON first to support newer structured formats
-    try:
-        if isinstance(skills_data, str) and skills_data.strip().startswith('['):
-            data = json.loads(skills_data)
-            if isinstance(data, list):
-                for item in data:
-                    if isinstance(item, str):
-                        raw_skills.append(item)
-                    elif isinstance(item, dict):
-                        # Extract skill name from objects (e.g., {"name": "Python", "level": "Expert"})
-                        name = item.get("name") or item.get("skill")
-                        if name:
-                            raw_skills.append(str(name))
-        else:
-            # Fallback to legacy comma-separated string format
-            raw_skills = [s.strip() for s in skills_data.split(",") if s.strip()]
-    except (json.JSONDecodeError, AttributeError):
-        # If JSON parsing fails or data is not a string, try basic split if possible
-        if isinstance(skills_data, str):
-            raw_skills = [s.strip() for s in skills_data.split(",") if s.strip()]
+    raw_skills = [
+        s.strip().lower()
+        for s in skills_string.split(",")
+        if s.strip()
+    ]
 
-    normalized_skills = []
-    seen_skills = set()
-
-    for rs in raw_skills:
-        # Normalize each skill name (case-insensitive deduplication)
-        skill_norm = rs.strip().lower()
-        if not skill_norm:
-            continue
-
-        # Resolve aliases (e.g., "js" -> "javascript")
-        canonical = SKILL_ALIASES.get(skill_norm, skill_norm)
-
-        # Check tracking set before adding to the final list
-        if canonical not in seen_skills:
-            normalized_skills.append(canonical)
-            seen_skills.add(canonical)
+    normalized_skills = [
+        SKILL_ALIASES.get(skill, skill)
+        for skill in raw_skills
+    ]
 
     return normalized_skills
 

--- a/utils/recommender.py
+++ b/utils/recommender.py
@@ -30,25 +30,52 @@ SKILL_ALIASES = {
 }
 
 
-def parse_skills(skills_string):
+def parse_skills(skills_data):
     """
-    Convert a raw comma-separated skills string into
-    a normalized lowercase list.
-
-    Example:
-    "JS, HTML5, CSS3" -> ["javascript", "html", "css"]
+    Convert raw skills data into a deduplicated, normalized list.
+    Supports both legacy comma-separated strings and newer JSON array formats
+    (including objects with proficiency levels).
     """
+    import json
+    raw_skills = []
 
-    raw_skills = [
-        s.strip().lower()
-        for s in skills_string.split(",")
-        if s.strip()
-    ]
+    # Attempt to parse as JSON first to support newer structured formats
+    try:
+        if isinstance(skills_data, str) and skills_data.strip().startswith('['):
+            data = json.loads(skills_data)
+            if isinstance(data, list):
+                for item in data:
+                    if isinstance(item, str):
+                        raw_skills.append(item)
+                    elif isinstance(item, dict):
+                        # Extract skill name from objects (e.g., {"name": "Python", "level": "Expert"})
+                        name = item.get("name") or item.get("skill")
+                        if name:
+                            raw_skills.append(str(name))
+        else:
+            # Fallback to legacy comma-separated string format
+            raw_skills = [s.strip() for s in skills_data.split(",") if s.strip()]
+    except (json.JSONDecodeError, AttributeError):
+        # If JSON parsing fails or data is not a string, try basic split if possible
+        if isinstance(skills_data, str):
+            raw_skills = [s.strip() for s in skills_data.split(",") if s.strip()]
 
-    normalized_skills = [
-        SKILL_ALIASES.get(skill, skill)
-        for skill in raw_skills
-    ]
+    normalized_skills = []
+    seen_skills = set()
+
+    for rs in raw_skills:
+        # Normalize each skill name (case-insensitive deduplication)
+        skill_norm = rs.strip().lower()
+        if not skill_norm:
+            continue
+
+        # Resolve aliases (e.g., "js" -> "javascript")
+        canonical = SKILL_ALIASES.get(skill_norm, skill_norm)
+
+        # Check tracking set before adding to the final list
+        if canonical not in seen_skills:
+            normalized_skills.append(canonical)
+            seen_skills.add(canonical)
 
     return normalized_skills
 

--- a/utils/recommender.py
+++ b/utils/recommender.py
@@ -32,25 +32,33 @@ SKILL_ALIASES = {
 
 def parse_skills(skills_string):
     """
-    Convert a raw comma-separated skills string into
-    a normalized lowercase list.
-
-    Example:
-    "JS, HTML5, CSS3" -> ["javascript", "html", "css"]
+    Convert a skills string into a normalized list of dicts.
+    Handles both legacy comma-separated strings and new JSON proficiency objects.
     """
+    import json
+    
+    try:
+        # Try to parse as JSON (new format: [{"name": "Python", "level": "Beginner"}])
+        skills_data = json.loads(skills_string)
+        if isinstance(skills_data, list):
+            return [{
+                "name": SKILL_ALIASES.get(item["name"].lower(), item["name"].lower()),
+                "level": item.get("level", "intermediate").lower()
+            } for item in skills_data if isinstance(item, dict) and item.get("name")]
+    except (json.JSONDecodeError, TypeError):
+        pass
 
+    # Fallback for legacy format: "JS, HTML5, CSS3" -> [{"name": "javascript", "level": "intermediate"}, ...]
     raw_skills = [
         s.strip().lower()
         for s in skills_string.split(",")
         if s.strip()
     ]
 
-    normalized_skills = [
-        SKILL_ALIASES.get(skill, skill)
+    return [
+        {"name": SKILL_ALIASES.get(skill, skill), "level": "intermediate"}
         for skill in raw_skills
     ]
-
-    return normalized_skills
 
 
 def score_single_project(
@@ -59,13 +67,10 @@ def score_single_project(
     """
     Calculate a numeric relevance score for one project.
 
-    Each matching criterion adds points:
-      - Each matching skill:  +3
-      - Level match:          +2
-      - Interest match:       +2
-      - Time match:           +1
-
-    Returns an integer score (0 means no match at all).
+    Weights are adjusted based on skill-specific proficiency:
+      - Skill match: +3 (base)
+      - Proficiency match bonus: +1
+      - Close match bonus (user > project): +0.5
     """
     # Compare time availability, return results with the same time availibity or lower.
     TIME_AVAILABILITY = ['low', 'medium', 'high']
@@ -74,14 +79,37 @@ def score_single_project(
     
     score = 0
 
-    # Compare user's skills against the project's required skills
+    # Project required skills (normalized)
     project_skills = [SKILL_ALIASES.get(s.lower(), s.lower()) for s in project.get("skills", [])]
-    # Count how many user skills overlap with the
-    # skills required by the current project.
-    matched_skills = sum(1 for skill in user_skills if skill in project_skills)
-    # Add weighted points based on the number of matching skills.
-    # More overlapping skills result in a higher recommendation score.
-    score += matched_skills * SCORING_WEIGHTS["skill"]
+    project_level = project.get("level", "beginner").lower()
+
+    # Score each user skill against project requirements
+    for u_skill in user_skills:
+        # Handle both list of strings (legacy/tests) and list of dicts (new)
+        if isinstance(u_skill, dict):
+            u_name = u_skill.get("name", "")
+            u_level = u_skill.get("level", "intermediate").lower()
+        else:
+            u_name = u_skill
+            u_level = "intermediate"
+
+        if not u_name:
+            continue
+            
+        u_name = SKILL_ALIASES.get(u_name.lower(), u_name.lower())
+
+        if u_name in project_skills:
+            # Base match points
+            points = SCORING_WEIGHTS["skill"]
+
+            # Adjust points based on proficiency match with project level
+            if u_level == project_level:
+                points += 1  # Perfect match
+            elif (u_level == "advanced" and project_level == "intermediate") or \
+                 (u_level == "intermediate" and project_level == "beginner"):
+                points += 0.5  # User over-qualified is still a good match
+
+            score += points
 
     # Award points for each additional matching criterion
     if project.get("level", "").lower() == level.lower():


### PR DESCRIPTION
## Summary
This PR introduces a new feature allowing users to specify their technical proficiency level (Beginner, Intermediate, Advanced) for each added skill. It maps these levels into a structured JSON payload and updates the underlying recommendation architecture to prioritize level-appropriate projects.

## Related Issue 
Closes #713 

## Type of Change
- [ ] Bug fix — resolves a broken behaviour
- [x] Feature — adds new functionality
- [ ] Data — adds new projects to `data/projects.json`
- [ ] Documentation — updates docs, README, or code comments only
- [x] Style — CSS or visual changes only, no logic change
- [ ] Refactor — restructures code without changing behaviour

## What Was Changed 
| File | Change made |
|------|-------------|
| `templates/index.html` | Appended inline drop-down selector to the input container. |
| `static/style.css` | Styled new select tags and created inline badge labels inside rendering chips. |
| `static/script.js` | Updated tracking arrays to handle objects and serialized fields as JSON strings. |
| `utils/recommender.py` | Rewrote `parse_skills` to intercept legacy array strings with "Intermediate" fallbacks, and re-weighted matching points inside `score_single_project`. |

## Test Results 
Verified locally. Form elements render seamlessly, database schemas transition safely without throwing data parsing exceptions on old/empty profile formats, and weighted scoring correctly changes recommendations dynamically.


## Self-Review Checklist 
- [x] I have read CONTRIBUTING.md and followed all guidelines
- [x] My branch name follows the convention: `feat/`, `fix/`, `docs/`, `data/`, `style/`, `test/`
- [x] Every new function I wrote has a docstring
- [x] I have not modified files outside the scope of the linked issue