### PR TITLE
fix: keyboard trap for GitHub modal and tooltip aria-hidden

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -689,16 +689,33 @@ updateProfileWidgets();
   var errorMsg = document.getElementById("github-modal-error");
 
   function closeGithubModal() {
-    modal.classList.remove("active");
-    githubInput.value = "";
-    errorMsg.textContent = "";
-  }
+  modal.classList.remove("active");
+  githubInput.value = "";
+  errorMsg.textContent = "";
+  openModalBtn.focus(); // add this line
+}
 
   if (modal && openModalBtn && closeModalBtn && fetchBtn && githubInput && errorMsg) {
     openModalBtn.addEventListener("click", function () {
       modal.classList.add("active");
       githubInput.focus();
     });
+    modal.addEventListener("keydown", function (event) {
+  if (!modal.classList.contains("active")) return;
+  var focusable = modal.querySelectorAll("button, input");
+  var first = focusable[0];
+  var last = focusable[focusable.length - 1];
+  if (event.key === "Tab") {
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+  if (event.key === "Escape") closeGithubModal();
+});
     closeModalBtn.addEventListener("click", closeGithubModal);
     modal.addEventListener("click", function (event) {
       if (event.target === modal) closeGithubModal();

--- a/templates/index.html
+++ b/templates/index.html
@@ -525,7 +525,9 @@
                 <label for="skills-input">
                   Your Skills
                   <button type="button" class="tooltip" aria-label="Skills help" aria-describedby="skills-tooltip">
-                    ⓘ
+  <span aria-hidden="true">ⓘ</span>
+</button>
+                    
                     <span id="skills-tooltip" class="tooltip-text" role="tooltip">
                       Add technologies, programming languages, or tools you know like Python, React, Git, SQL, etc.
                     </span>


### PR DESCRIPTION
## Summary

Fixes two keyboard accessibility issues flagged in #25.

### Changes

**`templates/index.html`**

- Added `aria-hidden="true"` to decorative tooltips so screen readers skip them

**`static/script.js`**

- Implemented focus trap for the GitHub modal — Tab and Shift+Tab now cycle within the modal while it's open

- Focus returns to the trigger element on modal close

### Testing

- Tabbed through the page with no mouse — focus no longer escapes the modal

- No visual changes

Closes #25