### PR TITLE
fix: define PROGRESS_MAX_POINTS to resolve ReferenceError in script.js

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,3 +1,4 @@
+const PROGRESS_MAX_POINTS = 100;
 <!DOCTYPE html>
 <html lang="en">
 


### PR DESCRIPTION
Fixes #932 . I was assigned to this issue. Ref: #932

## What was the bug?
PROGRESS_MAX_POINTS variable was being used in script.js 
but was never defined, causing an Uncaught ReferenceError 
and showing a red error banner on the live site.

## What did I fix?
Added `const PROGRESS_MAX_POINTS = 100;` at the top of 
script.js to define the variable before it is used.