### PR TITLE
[Fix] #782 — Fix search bar vertical misalignment in navigation header

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -391,7 +391,7 @@
               d="M21 21l-4.35-4.35m1.85-5.15a7 7 0 11-14 0 7 7 0 0114 0z" />
           </svg>
         </button>
-      </div>
+      </form>
 
       <button class="nav-mobile-toggle" id="nav-mobile-toggle" aria-label="Toggle navigation"
         aria-expanded="false" aria-controls="nav-mobile-menu">


### PR DESCRIPTION
## Summary
The search bar in the navigation header was visually misaligned. This was caused by a mismatched closing `</div>` tag instead of a `</form>` tag on the navbar search form, which closed the `.nav-inner` container prematurely and pushed subsequent elements outside the flexbox centering context.

## Root Cause
Root cause: `src/templates/index.html` closed the `form#topic-search-form` with `</div>` instead of `</form>`, causing the browser to close the `.nav-inner` container prematurely and disrupting flexbox alignment.

## Changes Made
- `src/templates/index.html`: Replaced `</div>` with `</form>` at the end of the navbar search form.

## How to Test
- Run test suite to verify no regressions: `venv\Scripts\pytest`

## Related Issue
Closes #782