### PR TITLE
[Fix] #786 — Fix feature card button text contrast in dark mode

### DIFF
--- a/src/static/style.css
+++ b/src/static/style.css
@@ -4287,10 +4287,18 @@ body.dark-theme .feature-card p {
   color: rgba(255,255,255,0.8);
 }
 
-body.dark-theme .feature-card-link {
-  background: rgba(255,255,255,0.08);
+body.dark-theme .feature-card-link,
+[data-theme="dark"] .feature-card-link {
+  background: rgba(255, 255, 255, 0.08);
   color: white;
-  border-color: rgba(255,255,255,0.14);
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
+body.dark-theme .feature-card-link:hover,
+[data-theme="dark"] .feature-card-link:hover {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.3);
+  color: white;
 }
 
 /*


### PR DESCRIPTION
## Summary
In dark mode, the text inside the feature section buttons was practically invisible due to low contrast against the dark card backgrounds. This PR fixes the text contrast by applying correct themed colors (`white` text on a semi-transparent background with border highlight) in dark mode.

## Root Cause
Root cause: `src/static/style.css` styles `.feature-card-link` dark mode colors under `body.dark-theme` which is not applied when the theme changes to dark using `html[data-theme="dark"]`.

## Changes Made
- `src/static/style.css`: Added `[data-theme="dark"] .feature-card-link` styling and its hover state alongside `body.dark-theme` selectors to ensure contrast styling is correctly synced.

## How to Test
- Run test suite to verify no regressions: `venv\Scripts\pytest`

## Related Issue
Closes #786