### PR TITLE
Add missing theme_head include to 500.html

### DIFF
--- a/templates/500.html
+++ b/templates/500.html
@@ -12,6 +12,7 @@
   <meta property="og:url" content="{{ config.get_base_url() }}/" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
+  {% include 'partials/theme_head.html' %}
   <link rel="stylesheet" href="/static/style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@400;500&display=swap" rel="stylesheet" />
 </head>


### PR DESCRIPTION
## Summary
Adds missing `{% include 'partials/theme_head.html' %}` to `templates/500.html` so the dark mode theme is properly initialized on the 500 error page.

## Changes
- Added `{% include 'partials/theme_head.html' %}` to the `<head>` of 500.html

## Related Issue
Closes #863

**GSSoC 2026**