### PR TITLE
Comparision feature added - User can compare between 2 tech stack 

### DIFF
--- a/data/career_roadmaps.json
+++ b/data/career_roadmaps.json
@@ -1,0 +1,158 @@
+[
+  {
+    "id": "frontend",
+    "title": "Frontend Development",
+    "description": "Build modern user interfaces with HTML, CSS, JavaScript, and popular frontend frameworks.",
+    "topics": [
+      "HTML & Semantic Markup",
+      "CSS Layout & Responsive Design",
+      "JavaScript Fundamentals",
+      "DOM Manipulation",
+      "React Basics",
+      "State Management",
+      "Accessibility (a11y)",
+      "Browser DevTools"
+    ],
+    "skills": ["HTML", "CSS", "JavaScript", "React", "Git", "Responsive Design", "REST APIs"],
+    "duration": "3–6 months",
+    "duration_weeks": 20,
+    "difficulty": "Beginner",
+    "difficulty_score": 2,
+    "career_opportunities": [
+      "Frontend Developer",
+      "UI Developer",
+      "Web Designer",
+      "React Developer"
+    ]
+  },
+  {
+    "id": "fullstack",
+    "title": "Full Stack Development",
+    "description": "End-to-end web development covering both client-side UI and server-side APIs, databases, and deployment.",
+    "topics": [
+      "Frontend Fundamentals",
+      "Backend APIs (REST)",
+      "Database Design (SQL)",
+      "Authentication & Sessions",
+      "Server Deployment",
+      "Testing Full Applications",
+      "DevOps Basics",
+      "Project Architecture"
+    ],
+    "skills": ["HTML", "CSS", "JavaScript", "Python", "Flask", "SQL", "Git", "REST APIs", "Deployment"],
+    "duration": "6–12 months",
+    "duration_weeks": 36,
+    "difficulty": "Intermediate",
+    "difficulty_score": 4,
+    "career_opportunities": [
+      "Full Stack Developer",
+      "Software Engineer",
+      "Web Application Developer",
+      "Startup Engineer"
+    ]
+  },
+  {
+    "id": "react",
+    "title": "React Development",
+    "description": "Specialize in building component-based UIs with React, hooks, routing, and modern frontend tooling.",
+    "topics": [
+      "JSX & Components",
+      "Props & State",
+      "React Hooks (useState, useEffect)",
+      "React Router",
+      "Context API",
+      "API Integration with fetch",
+      "Component Testing",
+      "Build Tools (Vite/CRA)"
+    ],
+    "skills": ["JavaScript", "React", "HTML", "CSS", "Git", "REST APIs", "npm"],
+    "duration": "2–4 months",
+    "duration_weeks": 14,
+    "difficulty": "Beginner",
+    "difficulty_score": 2,
+    "career_opportunities": [
+      "React Developer",
+      "Frontend Engineer",
+      "UI Engineer",
+      "JavaScript Developer"
+    ]
+  },
+  {
+    "id": "angular",
+    "title": "Angular Development",
+    "description": "Build enterprise-grade single-page applications with Angular, TypeScript, and RxJS.",
+    "topics": [
+      "TypeScript Fundamentals",
+      "Angular Components & Modules",
+      "Services & Dependency Injection",
+      "RxJS & Observables",
+      "Angular Routing",
+      "Forms (Template & Reactive)",
+      "HTTP Client",
+      "Unit Testing with Jasmine"
+    ],
+    "skills": ["TypeScript", "Angular", "RxJS", "HTML", "CSS", "Git", "REST APIs"],
+    "duration": "3–5 months",
+    "duration_weeks": 18,
+    "difficulty": "Intermediate",
+    "difficulty_score": 3,
+    "career_opportunities": [
+      "Angular Developer",
+      "Frontend Engineer",
+      "Enterprise Web Developer",
+      "TypeScript Developer"
+    ]
+  },
+  {
+    "id": "devops",
+    "title": "DevOps Engineering",
+    "description": "Automate software delivery with CI/CD pipelines, containerization, infrastructure as code, and monitoring.",
+    "topics": [
+      "Linux & Shell Scripting",
+      "Git & Version Control Workflows",
+      "CI/CD Pipelines",
+      "Docker & Containers",
+      "Kubernetes Basics",
+      "Infrastructure as Code (Terraform)",
+      "Monitoring & Logging",
+      "Cloud Deployment"
+    ],
+    "skills": ["Linux", "Docker", "Kubernetes", "Git", "CI/CD", "Terraform", "AWS", "Python", "Bash"],
+    "duration": "4–8 months",
+    "duration_weeks": 28,
+    "difficulty": "Intermediate",
+    "difficulty_score": 4,
+    "career_opportunities": [
+      "DevOps Engineer",
+      "Site Reliability Engineer (SRE)",
+      "Platform Engineer",
+      "Release Engineer"
+    ]
+  },
+  {
+    "id": "cloud",
+    "title": "Cloud Engineering",
+    "description": "Design, deploy, and manage scalable cloud-native applications on AWS, Azure, or GCP.",
+    "topics": [
+      "Cloud Computing Fundamentals",
+      "Virtual Machines & Networking",
+      "Serverless Architecture",
+      "Cloud Storage & Databases",
+      "Identity & Access Management (IAM)",
+      "Auto-scaling & Load Balancing",
+      "Cloud Security Best Practices",
+      "Cost Optimization"
+    ],
+    "skills": ["AWS", "Azure", "Linux", "Docker", "Terraform", "Python", "Networking", "SQL"],
+    "duration": "4–8 months",
+    "duration_weeks": 28,
+    "difficulty": "Intermediate",
+    "difficulty_score": 4,
+    "career_opportunities": [
+      "Cloud Engineer",
+      "Cloud Architect",
+      "Solutions Architect",
+      "Cloud Security Engineer"
+    ]
+  }
+]

--- a/routes/main_routes.py
+++ b/routes/main_routes.py
@@ -7,6 +7,7 @@ from flask import Blueprint, render_template, request, jsonify, send_from_direct
 
 from utils.recommender import get_recommendations, validate_recommendation_inputs
 from utils.data_loader import find_project_by_id, load_all_projects, get_available_levels, get_project_stats
+from utils.roadmap_comparer import load_all_career_roadmaps, compare_roadmaps
 from utils.file_server import read_starter_code, resolve_starter_file, get_starter_code_dir
 from config import Config
 import os
@@ -37,6 +38,39 @@ def index():
 @main.route("/contact")
 def contact():
     return render_template("contact.html")
+
+
+@main.route("/compare")
+def compare_page():
+    """Render the career roadmap comparison page."""
+    roadmaps = load_all_career_roadmaps()
+    return render_template("compare.html", roadmaps=roadmaps, config=Config)
+
+
+@main.route("/api/roadmaps")
+def list_roadmaps():
+    """Return all career roadmaps as JSON."""
+    return jsonify(load_all_career_roadmaps()), 200
+
+
+@main.route("/api/compare")
+def compare_roadmaps_api():
+    """Return a side-by-side comparison of two career roadmaps."""
+    roadmap_a = (request.args.get("a") or "").strip()
+    roadmap_b = (request.args.get("b") or "").strip()
+
+    if not roadmap_a or not roadmap_b:
+        return jsonify({"error": "Both 'a' and 'b' query parameters are required."}), 400
+
+    result = compare_roadmaps(roadmap_a, roadmap_b)
+
+    if result is None:
+        return jsonify({"error": "One or both roadmap IDs were not found."}), 404
+
+    if result.get("error"):
+        return jsonify(result), 400
+
+    return jsonify(result), 200
 
 @main.route("/health")
 def health_check():
@@ -151,7 +185,7 @@ def sitemap():
     base = request.host_url.rstrip("/")
     projects = load_all_projects()
 
-    urls = [f"<url><loc>{base}/</loc></url>"]
+    urls = [f"<url><loc>{base}/</loc></url>", f"<url><loc>{base}/compare</loc></url>"]
     for p in projects:
         urls.append(f"<url><loc>{base}/project/{p['id']}</loc></url>")
 

--- a/static/compare.js
+++ b/static/compare.js
@@ -1,0 +1,223 @@
+// compare.js — Career roadmap comparison page logic
+
+(function () {
+  var selectA = document.getElementById("roadmap-select-a");
+  var selectB = document.getElementById("roadmap-select-b");
+  var compareBtn = document.getElementById("compare-btn");
+  var errorEl = document.getElementById("compare-error");
+  var emptyEl = document.getElementById("compare-empty");
+  var resultsEl = document.getElementById("compare-results");
+  var quickBtns = document.querySelectorAll(".compare-quick-btn");
+
+  if (!selectA || !selectB || !compareBtn) return;
+
+  function showError(message) {
+    if (!errorEl) return;
+    errorEl.textContent = message;
+    errorEl.hidden = !message;
+  }
+
+  function setLoading(isLoading) {
+    compareBtn.disabled = isLoading;
+    compareBtn.textContent = isLoading ? "Comparing…" : "Compare Roadmaps";
+  }
+
+  function renderBarChart(container, labelA, labelB, valueA, valueB, maxValue, unit) {
+    if (!container) return;
+    container.innerHTML = "";
+
+    var rows = [
+      { label: labelA, value: valueA, cls: "compare-bar--a" },
+      { label: labelB, value: valueB, cls: "compare-bar--b" },
+    ];
+
+    rows.forEach(function (row) {
+      var pct = maxValue > 0 ? Math.round((row.value / maxValue) * 100) : 0;
+      var wrap = document.createElement("div");
+      wrap.className = "compare-bar-row";
+
+      var name = document.createElement("span");
+      name.className = "compare-bar-label";
+      name.textContent = row.label;
+
+      var track = document.createElement("div");
+      track.className = "compare-bar-track";
+      track.setAttribute("role", "meter");
+      track.setAttribute("aria-valuemin", "0");
+      track.setAttribute("aria-valuemax", String(maxValue));
+      track.setAttribute("aria-valuenow", String(row.value));
+
+      var fill = document.createElement("div");
+      fill.className = "compare-bar-fill " + row.cls;
+      fill.style.width = pct + "%";
+
+      var val = document.createElement("span");
+      val.className = "compare-bar-value";
+      val.textContent = row.value + (unit || "");
+
+      track.appendChild(fill);
+      wrap.appendChild(name);
+      wrap.appendChild(track);
+      wrap.appendChild(val);
+      container.appendChild(wrap);
+    });
+  }
+
+  function renderTagList(el, items, sharedSet, side) {
+    if (!el) return;
+    el.innerHTML = "";
+    items.forEach(function (item) {
+      var li = document.createElement("li");
+      li.textContent = item;
+      var norm = item.toLowerCase();
+      if (sharedSet && sharedSet.has(norm)) {
+        li.className = "compare-tag compare-tag--shared";
+      } else {
+        li.className = "compare-tag compare-tag--" + side;
+      }
+      el.appendChild(li);
+    });
+  }
+
+  function renderSkillChips(el, items, chipClass) {
+    if (!el) return;
+    el.innerHTML = "";
+    if (!items.length) {
+      var empty = document.createElement("li");
+      empty.className = "compare-skill-empty";
+      empty.textContent = "None";
+      el.appendChild(empty);
+      return;
+    }
+    items.forEach(function (skill) {
+      var li = document.createElement("li");
+      li.className = "compare-skill-chip " + (chipClass || "");
+      li.textContent = skill;
+      el.appendChild(li);
+    });
+  }
+
+  function renderComparison(data) {
+    var a = data.roadmap_a;
+    var b = data.roadmap_b;
+    var metrics = data.metrics;
+
+    document.getElementById("summary-title-a").textContent = a.title;
+    document.getElementById("summary-desc-a").textContent = a.description;
+    document.getElementById("summary-title-b").textContent = b.title;
+    document.getElementById("summary-desc-b").textContent = b.description;
+
+    document.getElementById("shared-skills-count").textContent = data.summary.shared_skills_count;
+    document.getElementById("shared-topics-count").textContent = data.summary.shared_topics_count;
+
+    document.getElementById("detail-title-a").textContent = a.title;
+    document.getElementById("detail-title-b").textContent = b.title;
+    document.getElementById("meta-duration-a").textContent = a.duration;
+    document.getElementById("meta-duration-b").textContent = b.duration;
+    document.getElementById("meta-difficulty-a").textContent = a.difficulty;
+    document.getElementById("meta-difficulty-b").textContent = b.difficulty;
+
+    var sharedTopicSet = new Set(
+      data.overlapping_topics.map(function (t) { return t.toLowerCase(); })
+    );
+
+    renderTagList(document.getElementById("topics-list-a"), a.topics, sharedTopicSet, "a");
+    renderTagList(document.getElementById("topics-list-b"), b.topics, sharedTopicSet, "b");
+
+    renderTagList(document.getElementById("careers-list-a"), a.career_opportunities, null, "a");
+    renderTagList(document.getElementById("careers-list-b"), b.career_opportunities, null, "b");
+
+    renderSkillChips(document.getElementById("unique-skills-a"), data.unique_skills_a, "compare-skill-chip--a");
+    renderSkillChips(document.getElementById("shared-skills"), data.overlapping_skills, "compare-skill-chip--shared");
+    renderSkillChips(document.getElementById("unique-skills-b"), data.unique_skills_b, "compare-skill-chip--b");
+
+    var maxTopics = Math.max(metrics.topics_count.a, metrics.topics_count.b, 1);
+    var maxSkills = Math.max(metrics.skills_count.a, metrics.skills_count.b, 1);
+
+    renderBarChart(
+      document.getElementById("chart-duration"),
+      a.title, b.title,
+      metrics.duration_weeks.a, metrics.duration_weeks.b,
+      metrics.duration_weeks.max, " wks"
+    );
+    renderBarChart(
+      document.getElementById("chart-difficulty"),
+      a.title, b.title,
+      metrics.difficulty_score.a, metrics.difficulty_score.b,
+      metrics.difficulty_score.max, "/5"
+    );
+    renderBarChart(
+      document.getElementById("chart-topics"),
+      a.title, b.title,
+      metrics.topics_count.a, metrics.topics_count.b,
+      maxTopics, ""
+    );
+    renderBarChart(
+      document.getElementById("chart-skills"),
+      a.title, b.title,
+      metrics.skills_count.a, metrics.skills_count.b,
+      maxSkills, ""
+    );
+
+    emptyEl.hidden = true;
+    resultsEl.hidden = false;
+    resultsEl.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
+  function runComparison() {
+    var idA = selectA.value;
+    var idB = selectB.value;
+
+    showError("");
+
+    if (!idA || !idB) {
+      showError("Please select both roadmaps before comparing.");
+      return;
+    }
+
+    if (idA === idB) {
+      showError("Please select two different roadmaps to compare.");
+      return;
+    }
+
+    setLoading(true);
+
+    fetch("/api/compare?a=" + encodeURIComponent(idA) + "&b=" + encodeURIComponent(idB))
+      .then(function (res) {
+        return res.json().then(function (body) {
+          return { ok: res.ok, status: res.status, body: body };
+        });
+      })
+      .then(function (result) {
+        if (!result.ok) {
+          showError(result.body.error || "Comparison failed. Please try again.");
+          return;
+        }
+        renderComparison(result.body);
+      })
+      .catch(function () {
+        showError("Network error. Please check your connection and try again.");
+      })
+      .finally(function () {
+        setLoading(false);
+      });
+  }
+
+  compareBtn.addEventListener("click", runComparison);
+
+  quickBtns.forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      selectA.value = btn.getAttribute("data-a") || "";
+      selectB.value = btn.getAttribute("data-b") || "";
+      runComparison();
+    });
+  });
+
+  // Pre-select from URL query params: /compare?a=frontend&b=fullstack
+  var params = new URLSearchParams(window.location.search);
+  var paramA = params.get("a");
+  var paramB = params.get("b");
+  if (paramA) selectA.value = paramA;
+  if (paramB) selectB.value = paramB;
+  if (paramA && paramB) runComparison();
+})();

--- a/static/script.js
+++ b/static/script.js
@@ -550,6 +550,51 @@ updateProfileWidgets();
     resultsSection.scrollIntoView({ behavior: "smooth" });
   }
 
+  function runProjectSearch(query) {
+    if (!query) return;
+    setLoadingState(true);
+    fetch("/api/search?q=" + encodeURIComponent(query))
+      .then(function (response) {
+        return response.json().then(function (data) {
+          if (!response.ok) throw new Error("Search failed. Please try again.");
+          return data;
+        });
+      })
+      .then(function (projects) {
+        setLoadingState(false);
+        recordSearch();
+        var message = projects.length
+          ? null
+          : "No projects matched \"" + query + "\". Try a different keyword.";
+        renderResults(projects, message);
+        var mobileMenu = document.getElementById("nav-mobile-menu");
+        var mobileToggle = document.getElementById("nav-mobile-toggle");
+        if (mobileMenu && mobileMenu.classList.contains("open")) {
+          mobileMenu.classList.remove("open");
+          if (mobileToggle) {
+            mobileToggle.classList.remove("open");
+            mobileToggle.setAttribute("aria-expanded", "false");
+          }
+        }
+      })
+      .catch(function (err) {
+        setLoadingState(false);
+        var general = document.getElementById("form-error-general");
+        if (general) general.textContent = err.message || "Search failed. Please try again.";
+      });
+  }
+
+  function bindSearchForm(form, input) {
+    if (!form || !input) return;
+    form.addEventListener("submit", function (event) {
+      event.preventDefault();
+      runProjectSearch(input.value.trim());
+    });
+  }
+
+  bindSearchForm(document.getElementById("topic-search-form"), document.getElementById("topic-search"));
+  bindSearchForm(document.getElementById("topic-search-form-mobile"), document.getElementById("topic-search-mobile"));
+
   skillsInput.setAttribute("role", "combobox");
   skillsInput.setAttribute("aria-expanded", "false");
   suggestions.setAttribute("role", "listbox");

--- a/static/style.css
+++ b/static/style.css
@@ -502,21 +502,22 @@ html[data-entry-anim="true"] .form-card form > .btn-submit              { animat
 }
 
 .nav-inner {
-  max-width: 1140px;
+  max-width: 1200px;
   margin: 0 auto;
-  padding: 0 32px;
+  padding: 0 24px;
   height: 64px;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 16px;
 }
 
 .nav-logo {
   font-family: var(--font-display);
-  font-size: 1.3rem;
+  font-size: 1.25rem;
   font-weight: 800;
-  color: #ffffff; /* always white; navbar bg is always dark */
+  color: #ffffff;
   letter-spacing: -0.04em;
+  flex-shrink: 0;
 }
 
 .nav-logo:hover {
@@ -527,21 +528,118 @@ html[data-entry-anim="true"] .form-card form > .btn-submit              { animat
   color: var(--yellow-400);
 }
 
+/* Navbar search — matches dark glass navbar theme */
+.navbar-search {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  max-width: 240px;
+  margin-left: 8px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1.5px solid rgba(255, 255, 255, 0.16);
+  border-radius: var(--r-full);
+  overflow: hidden;
+  transition: border-color var(--t), background var(--t), box-shadow var(--t);
+}
+
+.navbar-search:focus-within {
+  border-color: rgba(255, 255, 255, 0.32);
+  background: rgba(255, 255, 255, 0.11);
+  box-shadow: 0 0 0 3px rgba(79, 110, 247, 0.25);
+}
+
+#topic-search,
+#topic-search-mobile {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  padding: 8px 14px;
+  font-size: 0.84rem;
+  font-family: var(--font-body);
+  color: #ffffff;
+}
+
+#topic-search::placeholder,
+#topic-search-mobile::placeholder {
+  color: rgba(255, 255, 255, 0.42);
+}
+
+#topic-search:focus,
+#topic-search-mobile:focus {
+  outline: none;
+}
+
+.navbar-search-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  margin: 3px;
+  border: none;
+  border-radius: var(--r-full);
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.85);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background var(--t), color var(--t), transform var(--t);
+}
+
+.navbar-search-btn:hover {
+  background: var(--indigo-500);
+  color: #ffffff;
+}
+
+.navbar-search-btn:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 1px;
+}
+
+.navbar-search-btn svg {
+  width: 16px;
+  height: 16px;
+}
+
+.navbar-search--mobile {
+  max-width: none;
+  margin: 0 0 20px;
+  width: 100%;
+}
+
+.nav-right {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
 .nav-links {
   display: flex;
   align-items: center;
-  gap: 32px;
+  gap: 20px;
 }
 
 .nav-link {
   position: relative;
-  font-size: 0.88rem;
+  font-size: 0.84rem;
   font-weight: 500;
-  color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.72);
   transition: color var(--t);
-
   text-decoration: none;
   display: inline-block;
+  white-space: nowrap;
+}
+
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+  padding-left: 4px;
+  border-left: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 /* Animated underline on nav links */
@@ -581,12 +679,13 @@ html[data-entry-anim="true"] .form-card form > .btn-submit              { animat
 }
 
 .nav-btn-outline {
-  font-size: 0.86rem;
+  font-size: 0.82rem;
   font-weight: 600;
   color: rgba(255, 255, 255, 0.85);
   border: 1.5px solid rgba(255, 255, 255, 0.28);
   border-radius: var(--r-full);
-  padding: 7px 18px;
+  padding: 6px 14px;
+  white-space: nowrap;
   transition: background var(--t), border-color var(--t);
 }
 
@@ -709,14 +808,60 @@ html[data-entry-anim="true"] .form-card form > .btn-submit              { animat
   border-bottom: none;
 }
 
-/* Mobile nav breakpoint (upstream) */
-@media (max-width: 768px) {
+/* Responsive navbar — tighten before switching to mobile menu */
+@media (max-width: 1100px) {
   .nav-links {
+    gap: 14px;
+  }
+
+  .nav-link {
+    font-size: 0.8rem;
+  }
+
+  .navbar-search:not(.navbar-search--mobile) {
+    max-width: 200px;
+  }
+
+  .nav-right {
+    gap: 14px;
+  }
+}
+
+@media (max-width: 992px) {
+  .navbar-search:not(.navbar-search--mobile) {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .nav-right {
     display: none;
   }
 
   .nav-mobile-toggle {
     display: flex;
+    margin-left: auto;
+  }
+
+  .nav-mobile-menu .theme-toggle {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: none;
+    border: none;
+    text-align: left;
+    cursor: pointer;
+    width: 100%;
+    padding: 10px 0;
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.8);
+  }
+}
+
+@media (min-width: 769px) {
+  .nav-mobile-toggle {
+    display: none;
   }
 }
 
@@ -3458,16 +3603,13 @@ input[type="text"]:not(.skill-input-wrap input):focus {
 }
 
 @media (max-width: 640px) {
-  .nav-links {
-    display: none;
-  }
-
   .nav-mobile-toggle {
     display: flex;
   }
 
   .nav-inner {
-    padding: 0 20px;
+    padding: 0 16px;
+    gap: 12px;
   }
 
   .hero {
@@ -3767,22 +3909,517 @@ html[data-theme="dark"] .btn-view-code-sm {
   }
 }
 
-.theme-toggle {
-  width: 42px;
-  height: 42px;
-  border-radius: 12px;
-  border: 1px solid rgba(255,255,255,0.15);
-  background: rgba(255,255,255,0.08);
-  color: white;
-  cursor: pointer;
-  font-size: 1rem;
-  transition: all 0.25s ease;
-}
-
-.theme-toggle:hover {
-  background: rgba(255,255,255,0.18);
-  transform: translateY(-2px);
-}
-
 /* ============================================================
    WORKING DARK MODE
+   ============================================================ */
+
+/* =============================================================
+   CAREER ROADMAP COMPARISON PAGE
+   ============================================================= */
+
+.compare-page-body {
+  background: var(--bg-secondary);
+  min-height: 100vh;
+}
+
+.nav-link--active {
+  color: var(--indigo-600);
+  font-weight: 600;
+}
+
+.compare-hero {
+  background: linear-gradient(135deg, var(--indigo-900) 0%, var(--indigo-700) 60%, var(--purple-700) 100%);
+  padding: 120px 24px 64px;
+  text-align: center;
+}
+
+.compare-hero-inner {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.compare-badge {
+  display: inline-block;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--yellow-300);
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  padding: 6px 14px;
+  border-radius: var(--r-full);
+  margin-bottom: 16px;
+}
+
+.compare-title {
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  font-weight: 800;
+  color: var(--white);
+  margin-bottom: 12px;
+}
+
+.compare-subtitle {
+  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.82);
+  line-height: 1.6;
+  max-width: 580px;
+  margin: 0 auto;
+}
+
+.compare-main {
+  max-width: 1100px;
+  margin: -32px auto 64px;
+  padding: 0 20px;
+}
+
+.compare-selectors {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: 24px;
+  box-shadow: var(--shadow-md);
+  margin-bottom: 24px;
+}
+
+.compare-select-card {
+  flex: 1;
+  min-width: 200px;
+}
+
+.compare-select-label {
+  display: block;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-body);
+  margin-bottom: 8px;
+}
+
+.compare-select {
+  width: 100%;
+  padding: 12px 14px;
+  font-size: 0.92rem;
+  font-family: var(--font-body);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+  color: var(--text-heading);
+  cursor: pointer;
+}
+
+.compare-select:focus {
+  outline: 2px solid var(--indigo-500);
+  outline-offset: 2px;
+}
+
+.compare-vs-badge {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 0.9rem;
+  color: var(--indigo-600);
+  background: var(--indigo-100);
+  padding: 10px 14px;
+  border-radius: var(--r-full);
+  align-self: center;
+  margin-bottom: 4px;
+}
+
+.compare-btn {
+  white-space: nowrap;
+  padding: 12px 24px;
+}
+
+.compare-error {
+  background: #fef2f2;
+  color: var(--red-500);
+  border: 1px solid #fecaca;
+  border-radius: var(--r-md);
+  padding: 12px 16px;
+  font-size: 0.88rem;
+  font-weight: 500;
+  margin-bottom: 20px;
+}
+
+.compare-empty {
+  text-align: center;
+  padding: 64px 24px;
+  background: var(--surface);
+  border: 1px dashed var(--border);
+  border-radius: var(--r-lg);
+}
+
+.compare-empty-icon {
+  color: var(--gray-400);
+  margin-bottom: 16px;
+}
+
+.compare-empty h2 {
+  font-size: 1.2rem;
+  color: var(--text-heading);
+  margin-bottom: 8px;
+}
+
+.compare-empty p {
+  color: var(--text-body);
+  font-size: 0.92rem;
+  margin-bottom: 24px;
+}
+
+.compare-quick-picks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}
+
+.compare-quick-btn {
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 8px 16px;
+  border-radius: var(--r-full);
+  border: 1px solid var(--indigo-100);
+  background: var(--indigo-50);
+  color: var(--indigo-600);
+  cursor: pointer;
+  transition: background 0.2s, transform 0.15s;
+}
+
+.compare-quick-btn:hover {
+  background: var(--indigo-100);
+  transform: translateY(-1px);
+}
+
+.compare-results {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.compare-summary-grid {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 16px;
+  align-items: stretch;
+}
+
+.compare-summary-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: 24px;
+  box-shadow: var(--shadow-sm);
+}
+
+.compare-summary-card--a {
+  border-top: 3px solid var(--indigo-600);
+}
+
+.compare-summary-card--b {
+  border-top: 3px solid var(--purple-600);
+}
+
+.compare-summary-card--shared {
+  border-top: 3px solid var(--green-500);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 160px;
+}
+
+.compare-summary-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-light);
+}
+
+.compare-summary-card h2 {
+  font-size: 1.1rem;
+  color: var(--text-heading);
+  margin: 8px 0;
+}
+
+.compare-summary-card p {
+  font-size: 0.85rem;
+  color: var(--text-body);
+  line-height: 1.5;
+}
+
+.compare-shared-stat {
+  margin-top: 12px;
+}
+
+.compare-stat-num {
+  display: block;
+  font-family: var(--font-display);
+  font-size: 1.8rem;
+  font-weight: 800;
+  color: var(--green-500);
+}
+
+.compare-stat-text {
+  font-size: 0.78rem;
+  color: var(--text-body);
+}
+
+.compare-section-title {
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--text-heading);
+  margin-bottom: 16px;
+}
+
+.compare-charts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.compare-chart-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: 20px;
+}
+
+.compare-chart-card h3 {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--text-body);
+  margin-bottom: 16px;
+}
+
+.compare-bar-row {
+  display: grid;
+  grid-template-columns: 1fr 2fr auto;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.compare-bar-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-heading);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compare-bar-track {
+  height: 10px;
+  background: var(--gray-100);
+  border-radius: var(--r-full);
+  overflow: hidden;
+}
+
+.compare-bar-fill {
+  height: 100%;
+  border-radius: var(--r-full);
+  transition: width 0.6s ease;
+}
+
+.compare-bar-fill.compare-bar--a {
+  background: var(--indigo-600);
+}
+
+.compare-bar-fill.compare-bar--b {
+  background: var(--purple-600);
+}
+
+.compare-bar-value {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-body);
+  min-width: 48px;
+  text-align: right;
+}
+
+.compare-details-grid {
+  display: grid;
+  grid-template-columns: 1fr 1.2fr 1fr;
+  gap: 20px;
+}
+
+.compare-detail-col {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: 24px;
+}
+
+.compare-detail-col--a {
+  border-top: 3px solid var(--indigo-600);
+}
+
+.compare-detail-col--b {
+  border-top: 3px solid var(--purple-600);
+}
+
+.compare-detail-col--center {
+  border-top: 3px solid var(--green-500);
+}
+
+.compare-detail-col h3 {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-heading);
+  margin-bottom: 12px;
+}
+
+.compare-detail-col h4 {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-body);
+  margin: 16px 0 8px;
+}
+
+.compare-meta-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 8px;
+}
+
+.compare-meta-list li {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.compare-meta-list span {
+  color: var(--text-light);
+}
+
+.compare-tag-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.compare-tag {
+  font-size: 0.78rem;
+  font-weight: 500;
+  padding: 4px 10px;
+  border-radius: var(--r-full);
+  background: var(--gray-100);
+  color: var(--text-body);
+}
+
+.compare-tag--a {
+  background: var(--indigo-100);
+  color: var(--indigo-700);
+}
+
+.compare-tag--b {
+  background: var(--purple-100);
+  color: var(--purple-700);
+}
+
+.compare-tag--shared {
+  background: var(--green-100);
+  color: #047857;
+  font-weight: 600;
+}
+
+.compare-skills-venn {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.compare-skills-block h4 {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-light);
+  margin-bottom: 8px;
+}
+
+.compare-skill-chips {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.compare-skill-chip {
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 5px 12px;
+  border-radius: var(--r-full);
+}
+
+.compare-skill-chip--a {
+  background: var(--indigo-100);
+  color: var(--indigo-700);
+}
+
+.compare-skill-chip--b {
+  background: var(--purple-100);
+  color: var(--purple-700);
+}
+
+.compare-skill-chip--shared {
+  background: var(--green-100);
+  color: #047857;
+}
+
+.compare-skill-empty {
+  font-size: 0.82rem;
+  color: var(--text-light);
+  font-style: italic;
+}
+
+@media (max-width: 900px) {
+  .compare-summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .compare-summary-card--shared {
+    order: -1;
+  }
+
+  .compare-details-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .compare-selectors {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .compare-vs-badge {
+    align-self: center;
+  }
+
+  .compare-btn {
+    width: 100%;
+  }
+}
+
+[data-theme="dark"] .compare-error {
+  background: rgba(239, 68, 68, 0.1);
+  border-color: rgba(239, 68, 68, 0.3);
+}
+
+[data-theme="dark"] .compare-tag--shared,
+[data-theme="dark"] .compare-skill-chip--shared {
+  background: rgba(16, 185, 129, 0.15);
+  color: #6ee7b7;
+}

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description"
+    content="Compare career roadmaps side by side — topics, duration, difficulty, skills overlap, and career opportunities on DevPath." />
+  <title>Compare Roadmaps — DevPath</title>
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml" />
+  {% include 'partials/theme_head.html' %}
+  <link rel="stylesheet" href="/static/style.css" />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@400;500;600&display=swap"
+    rel="stylesheet" />
+</head>
+
+<body class="compare-page-body">
+
+  <nav class="navbar" id="navbar" aria-label="Main navigation">
+    <div class="nav-inner">
+      <a href="/" class="nav-logo">Dev<span class="nav-logo-accent">Path</span></a>
+      <div class="nav-links">
+        <a href="/" class="nav-link">Home</a>
+        <a href="/compare" class="nav-link nav-link--active">Compare</a>
+        <a href="/#find-project" class="nav-link">Find Project</a>
+        <a href="/contact" class="nav-link">Contact</a>
+        <a href="https://github.com/komalharshita/DevPath" target="_blank" rel="noopener noreferrer"
+          class="nav-btn-outline">GitHub</a>
+        <button class="theme-toggle" id="theme-toggle-desktop" aria-pressed="false" aria-label="Switch to dark mode">
+          <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+            stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+          </svg>
+          <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+            stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="5" />
+            <line x1="12" y1="1" x2="12" y2="3" />
+            <line x1="12" y1="21" x2="12" y2="23" />
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+            <line x1="1" y1="12" x2="3" y2="12" />
+            <line x1="21" y1="12" x2="23" y2="12" />
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+          </svg>
+        </button>
+      </div>
+      <button class="nav-mobile-toggle" id="nav-mobile-toggle" aria-label="Toggle navigation" aria-expanded="false"
+        aria-controls="nav-mobile-menu">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+    <div class="nav-mobile-menu" id="nav-mobile-menu" role="menu">
+      <a href="/" class="nav-mobile-link" role="menuitem">Home</a>
+      <a href="/compare" class="nav-mobile-link" role="menuitem">Compare</a>
+      <a href="/#find-project" class="nav-mobile-link" role="menuitem">Find Project</a>
+      <a href="/contact" class="nav-mobile-link" role="menuitem">Contact</a>
+    </div>
+  </nav>
+
+  <header class="compare-hero">
+    <div class="compare-hero-inner">
+      <span class="compare-badge">Career Decision Tool</span>
+      <h1 class="compare-title">Compare Learning Roadmaps</h1>
+      <p class="compare-subtitle">
+        Select two career paths to compare topics, duration, difficulty, overlapping skills, and job opportunities —
+        side by side.
+      </p>
+    </div>
+  </header>
+
+  <main class="compare-main">
+    <!-- Roadmap selectors -->
+    <section class="compare-selectors" aria-label="Select roadmaps to compare">
+      <div class="compare-select-card">
+        <label for="roadmap-select-a" class="compare-select-label">Roadmap A</label>
+        <select id="roadmap-select-a" class="compare-select">
+          <option value="">Choose a roadmap…</option>
+          {% for roadmap in roadmaps %}
+          <option value="{{ roadmap.id }}">{{ roadmap.title }}</option>
+          {% endfor %}
+        </select>
+      </div>
+
+      <div class="compare-vs-badge" aria-hidden="true">VS</div>
+
+      <div class="compare-select-card">
+        <label for="roadmap-select-b" class="compare-select-label">Roadmap B</label>
+        <select id="roadmap-select-b" class="compare-select">
+          <option value="">Choose a roadmap…</option>
+          {% for roadmap in roadmaps %}
+          <option value="{{ roadmap.id }}">{{ roadmap.title }}</option>
+          {% endfor %}
+        </select>
+      </div>
+
+      <button type="button" id="compare-btn" class="btn-primary compare-btn">Compare Roadmaps</button>
+    </section>
+
+    <div id="compare-error" class="compare-error" role="alert" hidden></div>
+
+    <!-- Empty state -->
+    <section id="compare-empty" class="compare-empty">
+      <div class="compare-empty-icon" aria-hidden="true">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <path d="M16 3h5v5M4 20L21 3M21 16v5h-5M15 15l6 6M4 4l5 5" />
+        </svg>
+      </div>
+      <h2>Pick two roadmaps to get started</h2>
+      <p>Try comparing <strong>Frontend vs Full Stack</strong>, <strong>React vs Angular</strong>, or
+        <strong>DevOps vs Cloud Engineering</strong>.
+      </p>
+      <div class="compare-quick-picks">
+        <button type="button" class="compare-quick-btn" data-a="frontend" data-b="fullstack">Frontend vs Full Stack</button>
+        <button type="button" class="compare-quick-btn" data-a="react" data-b="angular">React vs Angular</button>
+        <button type="button" class="compare-quick-btn" data-a="devops" data-b="cloud">DevOps vs Cloud</button>
+      </div>
+    </section>
+
+    <!-- Results -->
+    <section id="compare-results" class="compare-results" hidden>
+
+      <!-- Summary cards -->
+      <div class="compare-summary-grid">
+        <div class="compare-summary-card compare-summary-card--a">
+          <span class="compare-summary-label">Roadmap A</span>
+          <h2 id="summary-title-a"></h2>
+          <p id="summary-desc-a"></p>
+        </div>
+        <div class="compare-summary-card compare-summary-card--shared">
+          <span class="compare-summary-label">Overlap</span>
+          <div class="compare-shared-stat">
+            <span id="shared-skills-count" class="compare-stat-num">0</span>
+            <span class="compare-stat-text">shared skills</span>
+          </div>
+          <div class="compare-shared-stat">
+            <span id="shared-topics-count" class="compare-stat-num">0</span>
+            <span class="compare-stat-text">shared topics</span>
+          </div>
+        </div>
+        <div class="compare-summary-card compare-summary-card--b">
+          <span class="compare-summary-label">Roadmap B</span>
+          <h2 id="summary-title-b"></h2>
+          <p id="summary-desc-b"></p>
+        </div>
+      </div>
+
+      <!-- Visual charts -->
+      <section class="compare-charts" aria-label="Comparison charts">
+        <h2 class="compare-section-title">Visual Comparison</h2>
+        <div class="compare-charts-grid">
+          <div class="compare-chart-card">
+            <h3>Estimated Duration (weeks)</h3>
+            <div class="compare-bar-chart" id="chart-duration"></div>
+          </div>
+          <div class="compare-chart-card">
+            <h3>Difficulty Level</h3>
+            <div class="compare-bar-chart" id="chart-difficulty"></div>
+          </div>
+          <div class="compare-chart-card">
+            <h3>Topics Covered</h3>
+            <div class="compare-bar-chart" id="chart-topics"></div>
+          </div>
+          <div class="compare-chart-card">
+            <h3>Skills Required</h3>
+            <div class="compare-bar-chart" id="chart-skills"></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Side-by-side details -->
+      <section class="compare-details" aria-label="Detailed comparison">
+        <h2 class="compare-section-title">Side-by-Side Details</h2>
+        <div class="compare-details-grid">
+          <div class="compare-detail-col compare-detail-col--a">
+            <h3 id="detail-title-a"></h3>
+            <ul class="compare-meta-list">
+              <li><span>Duration</span><strong id="meta-duration-a"></strong></li>
+              <li><span>Difficulty</span><strong id="meta-difficulty-a"></strong></li>
+            </ul>
+            <h4>Topics Covered</h4>
+            <ul id="topics-list-a" class="compare-tag-list"></ul>
+            <h4>Career Opportunities</h4>
+            <ul id="careers-list-a" class="compare-tag-list compare-tag-list--career"></ul>
+          </div>
+
+          <div class="compare-detail-col compare-detail-col--center">
+            <h3>Skills Breakdown</h3>
+            <div class="compare-skills-venn">
+              <div class="compare-skills-block compare-skills-block--unique-a">
+                <h4>Unique to A</h4>
+                <ul id="unique-skills-a" class="compare-skill-chips"></ul>
+              </div>
+              <div class="compare-skills-block compare-skills-block--shared">
+                <h4>Shared Skills</h4>
+                <ul id="shared-skills" class="compare-skill-chips compare-skill-chips--shared"></ul>
+              </div>
+              <div class="compare-skills-block compare-skills-block--unique-b">
+                <h4>Unique to B</h4>
+                <ul id="unique-skills-b" class="compare-skill-chips"></ul>
+              </div>
+            </div>
+          </div>
+
+          <div class="compare-detail-col compare-detail-col--b">
+            <h3 id="detail-title-b"></h3>
+            <ul class="compare-meta-list">
+              <li><span>Duration</span><strong id="meta-duration-b"></strong></li>
+              <li><span>Difficulty</span><strong id="meta-difficulty-b"></strong></li>
+            </ul>
+            <h4>Topics Covered</h4>
+            <ul id="topics-list-b" class="compare-tag-list"></ul>
+            <h4>Career Opportunities</h4>
+            <ul id="careers-list-b" class="compare-tag-list compare-tag-list--career"></ul>
+          </div>
+        </div>
+      </section>
+
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <p class="footer-copy">&copy; 2025 DevPath. Built for learners.</p>
+      <ul class="footer-links">
+        <li><a href="/">Home</a></li>
+        <li><a href="/compare">Compare Roadmaps</a></li>
+        <li><a href="/contact">Contact</a></li>
+      </ul>
+    </div>
+  </footer>
+
+  <script src="/static/script.js"></script>
+  <script src="/static/compare.js"></script>
+</body>
+
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,94 +41,85 @@
     <div class="nav-inner">
       <a href="/" class="nav-logo">Dev<span class="nav-logo-accent">Path</span></a>
 
-      <form id="topic-search-form" class="navbar-search">
-          <input
-            type="text"
-            id="topic-search"
-            autocomplete="on"
-            aria-label="Search projects"
-            placeholder="Search Projects"
-          />
-
-          <button class="glass-search-btn" type="submit" aria-label="Search">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              stroke-width="2"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M21 21l-4.35-4.35m1.85-5.15a7 7 0 11-14 0 7 7 0 0114 0z"
-              />
-            </svg>
-          </button>
-        </form>
-      
-      <div class="nav-links">
-        <a href="#home" class="nav-link">Home</a>
-        <a href="#how-it-works" class="nav-link">How It Works</a>
-        <a href="#features" class="nav-link">Features</a>
-        <a href="#find-project" class="nav-link">Find Project</a>
-        <a href="/contact" class="nav-link">Contact Us</a>
-        <a href="https://github.com/komalharshita/DevPath" target="_blank" rel="noopener noreferrer" class="nav-btn-outline">GitHub</a>
-       
-        <button class="theme-toggle" id="theme-toggle-desktop"
-                aria-pressed="false"
-                aria-label="Switch to dark mode">
-          <!-- Moon icon: shown in light mode (clicking switches to dark) -->
-          <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24"
-               fill="none" stroke="currentColor" stroke-width="2"
-               stroke-linecap="round" stroke-linejoin="round"
-               aria-hidden="true">
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
-          </svg>
-          <!-- Sun icon: shown in dark mode (clicking switches to light) -->
-          <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24"
-               fill="none" stroke="currentColor" stroke-width="2"
-               stroke-linecap="round" stroke-linejoin="round"
-               aria-hidden="true">
-            <circle cx="12" cy="12" r="5"/>
-            <line x1="12" y1="1" x2="12" y2="3"/>
-            <line x1="12" y1="21" x2="12" y2="23"/>
-            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
-            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
-            <line x1="1" y1="12" x2="3" y2="12"/>
-            <line x1="21" y1="12" x2="23" y2="12"/>
-            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
-            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+      <form id="topic-search-form" class="navbar-search" role="search">
+        <input
+          type="search"
+          id="topic-search"
+          autocomplete="off"
+          aria-label="Search projects"
+          placeholder="Search projects…"
+        />
+        <button class="navbar-search-btn" type="submit" aria-label="Search">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+            stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round"
+              d="M21 21l-4.35-4.35m1.85-5.15a7 7 0 11-14 0 7 7 0 0114 0z" />
           </svg>
         </button>
+      </form>
 
-        <button
-        id="theme-toggle"
-        class="theme-toggle"
-        aria-label="Toggle dark mode"
-        aria-pressed="false"
-        >
-        🌙
-      </button>
+      <div class="nav-right">
+        <div class="nav-links">
+          <a href="#home" class="nav-link">Home</a>
+          <a href="#how-it-works" class="nav-link">How It Works</a>
+          <a href="#features" class="nav-link">Features</a>
+          <a href="#find-project" class="nav-link">Find Project</a>
+          <a href="/compare" class="nav-link">Compare</a>
+          <a href="/contact" class="nav-link">Contact</a>
+        </div>
+
+        <div class="nav-actions">
+          <a href="https://github.com/komalharshita/DevPath" target="_blank" rel="noopener noreferrer"
+            class="nav-btn-outline">GitHub</a>
+          <button class="theme-toggle" id="theme-toggle-desktop" aria-pressed="false"
+            aria-label="Switch to dark mode">
+            <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+              stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+            </svg>
+            <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+              stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="12" cy="12" r="5" />
+              <line x1="12" y1="1" x2="12" y2="3" />
+              <line x1="12" y1="21" x2="12" y2="23" />
+              <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+              <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+              <line x1="1" y1="12" x2="3" y2="12" />
+              <line x1="21" y1="12" x2="23" y2="12" />
+              <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+              <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+            </svg>
+          </button>
+        </div>
       </div>
-      <!-- Mobile hamburger toggle -->
-      <button class="nav-mobile-toggle" id="nav-mobile-toggle" aria-label="Toggle navigation" aria-expanded="false"
-        aria-controls="nav-mobile-menu">
+
+      <button class="nav-mobile-toggle" id="nav-mobile-toggle" aria-label="Toggle navigation"
+        aria-expanded="false" aria-controls="nav-mobile-menu">
         <span></span><span></span><span></span>
       </button>
     </div>
-    <!-- Mobile menu — includes upstream's #home link and HEAD's theme toggle + accessibility attrs -->
+
     <div class="nav-mobile-menu" id="nav-mobile-menu" role="menu">
+      <form id="topic-search-form-mobile" class="navbar-search navbar-search--mobile" role="search">
+        <input type="search" id="topic-search-mobile" autocomplete="off" aria-label="Search projects"
+          placeholder="Search projects…" />
+        <button class="navbar-search-btn" type="submit" aria-label="Search">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"
+            stroke-width="2" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round"
+              d="M21 21l-4.35-4.35m1.85-5.15a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+        </button>
+      </form>
       <a href="#home" class="nav-mobile-link" role="menuitem">Home</a>
       <a href="#how-it-works" class="nav-mobile-link" role="menuitem">How It Works</a>
       <a href="#features" class="nav-mobile-link" role="menuitem">Features</a>
       <a href="#find-project" class="nav-mobile-link" role="menuitem">Find Project</a>
+      <a href="/compare" class="nav-mobile-link" role="menuitem">Compare</a>
+      <a href="/contact" class="nav-mobile-link" role="menuitem">Contact</a>
       <a href="https://github.com/komalharshita/DevPath" target="_blank" rel="noopener noreferrer"
         class="nav-mobile-link" role="menuitem">GitHub</a>
-      <!-- Theme toggle in mobile menu — same .theme-toggle class so
-           the JS engine updates both this and the desktop button together -->
       <button class="nav-mobile-link theme-toggle" id="theme-toggle-mobile"
-        style="background:none;border:none;text-align:left;cursor:pointer;display:flex;align-items:center;gap:10px;width:100%;padding:10px 0;font-size:0.95rem;font-weight:500;color:rgba(255,255,255,0.8);"
         aria-pressed="false" aria-label="Switch to dark mode" role="menuitem">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
           stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -19,6 +19,12 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from utils.data_loader import load_all_projects, find_project_by_id, clear_cache, validate_projects
+from utils.roadmap_comparer import (
+    load_all_career_roadmaps,
+    find_roadmap_by_id,
+    compare_roadmaps,
+    clear_roadmap_cache,
+)
 from utils.recommender import (
     get_recommendations,
     validate_recommendation_inputs,
@@ -38,6 +44,7 @@ from app import app, internal_server_error
 def setup_module():
     """Clear the data cache before running the test suite to ensure clean state."""
     clear_cache()
+    clear_roadmap_cache()
 
 
 # ============================================================
@@ -708,6 +715,85 @@ def test_project_links_have_noopener():
     assert response.status_code == 200
     assert b'target="_blank"' in response.data
     assert b'rel="noopener noreferrer"' in response.data
+
+
+# ============================================================
+# Career roadmap comparison tests
+# ============================================================
+
+def test_career_roadmaps_load():
+    """Career roadmaps JSON must load and contain entries."""
+    roadmaps = load_all_career_roadmaps()
+    assert isinstance(roadmaps, list)
+    assert len(roadmaps) >= 2
+
+
+def test_compare_roadmaps_finds_overlap():
+    """Comparing frontend and fullstack should find shared skills."""
+    result = compare_roadmaps("frontend", "fullstack")
+    assert result is not None
+    assert "overlapping_skills" in result
+    assert len(result["overlapping_skills"]) > 0
+    assert result["roadmap_a"]["id"] == "frontend"
+    assert result["roadmap_b"]["id"] == "fullstack"
+
+
+def test_compare_same_roadmap_returns_error():
+    """Comparing a roadmap with itself should return an error message."""
+    result = compare_roadmaps("react", "react")
+    assert result is not None
+    assert "error" in result
+
+
+def test_compare_invalid_roadmap_returns_none():
+    """Unknown roadmap IDs should return None."""
+    assert compare_roadmaps("nonexistent", "frontend") is None
+
+
+def test_compare_page_route(client):
+    """Compare page should render successfully."""
+    response = client.get("/compare")
+    assert response.status_code == 200
+    assert b"Compare Learning Roadmaps" in response.data
+
+
+def test_list_roadmaps_api(client):
+    """API should return all career roadmaps."""
+    response = client.get("/api/roadmaps")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert isinstance(data, list)
+    assert len(data) >= 2
+
+
+def test_compare_api(client):
+    """Compare API should return structured comparison data."""
+    response = client.get("/api/compare?a=react&b=angular")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["roadmap_a"]["id"] == "react"
+    assert data["roadmap_b"]["id"] == "angular"
+    assert "metrics" in data
+    assert "overlapping_skills" in data
+
+
+def test_compare_api_missing_params(client):
+    """Compare API should reject requests missing query params."""
+    response = client.get("/api/compare?a=react")
+    assert response.status_code == 400
+
+
+def test_compare_api_not_found(client):
+    """Compare API should 404 for invalid roadmap IDs."""
+    response = client.get("/api/compare?a=invalid&b=alsoinvalid")
+    assert response.status_code == 404
+
+
+def test_sitemap_includes_compare(client):
+    """Sitemap should include the compare page."""
+    response = client.get("/sitemap.xml")
+    assert response.status_code == 200
+    assert b"/compare" in response.data
 
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -21,7 +21,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from utils.data_loader import load_all_projects, find_project_by_id, clear_cache, validate_projects
 from utils.roadmap_comparer import (
     load_all_career_roadmaps,
-    find_roadmap_by_id,
     compare_roadmaps,
     clear_roadmap_cache,
 )
@@ -750,15 +749,17 @@ def test_compare_invalid_roadmap_returns_none():
     assert compare_roadmaps("nonexistent", "frontend") is None
 
 
-def test_compare_page_route(client):
+def test_compare_page_route():
     """Compare page should render successfully."""
+    client = get_client()
     response = client.get("/compare")
     assert response.status_code == 200
     assert b"Compare Learning Roadmaps" in response.data
 
 
-def test_list_roadmaps_api(client):
+def test_list_roadmaps_api():
     """API should return all career roadmaps."""
+    client = get_client()
     response = client.get("/api/roadmaps")
     assert response.status_code == 200
     data = response.get_json()
@@ -766,8 +767,9 @@ def test_list_roadmaps_api(client):
     assert len(data) >= 2
 
 
-def test_compare_api(client):
+def test_compare_api():
     """Compare API should return structured comparison data."""
+    client = get_client()
     response = client.get("/api/compare?a=react&b=angular")
     assert response.status_code == 200
     data = response.get_json()
@@ -777,20 +779,23 @@ def test_compare_api(client):
     assert "overlapping_skills" in data
 
 
-def test_compare_api_missing_params(client):
+def test_compare_api_missing_params():
     """Compare API should reject requests missing query params."""
+    client = get_client()
     response = client.get("/api/compare?a=react")
     assert response.status_code == 400
 
 
-def test_compare_api_not_found(client):
+def test_compare_api_not_found():
     """Compare API should 404 for invalid roadmap IDs."""
+    client = get_client()
     response = client.get("/api/compare?a=invalid&b=alsoinvalid")
     assert response.status_code == 404
 
 
-def test_sitemap_includes_compare(client):
+def test_sitemap_includes_compare():
     """Sitemap should include the compare page."""
+    client = get_client()
     response = client.get("/sitemap.xml")
     assert response.status_code == 200
     assert b"/compare" in response.data

--- a/tests/test_og_tags.py
+++ b/tests/test_og_tags.py
@@ -3,6 +3,8 @@
 
 import sys
 import os
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from app import app
@@ -140,10 +142,10 @@ def test_og_banner_exists():
 
 def test_og_banner_dimensions():
     """The og-banner.png must be 1200x630 pixels."""
+    pytest.importorskip("PIL")
     from PIL import Image
     img = Image.open("static/og-banner.png")
     assert img.size == (1200, 630), f"Expected 1200x630, got {img.size}"
 
 if __name__ == "__main__":
-    import pytest
     pytest.main([__file__, "-v"])

--- a/utils/roadmap_comparer.py
+++ b/utils/roadmap_comparer.py
@@ -1,0 +1,169 @@
+# utils/roadmap_comparer.py
+# Load career roadmaps and compute side-by-side comparisons.
+
+import json
+import os
+import threading
+
+ROADMAPS_FILE = os.path.join(
+    os.path.dirname(__file__), "..", "data", "career_roadmaps.json"
+)
+_roadmaps_cache = None
+_cache_lock = threading.Lock()
+
+REQUIRED_FIELDS = [
+    "id", "title", "description", "topics", "skills",
+    "duration", "duration_weeks", "difficulty", "difficulty_score",
+    "career_opportunities",
+]
+
+
+def _normalize(value):
+    """Normalize a string for case-insensitive comparison."""
+    return value.strip().lower()
+
+
+def validate_roadmaps(roadmaps):
+    """Validate career roadmap dataset integrity."""
+    seen_ids = set()
+
+    for roadmap in roadmaps:
+        for field in REQUIRED_FIELDS:
+            if field not in roadmap:
+                raise ValueError(f"Missing required field: {field}")
+
+        roadmap_id = roadmap["id"]
+        if roadmap_id in seen_ids:
+            raise ValueError(f"Duplicate roadmap ID found: {roadmap_id}")
+        seen_ids.add(roadmap_id)
+
+        if not isinstance(roadmap["topics"], list) or not roadmap["topics"]:
+            raise ValueError(f"Roadmap '{roadmap_id}' must have at least one topic")
+
+        if not isinstance(roadmap["skills"], list) or not roadmap["skills"]:
+            raise ValueError(f"Roadmap '{roadmap_id}' must have at least one skill")
+
+
+def load_all_career_roadmaps():
+    """Read and return all career roadmaps from JSON (cached after first read)."""
+    global _roadmaps_cache
+    with _cache_lock:
+        if _roadmaps_cache is None:
+            with open(ROADMAPS_FILE, "r", encoding="utf-8") as handle:
+                _roadmaps_cache = json.load(handle)
+            validate_roadmaps(_roadmaps_cache)
+    return _roadmaps_cache
+
+
+def find_roadmap_by_id(roadmap_id):
+    """Return the roadmap whose id matches, or None."""
+    for roadmap in load_all_career_roadmaps():
+        if roadmap.get("id") == roadmap_id:
+            return roadmap
+    return None
+
+
+def _partition_lists(list_a, list_b):
+    """Return (overlapping, unique_a, unique_b) using case-insensitive matching."""
+    norm_b = {_normalize(item): item for item in list_b}
+    norm_a = {_normalize(item): item for item in list_a}
+
+    overlapping = []
+    unique_a = []
+    seen_overlap = set()
+
+    for key, original in norm_a.items():
+        if key in norm_b:
+            if key not in seen_overlap:
+                overlapping.append(original)
+                seen_overlap.add(key)
+        else:
+            unique_a.append(original)
+
+    unique_b = [
+        original for key, original in norm_b.items() if key not in norm_a
+    ]
+
+    return overlapping, unique_a, unique_b
+
+
+def compare_roadmaps(roadmap_id_a, roadmap_id_b):
+    """
+    Compare two career roadmaps and return structured comparison data.
+
+    Returns None if either roadmap ID is invalid.
+    """
+    roadmap_a = find_roadmap_by_id(roadmap_id_a)
+    roadmap_b = find_roadmap_by_id(roadmap_id_b)
+
+    if not roadmap_a or not roadmap_b:
+        return None
+
+    if roadmap_id_a == roadmap_id_b:
+        return {
+            "error": "Please select two different roadmaps to compare.",
+        }
+
+    overlap_skills, unique_a_skills, unique_b_skills = _partition_lists(
+        roadmap_a["skills"], roadmap_b["skills"]
+    )
+    overlap_topics, unique_a_topics, unique_b_topics = _partition_lists(
+        roadmap_a["topics"], roadmap_b["topics"]
+    )
+
+    overlap_careers, unique_a_careers, unique_b_careers = _partition_lists(
+        roadmap_a["career_opportunities"], roadmap_b["career_opportunities"]
+    )
+
+    max_duration = max(roadmap_a["duration_weeks"], roadmap_b["duration_weeks"], 1)
+    max_difficulty = 5
+
+    return {
+        "roadmap_a": roadmap_a,
+        "roadmap_b": roadmap_b,
+        "overlapping_skills": overlap_skills,
+        "unique_skills_a": unique_a_skills,
+        "unique_skills_b": unique_b_skills,
+        "overlapping_topics": overlap_topics,
+        "unique_topics_a": unique_a_topics,
+        "unique_topics_b": unique_b_topics,
+        "overlapping_careers": overlap_careers,
+        "unique_careers_a": unique_a_careers,
+        "unique_careers_b": unique_b_careers,
+        "summary": {
+            "shared_skills_count": len(overlap_skills),
+            "shared_topics_count": len(overlap_topics),
+            "total_unique_skills": len(unique_a_skills) + len(unique_b_skills),
+        },
+        "metrics": {
+            "duration_weeks": {
+                "a": roadmap_a["duration_weeks"],
+                "b": roadmap_b["duration_weeks"],
+                "max": max_duration,
+            },
+            "difficulty_score": {
+                "a": roadmap_a["difficulty_score"],
+                "b": roadmap_b["difficulty_score"],
+                "max": max_difficulty,
+            },
+            "topics_count": {
+                "a": len(roadmap_a["topics"]),
+                "b": len(roadmap_b["topics"]),
+            },
+            "skills_count": {
+                "a": len(roadmap_a["skills"]),
+                "b": len(roadmap_b["skills"]),
+            },
+            "career_count": {
+                "a": len(roadmap_a["career_opportunities"]),
+                "b": len(roadmap_b["career_opportunities"]),
+            },
+        },
+    }
+
+
+def clear_roadmap_cache():
+    """Reset the in-memory roadmap cache (used in tests)."""
+    global _roadmaps_cache
+    with _cache_lock:
+        _roadmaps_cache = None


### PR DESCRIPTION
## Summary

This PR adds a Career Roadmap Comparison feature so learners can select two paths (e.g. Frontend vs Full Stack, React vs Angular, DevOps vs Cloud) and view a side-by-side breakdown of topics, duration, difficulty, shared/unique skills, career opportunities, and visual bar charts. It also improves the homepage navbar by styling the project search bar to match the theme, reorganizing congested nav items, removing a duplicate theme toggle, and wiring search to the existing `/api/search` endpoint.

## Changes Made

- `data/career_roadmaps.json` — New dataset with 6 career roadmaps (Frontend, Full Stack, React, Angular, DevOps, Cloud)
- `utils/roadmap_comparer.py` — Load roadmaps, validate data, compute overlapping/unique skills, topics, and careers
- `routes/main_routes.py` — Added `/compare`, `/api/roadmaps`, `/api/compare`; included compare page in sitemap
- `templates/compare.html` — Comparison page with selectors, quick-pick buttons, charts, and side-by-side details
- `static/compare.js` — Client logic for fetching comparisons and rendering bar charts and skill breakdowns
- `static/style.css` — Compare page styles; navbar search styling; improved nav layout and responsive breakpoints
- `templates/index.html` — Reorganized navbar (logo, search, links, actions); mobile search; Compare nav link
- `static/script.js` — Wired navbar search (desktop + mobile) to `/api/search` and results rendering
- `tests/test_basic.py` — 9 new tests for roadmap loading, comparison logic, API routes, and sitemap

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Data addition (new projects)
- [x] Style / UI change

## Testing Done

Manual testing:
1. Open `/compare` — select two roadmaps and click Compare Roadmaps
2. Use quick picks: Frontend vs Full Stack, React vs Angular, DevOps vs Cloud
3. Verify bar charts, shared skills, unique skills, topics, and career tags render correctly
4. Test URL params: `/compare?a=frontend&b=fullstack`
5. Homepage navbar — search bar matches theme; nav less congested; search returns project results
6. Mobile menu — search and all nav links accessible

Automated tests:
venv\Scripts\python.exe -m pytest tests/test_basic.py -q 72 passed


## Video

https://github.com/user-attachments/assets/87065348-3151-41fa-a1ae-bc9ef5c8ee7e




Before: No roadmap comparison page; navbar search unstyled and nav crowded with duplicate theme toggle.

After: Full comparison UI at `/compare` with charts and skill overlap; themed search pill in navbar.
(Add screenshots of `/compare` results and updated navbar here.)
## Related Issue

Closes #785 