### PR TITLE
fix: improve OG and Twitter description truncation

### DIFF
--- a/src/templates/project.html
+++ b/src/templates/project.html
@@ -10,7 +10,7 @@
   
   <!-- Open Graph meta tags for social media sharing -->
   <meta property="og:title" content="{{ project.title }} — DevPath" />
-  <meta property="og:description" content="{{ project.description[:155] }}" />
+  <meta property="og:description" content="{{ project.description|truncate(155, False, '...') }}" />
   <meta property="og:image" content="{{ config.get_og_image_url() }}" />
   <meta property="og:url" content="{{ config.get_base_url() }}/project/{{ project.id }}" />
   <meta property="og:type" content="article" />
@@ -19,7 +19,7 @@
   <!-- Twitter Card meta tags -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="{{ project.title }} — DevPath" />
-  <meta name="twitter:description" content="{{ project.description[:155] }}" />
+  <meta name="twitter:description" content="{{ project.description|truncate(155, False, '...') }}" />
   <meta name="twitter:image" content="{{ config.get_og_image_url() }}" />
   <link rel="stylesheet" href="/static/style.css" />
   <link

--- a/tests/test_og_tags.py
+++ b/tests/test_og_tags.py
@@ -64,6 +64,13 @@ def test_index_twitter_image():
 # Project Page OG Tag Tests
 # ============================================================
 
+def test_project_og_description_rendered():
+    """Project page OG description should render actual text."""
+    html = get_client().get("/project/1").data.decode()
+
+    assert 'property="og:description"' in html
+    assert "Great for learning file handling" in html
+
 def test_project_og_title_dynamic():
     """Project page og:title must contain the project's actual title."""
     client = get_client()


### PR DESCRIPTION
Fixes #930 

## Summary

Fixes truncated Open Graph and Twitter Card descriptions on project detail pages.

## Problem

Project descriptions were being truncated using a fixed character slice:

```html
{{ project.description[:155] }}
```

This could cut text in the middle of a word, resulting in incomplete social media previews such as:

> Great for learning file handling, loop

## Solution

Replaced direct slicing with Jinja's `truncate` filter:

```html
{{ project.description|truncate(155, False, '...') }}
```

This:

- Preserves word boundaries
- Prevents mid-word truncation
- Adds an ellipsis when text exceeds the limit
- Applies to both Open Graph and Twitter metadata

## Testing

- Verified project descriptions longer than 155 characters exist in the dataset.
- Ran `tests/test_og_tags.py` successfully.
- Existing unrelated failure in `test_score_coverage_ratio_exact_values` was present before this change.