### PR TITLE
[Fix] #710 — Deduplicate skills in parse_skills()

### DIFF
--- a/src/utils/recommender.py
+++ b/src/utils/recommender.py
@@ -63,20 +63,30 @@ def parse_skills(skills_string):
         "JS, HTML5, CSS3"   -> ["javascript", "html", "css"]
     """
     stripped = skills_string.strip()
+    raw_skills = []
     if stripped.startswith("["):
         try:
             parsed = json.loads(stripped)
             if isinstance(parsed, list):
                 raw_skills = [str(s).strip().lower() for s in parsed if str(s).strip()]
-                return [SKILL_ALIASES.get(skill, skill) for skill in raw_skills]
         except (json.JSONDecodeError, ValueError):
             pass
-    raw_skills = [
-        s.strip().lower()
-        for s in skills_string.split(",")
-        if s.strip()
-    ]
-    return [SKILL_ALIASES.get(skill, skill) for skill in raw_skills]
+    if not raw_skills:
+        raw_skills = [
+            s.strip().lower()
+            for s in skills_string.split(",")
+            if s.strip()
+        ]
+    
+    seen = set()
+    deduped_skills = []
+    for skill in raw_skills:
+        normalized = SKILL_ALIASES.get(skill, skill)
+        if normalized not in seen:
+            seen.add(normalized)
+            deduped_skills.append(normalized)
+            
+    return deduped_skills
 
 def _tokenize(text):
     return re.findall(r"[a-z0-9]+", str(text).lower())

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -232,6 +232,16 @@ def test_parse_skills_containing_commas():
     assert result == ["html, css", "javascript"]
 
 
+def test_parse_skills_deduplicates_entries():
+    """parse_skills should deduplicate skill entries, including resolving aliases."""
+    result = parse_skills("python, python, py, html, HTML")
+    assert result == ["python", "html"]
+
+    # Test JSON array deduplication
+    result_json = parse_skills('["Python", "python", "py", "JS", "JavaScript"]')
+    assert result_json == ["python", "javascript"]
+
+
 def test_score_single_project_full_match():
     """A project that matches all four criteria should receive the maximum score."""
     project = {


### PR DESCRIPTION
## Summary
The recommendation scoring logic in the backend was treating duplicate skill inputs (e.g. "python, python, py") as multiple independent matches, resulting in inflated recommendation scores and distorted rankings. This PR updates the skill parsing helper to deduplicate skills (including resolved aliases) before returning them.

## Root Cause
Root cause: `src/utils/recommender.py` `parse_skills()` does not remove duplicate skills from the resulting list after resolving aliases, which causes `score_single_project` to count matching skills multiple times.

## Changes Made
- `src/utils/recommender.py`: Modified `parse_skills` to resolve aliases first, and then deduplicate the final list while preserving the original input order.
- `tests/test_basic.py`: Added a unit test function `test_parse_skills_deduplicates_entries` verifying that both comma-separated and JSON skill list formats are correctly deduplicated.

## How to Test
- Add a new unit test in `tests/test_basic.py` to assert that `parse_skills` successfully deduplicates list items for both JSON format and comma-separated inputs (including resolving aliases first).
- Run the test suite: `venv\Scripts\pytest`

## Related Issue
Closes #710