### PR TITLE
[Fix] #910 — Correct mismatched closing tag for navigation search form

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -391,7 +391,7 @@
               d="M21 21l-4.35-4.35m1.85-5.15a7 7 0 11-14 0 7 7 0 0114 0z" />
           </svg>
         </button>
-      </div>
+      </form>
 
       <button class="nav-mobile-toggle" id="nav-mobile-toggle" aria-label="Toggle navigation"
         aria-expanded="false" aria-controls="nav-mobile-menu">


### PR DESCRIPTION
## Summary
This pull request resolves a mismatched closing tag in the HTML template for the navigation search form, replacing an incorrect `</div>` tag with `</form>`.

## Root Cause
The `<form>` search element at line 379 in `src/templates/index.html` was incorrectly closed with a `</div>` tag on line 394.

## Changes Made
- [index.html](file:///c:/Users/conta.LAPTOP-IR41J1UC/Desktop/OSC/devpath/src/templates/index.html): Replaced `</div>` with `</form>` on line 394 to correctly close `<form id="topic-search-form">`.

## How to Test
1. Run `pytest` to ensure template syntax validation tests pass.
2. View source on the index page and verify that all `<form>` tags are properly balanced and closed.

## Related Issue
Closes #910