### PR TITLE
Fix: add aria-label="

### DIFF
--- a/templates/contact.html
+++ b/templates/contact.html
@@ -8,7 +8,7 @@
 </head>
 <body>
 
-    <nav class="navbar">
+    <nav class="navbar" aria-label="Main navigation">
         <div class="nav-inner">
             <a href="/" class="nav-logo">
                 Dev<span class="nav-logo-accent">Path</span>


### PR DESCRIPTION
## Summary

Adds missing `aria-label="Main navigation"` to the navbar element in the contact page for accessibility compliance. This aligns with other pages in the project (index.html, project.html, 404.html, etc.).

## Related Issue

Closes #867

## Type of Change

- [x] Bug fix — resolves a broken behaviour

## What Was Changed

| File | Change made |
|------|-------------|
| [DevPath/DevPath/templates/contact.html](DevPath/DevPath/templates/contact.html#L11) | Added `aria-label="Main navigation"` to the `<nav>` element for accessibility. |

## How to Test This PR

1. Checkout the branch:
```bash
git checkout fix/add-aria-label-contact-867