### PR TITLE
[Docs] #931 — Remove duplicate paragraph and button in download starter code

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -824,9 +824,6 @@
           <h3>Starter Code Included</h3>
           <p>Download a working template for every project. Skip the blank-page problem and start building immediately.</p>
           <a href="#the-project" class="feature-card-link">Get starter code</a>
-          <p>Download a working template for every project. Skip the blank-page problem and start building immediately.
-          </p>
-          <a href="#find-project" class="feature-card-link">Get starter code</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
This pull request resolves a duplication issue inside the "Starter Code Included" feature card where a paragraph and a button/link were duplicate.

## Root Cause
Lines 827-829 in `src/templates/index.html` duplicated the paragraph and link elements from lines 825-826 with slightly different href targets.

## Changes Made
- [index.html](file:///c:/Users/conta.LAPTOP-IR41J1UC/Desktop/OSC/devpath/src/templates/index.html): Removed duplicate paragraph and link elements within the "Starter Code Included" feature card.

## How to Test
1. Run `pytest` to make sure all template syntax and application tests pass.
2. Load the homepage and scroll to the Features section. Verify that the "Starter Code Included" card only has a single paragraph and button.

## Related Issue
Closes #931