### PR TITLE
fix: add theme support to 403 and 405 pages

### DIFF
--- a/templates/403.html
+++ b/templates/403.html
@@ -12,6 +12,7 @@
   <meta property="og:url" content="{{ config.get_base_url() }}/" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
+  {% include 'partials/theme_head.html' %}
   <link rel="stylesheet" href="/static/style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@400;500&display=swap" rel="stylesheet" />
 </head>
@@ -19,6 +20,7 @@
   <nav class="navbar">
     <div class="nav-inner">
       <a href="/" class="nav-logo">DevPath</a>
+      {% include 'partials/theme_toggle.html' %}
     </div>
   </nav>
   <div class="error-page">

--- a/templates/405.html
+++ b/templates/405.html
@@ -12,6 +12,7 @@
   <meta property="og:url" content="{{ config.get_base_url() }}/" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
+  {% include 'partials/theme_head.html' %}
   <link rel="stylesheet" href="/static/style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@400;500&display=swap" rel="stylesheet" />
 </head>
@@ -19,6 +20,7 @@
   <nav class="navbar">
     <div class="nav-inner">
       <a href="/" class="nav-logo">DevPath</a>
+      {% include 'partials/theme_toggle.html' %}
     </div>
   </nav>
   <div class="error-page">


### PR DESCRIPTION
## Summary [required]

This PR fixes theme support inconsistencies on the 403 (Forbidden) and 405 (Method Not Allowed) error pages. Both templates were missing the theme_head.html partial responsible for applying the saved theme before rendering, which could result in a Flash of Unstyled Content (FOUC) for users with dark mode enabled. They were also missing the theme toggle button available on other error pages, preventing users from switching themes from these pages.

## Related Issue [required]

Closes #756

## Type of Change [required]

- [x] Bug fix — resolves a broken behaviour
- [ ] Feature — adds new functionality
- [ ] Data — adds new projects to `data/projects.json`
- [ ] Documentation — updates docs, README, or code comments only
- [ ] Style — CSS or visual changes only, no logic change
- [ ] Refactor — restructures code without changing behaviour
- [ ] Test — adds or updates tests

## What Was Changed [required]

<!-- List every file you modified and briefly explain why. -->
<!-- Do not list files you only read. -->

| File | Change made |
|------|-------------|
| templates/403.html |Added partials/theme_head.html and partials/theme_toggle.html includes |
|templates/405.html |Added partials/theme_head.html and partials/theme_toggle.html includes |

## How to Test This PR [required]

1. Clone this branch:
2. git checkout fix-403-405-theme
3. Install dependencies:
- pip install -r requirements.txt
4. Run the application.
5. Navigate to the 403 error page.
6. Verify that:

- The page loads with the correct saved theme applied.
- No light-theme flash occurs for dark-mode users.
- The theme toggle button is visible and functional.

7. Navigate to the 405 error page.
8. Verify the same behavior as above.

Expected test output:
```
Not applicable - template-only change.
```

## Test Results [required]

<!-- Paste the full output of python tests/test_basic.py -->

```
paste output here
```

## Screenshots (if UI change)

<!-- Before and after screenshots for any visual change. -->
<!-- Remove this section if your PR has no visual change. -->

| Before | After |
|--------|-------|
| 
<img width="1917" height="966" alt="image" src="https://github.com/user-attachments/assets/34abdb7a-a118-4dd5-99f9-36319c81598a" />
 | 
<img width="1917" height="966" alt="image" src="https://github.com/user-attachments/assets/ae9f8fb8-c0e8-4bee-97d1-6cc36038a2c8" />
 |

## Self-Review Checklist [required]

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed all guidelines
- [x] My branch name follows the convention: `feat/`, `fix/`, `docs/`, `data/`, `style/`, `test/`
- [ ] I have run `python tests/test_basic.py` and all 27 tests pass
- [ ] I have run `flake8 .` locally and there are no errors
- [x] I have not introduced any `print()` or `console.log()` debug statements
- [x] Every new function I wrote has a docstring
- [x] I have not modified files outside the scope of the linked issue
- [x] If I changed the UI, I tested it at 375px (mobile) and 1280px (desktop)
- [ ] If I added a project to the dataset, it has all required JSON fields

## Notes for Reviewer

While working on this issue, I noticed that templates/500.html currently contains the theme toggle include but does not contain partials/theme_head.html. I left it unchanged to keep this PR strictly scoped to the reported issue affecting 403.html and 405.html.
also
This PR addresses the reported issue by adding the missing theme_head.html and theme_toggle.html includes to the 403 and 405 error pages so they match the other error templates.

During testing I also noticed that theme switching functionality is not active on these pages because script.js is not loaded in 403.html and 405.html. I did not modify that behavior because it was outside the scope of the issue, but I'm happy to add it if maintainers would like the toggle to be fully functional.