### PR TITLE
Add aria-label to navbar on contact page

### DIFF
--- a/templates/contact.html
+++ b/templates/contact.html
@@ -8,7 +8,7 @@
 </head>
 <body>
 
-    <nav class="navbar">
+    <nav class="navbar" aria-label="Main navigation">
         <div class="nav-inner">
             <a href="/" class="nav-logo">
                 Dev<span class="nav-logo-accent">Path</span>


### PR DESCRIPTION
## Summary
Adds `aria-label="Main navigation"` to the `<nav>` element in `templates/contact.html` for screen reader accessibility.

## Changes
- Added `aria-label="Main navigation"` to the navbar in contact.html

## Related Issue
Closes #867

**GSSoC 2026**