### PR TITLE
fix: remove duplicate broken syncSkillsHiddenInput function

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -997,11 +997,7 @@ updateProfileWidgets();
     });
   }
 
-  function syncSkillsHiddenInput() {
-    if (!skillsHidden) {
-      var skillsHidden = document.getElementById("skills");
-    }
-  }
+
 
   updateQuickPickState();
 


### PR DESCRIPTION
Fixes #951

## What was the bug?
syncSkillsHiddenInput was defined twice in script.js.
The second definition had incorrect variable scoping -
it declared skillsHidden inside an if block using var,
meaning it never actually synced the hidden input.

## What did I fix?
Removed the broken duplicate definition. The correct
version which properly saves selected skills using
JSON.stringify already exists and works correctly.