### PR TITLE
[Fix] #990 — Prevent JSON formatting in selected skill chips

### DIFF
--- a/src/static/bookmarks.js
+++ b/src/static/bookmarks.js
@@ -214,11 +214,21 @@ var DevPathBookmarks = (function () {
     var session = lsGet(SESSION_KEY);
     if (!session || typeof session !== "object") return;
 
-    // Restore skills: split comma-separated string, add each via script.js helper
+    // Restore skills: split comma-separated string or parse JSON array
     var rawSkills = (session.skills || "").trim();
     if (rawSkills) {
-      // window.addSkill is defined by script.js; it deduplicates and updates UI
-      var skillList = rawSkills.split(",").map(function (s) { return s.trim(); }).filter(Boolean);
+      var skillList = [];
+      if (rawSkills.startsWith("[")) {
+        try {
+          var parsed = JSON.parse(rawSkills);
+          if (Array.isArray(parsed)) {
+            skillList = parsed;
+          }
+        } catch (e) {}
+      }
+      if (skillList.length === 0) {
+        skillList = rawSkills.split(",").map(function (s) { return s.trim(); }).filter(Boolean);
+      }
       skillList.forEach(function (skill) {
         if (typeof window.addSkill === "function") window.addSkill(skill);
       });

--- a/src/static/script.js
+++ b/src/static/script.js
@@ -425,7 +425,9 @@ updateProfileWidgets();
   }
 
   function syncSkillsHiddenInput() {
-    skillsHidden.value = JSON.stringify(selectedSkills);
+    skillsHidden.value = selectedSkills.join(", ");
+    var event = new Event("change", { bubbles: true });
+    skillsHidden.dispatchEvent(event);
   }
 
   function isSelected(skill) {


### PR DESCRIPTION
## Summary
This PR resolves a bug where selected skill chips display raw JSON/stringified values instead of clean skill names when the session is restored from local storage.

## Root Cause
`syncSkillsHiddenInput()` in `script.js` was saving the selected skills in the hidden `#skills` input as a stringified JSON array, but `restoreSession()` in `bookmarks.js` parsed this value by splitting on commas, which caused brackets and quotes to remain in the skill names.

## Changes Made
- `src/static/script.js`: Updated `syncSkillsHiddenInput()` to set a clean comma-separated list of skills rather than a stringified JSON array, and triggered a `"change"` event.
- `src/static/bookmarks.js`: Enhanced `restoreSession()` with a JSON parsing fallback for robustness.

## How to Test
1. Go to the website.
2. Select some skills.
3. Reload the page.
4. Verify that the skill chips display clean text (e.g. `HTML`, `CSS`) without JSON formatting characters.

## Related Issue
Closes #990