### PR TITLE
fix: replace skillsTextInput with skillsInput to resolve ReferenceError

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -582,9 +582,9 @@ updateProfileWidgets();
 
   // Add skill on Enter key in the text input
   // we intercept Enter here so it doesn't accidentally submit the whole form
-  skillsTextInput.addEventListener("keydown", function (evt) {
+  skillsInput.addEventListener("keydown", function (evt) {
     if (evt.key === "ArrowDown" || evt.key === "ArrowUp") {
-      if (visibleSuggestions.length === 0) displaySuggestions(getFilteredSkills(skillsTextInput.value));
+      if (visibleSuggestions.length === 0) displaySuggestions(getFilteredSkills(skillsInput.value));
       if (visibleSuggestions.length === 0) return;
       evt.preventDefault();
       if (evt.key === "ArrowDown") {
@@ -602,7 +602,7 @@ updateProfileWidgets();
         selectSuggestion(visibleSuggestions[activeSuggestionIndex]);
         return;
       }
-      if (skillsTextInput.value.trim()) { addSkill(skillsTextInput.value); skillsTextInput.value = ""; }
+      if (skillsInput.value.trim()) { addSkill(skillsInput.value); skillsInput.value = ""; }
       hideSuggestions();
     }
   });
@@ -670,7 +670,7 @@ updateProfileWidgets();
       var skill = chip.getAttribute("data-skill");
       if (!skill) return;
       if (isSkillSelected(skill)) { removeSkill(skill); } else { addSkill(skill); }
-      skillsTextInput.value = "";
+      skillsInput.value = "";
       hideSuggestions();
   function renderSelectedChips() {
     selectedChips.textContent = "";
@@ -820,7 +820,7 @@ updateProfileWidgets();
         addSkill(skill);
       }
       hideSuggestions();
-      skillsTextInput.value = "";
+      skillsInput.value = "";
     });
   });
 
@@ -843,7 +843,7 @@ updateProfileWidgets();
   }
 
   // Show suggestions on input
-  skillsTextInput.addEventListener("input", function (evt) {
+  skillsInput.addEventListener("input", function (evt) {
     var typedValue = evt.target.value.trim();
     if (typedValue.length === 0) {
       hideSuggestions();
@@ -945,7 +945,7 @@ updateProfileWidgets();
       // ignore DOM errors
     }
     // Keep focus in the input so user can continue typing
-    if (skillsTextInput) skillsTextInput.focus();
+    if (skillsInput) skillsInput.focus();
   }
 
   // remove a skill from the list and update the UI accordingly


### PR DESCRIPTION
Fixes #952

## What was the bug?
In script.js, the variable skillsTextInput was used in 10 places but was never defined anywhere in the code.
The correct variable name defined in the codebase is skillsInput, causing a ReferenceError in the console and breaking all keyboard interactions with the skills input field.

## What did I fix?
Replaced all 10 occurrences of skillsTextInput with skillsInput which is the correct variable name.