### PR TITLE
Add aria-label to navbar on 400 error page

### DIFF
--- a/templates/400.html
+++ b/templates/400.html
@@ -16,7 +16,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@400;500&display=swap" rel="stylesheet" />
 </head>
 <body>
-  <nav class="navbar">
+  <nav class="navbar" aria-label="Main navigation">
     <div class="nav-inner">
       <a href="/" class="nav-logo">DevPath</a>
       {% include 'partials/theme_toggle.html' %}


### PR DESCRIPTION
## Summary
Adds `aria-label="Main navigation"` to the `<nav>` element in `templates/400.html` for screen reader accessibility.

## Changes
- Added `aria-label="Main navigation"` to the navbar in 400.html

## Related Issue
Closes #869

**GSSoC 2026**