### PR TITLE
[Fix] #809 — Sync theme state with body.dark-theme class to fix dark mode styling

### DIFF
--- a/src/static/script.js
+++ b/src/static/script.js
@@ -7,6 +7,9 @@
   function applyTheme(theme) {
     var isDark = theme === "dark";
     html.setAttribute("data-theme", theme);
+    if (document.body) {
+      document.body.classList.toggle("dark-theme", isDark);
+    }
     try {
       localStorage.setItem("theme", theme);
     } catch (err) {

--- a/src/templates/partials/theme_head.html
+++ b/src/templates/partials/theme_head.html
@@ -3,5 +3,10 @@
     var saved = localStorage.getItem("theme");
     var theme = saved || (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
     document.documentElement.setAttribute("data-theme", theme);
+    document.addEventListener("DOMContentLoaded", function() {
+      if (document.body) {
+        document.body.classList.toggle("dark-theme", theme === "dark");
+      }
+    });
   })();
 </script>


### PR DESCRIPTION
## Summary
This pull request ensures that the dark theme applies fully across the entire application by toggling the `dark-theme` class on the `<body>` element when theme switches.

## Root Cause
The stylesheet `style.css` relies on the `body.dark-theme` selector to style 50+ elements in dark mode. However, the client-side javascript (`script.js` and `theme_head.html`) only set `data-theme="dark"` attribute on the `<html>` tag and never added the `dark-theme` class to the `<body>` element, preventing those styles from applying.

## Changes Made
- [script.js](file:///c:/Users/conta.LAPTOP-IR41J1UC/Desktop/OSC/devpath/src/static/script.js): Toggled the `.dark-theme` class on `document.body` inside `applyTheme(theme)`.
- [theme_head.html](file:///c:/Users/conta.LAPTOP-IR41J1UC/Desktop/OSC/devpath/src/templates/partials/theme_head.html): Added a DOMContentLoaded event listener to set the `.dark-theme` class on the `<body>` element early during page loading.

## How to Test
1. Run `pytest` to make sure all integration tests pass.
2. Load the application and click the theme toggle button in the navbar.
3. Verify that selecting the Dark theme adds the `dark-theme` class to the `<body>` and all styles load correctly.

## Related Issue
Closes #809