### PR TITLE
fix: resolve skills dropdown stacking issue

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1483,9 +1483,13 @@ html[data-theme="dark"] .theme-toggle-label::before {
   text-align: left;
 }
 
-/* Form groups */
 .form-group {
   margin-bottom: 24px;
+}
+
+.form-card form > .form-group:first-child {
+  position: relative;
+  z-index: 1;
 }
 
 .form-row {
@@ -1507,6 +1511,7 @@ label {
 /* Skill input container */
 .skill-input-wrap {
   position: relative;
+  z-index: 1100;
   border: 1.5px solid var(--border);
   border-radius: var(--r-sm);
   background: var(--gray-50);


### PR DESCRIPTION
## Description

This PR fixes the "Your Skills" autocomplete dropdown being rendered behind the predefined skill tags on the homepage form.

### Root Cause

The autocomplete suggestions dropdown and the skill tags were being rendered in different stacking contexts, causing the dropdown to appear underneath the skill tags despite having its own z-index styling.

### Changes Made

* Investigated the stacking-context hierarchy affecting the skills autocomplete component.
* Updated the relevant form container styling to ensure the dropdown renders above the skill tags.
* Preserved the existing layout, animations, and component behavior.
* Applied a minimal CSS-only fix without modifying application logic.

### Testing

#### Steps Performed

1. Opened the homepage and navigated to the **Your Skills** section.
2. Typed skill prefixes such as:

   * `Py`
   * `Ja`
   * `Re`
3. Verified that:

   * Autocomplete suggestions appear above the skill tags.
   * Suggestions remain fully visible.
   * Suggestions are clickable and selectable.
   * Existing skill chips continue to render correctly.
   * No visual regressions were introduced in the form layout.

### Before

The autocomplete dropdown was partially hidden behind the predefined skill tags, making suggestions difficult to read and interact with.

### After

The autocomplete dropdown now correctly appears above the skill tags and remains fully accessible to users.

### Screenshots

<img width="1056" height="604" alt="image" src="https://github.com/user-attachments/assets/d887e2db-1555-4281-a9c4-30ec23c5fcdc" />


### Issue

Closes #773
