### PR TITLE
fix: show error messages for invalid GitHub username in Sync modal

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -782,7 +782,6 @@ if (isIndexPage) {
   // Render result cards
   // ----------------------------------------------------------
 
- main
   function truncate(text, maxLength) {
     if (!text) return "";
     return text.length > maxLength ? text.slice(0, maxLength) + "..." : text;
@@ -793,6 +792,7 @@ if (isIndexPage) {
     span.className = "project-tag project-tag--" + type;
     span.textContent = text;
     return span;
+  }
 
   //takes the array of projects from the api and draws them on the page as cards
   //if array is empty it shows the "no results" message instead
@@ -828,7 +828,6 @@ if (isIndexPage) {
     });
 
     resultsSection.scrollIntoView({ behavior: "smooth" });
- main
   }
 
   function buildProjectCard(project) {
@@ -986,11 +985,29 @@ if (isIndexPage) {
       // Show a loading message while we wait for the API response
       if (codeContentEl) codeContentEl.textContent = "Loading starter code...";
 
-
-  // ----------------------------------------------------------
-  // Copy Code button
-  // ----------------------------------------------------------
-  var btnCopyCode  = document.getElementById("btn-copy-code");
+      fetch("/project/" + PROJECT_ID + "/code")
+        .then(function (res) { return res.json(); })
+        .then(function (data) {
+          if (data.error) {
+            if (codeContentEl) codeContentEl.textContent = "Error: " + data.error;
+            return;
+          }
+          if (codePanelFilename) codePanelFilename.textContent = data.filename;
+          if (codeContentEl) {
+            codeContentEl.textContent = "";
+            renderCodeWithLineNumbers(data.code).forEach(function (row) {
+              codeContentEl.appendChild(row);
+            });
+          }
+          // Mark as fetched so we don't hit the API again on the next open
+          codeFetched = true;
+        })
+        .catch(function () {
+          if (codeContentEl) {
+            codeContentEl.textContent = "Could not load starter code. Try downloading it instead.";
+          }
+        });
+    }
 
    // ============================================================
 // ROADMAP PROGRESS TRACKER
@@ -1163,85 +1180,6 @@ roadmapCheckboxes.forEach(function(cb){
 // ------------------------------------------------------------
 
 updateRoadmapProgress();
-  var copyToast    = document.getElementById("copy-toast");
-  var toastTimeout = null;
-
-  var copyToast    = document.getElementById("copy-toast"); //popup msg when copied 
-  var toastTimeout = null; 
-
-
-  //shows the "copied to clipboard" state on the button and the toast message, then resets after a short delay
-  function showCopySuccess() {
-    if (!btnCopyCode) return;
-
-    // Swap icons on the button(copy and checkmark icons)
-    var copyIcon  = btnCopyCode.querySelector(".copy-icon");
-    var checkIcon = btnCopyCode.querySelector(".check-icon");
-    var btnLabel = btnCopyCode.querySelector(".copy-btn-label");
-
-    if (copyIcon) copyIcon.style.display = "none";
-    if (checkIcon) checkIcon.style.display = "inline";
-    if (btnLabel) btnLabel.textContent = "Copied!";
-    btnCopyCode.classList.add("copied");
-    // Disable button so user can't spam click it while toast is showing
-    btnCopyCode.disabled = true;
-
-    // Show toast
-    if (copyToast) {
-      copyToast.classList.add("show");
-    }
-
-    // Auto-reset after 2.5 s
-    // Clear any previous timeout first so timers don't stack up
-    clearTimeout(toastTimeout);
-    toastTimeout = setTimeout(function () {
-      if (copyIcon) copyIcon.style.display = "inline";
-      if (checkIcon) checkIcon.style.display = "none";
-      if (btnLabel) btnLabel.textContent = "Copy Code";
-      btnCopyCode.classList.remove("copied");
-      btnCopyCode.disabled = false;
-      if (copyToast) copyToast.classList.remove("show");
-    }, 2500);
-  }
-
-  if (btnCopyCode) {
-    btnCopyCode.addEventListener("click", function () {
-      var code = codeContentEl
-        ? Array.from(codeContentEl.querySelectorAll(".line-content"))
-          .map(function (el) { return el.textContent; })
-          .join("\n")
-        : "";
-      // Don't copy if the code hasn't loaded yet — just ignore the click
-      if (!code || code === "Loading..." || code === "Loading starter code...") return;
-
-      // Use Clipboard API with textarea fallback
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        navigator.clipboard.writeText(code).then(showCopySuccess).catch(function () {
-          fallbackCopy(code); // clipboard api failed, try the old way
-
-      fetch("/project/" + PROJECT_ID + "/code")
-        .then(function (res) { return res.json(); })
-        .then(function (data) {
-          if (data.error) {
-            if (codeContentEl) codeContentEl.textContent = "Error: " + data.error;
-            return;
-          }
-          if (codePanelFilename) codePanelFilename.textContent = data.filename;
-          if (codeContentEl) {
-            codeContentEl.textContent = "";
-            renderCodeWithLineNumbers(data.code).forEach(function (row) {
-              codeContentEl.appendChild(row);
-            });
-          }
-          // Mark as fetched so we don't hit the API again on the next open
-          codeFetched = true;
-        })
-        .catch(function () {
-          if (codeContentEl) {
-            codeContentEl.textContent = "Could not load starter code. Try downloading it instead.";
-          }
-        });
-    }
 
     // Attach open/close handlers
     if (btnViewCode) btnViewCode.addEventListener("click", openCodePanel);
@@ -1367,14 +1305,31 @@ updateRoadmapProgress();
     // 3. Fetch Skills Logic
     fetchBtn.addEventListener('click', async () => {
       const username = githubInput.value.trim();
-      if (!username) return;
+
+      // Clear any previous error before validating / retrying
+      errorMsg.textContent = '';
+
+      if (!username) {
+        errorMsg.textContent = "Please enter a GitHub username";
+        githubInput.focus();
+        return;
+      }
 
       fetchBtn.disabled = true;
       fetchBtn.textContent = 'Syncing...';
 
       try {
         const response = await fetch(`https://api.github.com/users/${username}/repos`);
-        if (!response.ok) throw new Error();
+
+        if (!response.ok) {
+          if (response.status === 404) {
+            throw new Error("Username not found. Please check and try again.");
+          }
+          if (response.status === 403) {
+            throw new Error("GitHub rate limit reached. Please try again later.");
+          }
+          throw new Error("Failed to fetch skills. Please try again.");
+        }
 
         const repos = await response.json();
         const langs = [...new Set(repos.map(r => r.language).filter(Boolean))];
@@ -1388,7 +1343,7 @@ updateRoadmapProgress();
           errorMsg.textContent = "No public languages found.";
         }
       } catch (err) {
-        errorMsg.textContent = err.message ?? "Failed to fetch skills";
+        errorMsg.textContent = err.message || "Failed to fetch skills";
       } finally {
         fetchBtn.disabled = false;
         fetchBtn.textContent = 'Fetch Skills';
@@ -1433,7 +1388,6 @@ updateRoadmapProgress();
     }
   }
 
- main
   if (scrollTopBtn) {
     window.addEventListener('scroll', handleScroll, { passive: true });
     scrollTopBtn.addEventListener('click', function () {
@@ -1445,11 +1399,5 @@ updateRoadmapProgress();
     });
     handleScroll();
   }
-}());
 
-/* Only wire up listeners if the button exists on this page */
-if (scrollTopBtn) {
-    window.addEventListener('scroll', handleScroll);
-    scrollTopBtn.addEventListener('click', scrollToTop);
-}
- main
+})();


### PR DESCRIPTION
## Summary

This PR fixes the Sync with GitHub modal so users get clear feedback when they submit an empty or invalid GitHub username. Previously, clicking Fetch Skills with bad input failed silently and the modal stayed open with no message. The fix adds validation and user-facing error text in #github-modal-error. While working in static/script.js, several pre-existing merge-corruption issues were also repaired (broken fetchStarterCode(), missing createTag() closing brace, stray main markers, and duplicate/broken copy-code handlers) so the client script parses and runs correctly again.

## Changes Made

- static/script.js
  - Show "Please enter a GitHub username" when the input is blank
  - Map GitHub API 404 to "Username not found. Please check and try again."
  - Map 403 to a rate-limit message; other failures to a generic retry message
  - Use err.message || "Failed to fetch skills" instead of ?? so empty errors still display
  - Clear previous errors on each retry and refocus the username field on empty input
  - Restore fetchStarterCode() body and remove duplicate/broken copy-code handler
  - Fix missing } on createTag() and remove leftover merge-conflict main markers
  - Remove duplicate out-of-scope scroll-button wiring and fix scroll IIFE closing syntax

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Data addition (new projects)
- [x] Style / UI change

## Testing Done

Manual testing on local dev server (python app.py):

1. Open homepage, go to Skills section, click Import from GitHub
2. Click Fetch Skills with empty input - shows "Please enter a GitHub username"
3. Enter xyzinvaliduser12345 - shows "Username not found. Please check and try again."
4. Enter valid username (e.g. torvalds) - languages import as skill chips and modal closes
5. node --check static/script.js passes

## Screenshots
<img width="1918" height="887" alt="Screenshot 2026-06-05 165715" src="https://github.com/user-attachments/assets/0da82663-1f0b-4e77-b920-7445b22c77a2" />
<img width="1918" height="892" alt="Screenshot 2026-06-05 165732" src="https://github.com/user-attachments/assets/999bac11-43be-4dcb-b562-420014227ad6" />
<img width="1918" height="972" alt="Screenshot 2026-06-05 165747" src="https://github.com/user-attachments/assets/a823f9e8-63f1-455a-bdc4-4cb9db849105" />


Before: modal stays open with no error text after invalid username
After: red error message visible below username input

## Related Issue

Closes #757 