### PR TITLE
Add accessible Back to Top button on long-scroll pages.

### DIFF
--- a/src/static/script.js
+++ b/src/static/script.js
@@ -1058,25 +1058,17 @@ updateProfileWidgets();
 
 (function initScrollButton() {
   var button = document.getElementById("scroll-top-btn");
-  var icon = document.getElementById("scroll-btn-icon");
   if (!button) return;
-  var atBottom = false;
 
-  function nearBottom() {
-    return window.innerHeight + window.pageYOffset >= document.body.scrollHeight - 40;
-  }
+  var prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
   function update() {
     button.classList.toggle("visible", window.pageYOffset > 200);
-    atBottom = nearBottom();
-    button.setAttribute("aria-label", atBottom ? "Scroll to top" : "Scroll to bottom");
-    button.title = atBottom ? "Scroll to top" : "Scroll to bottom";
-    if (icon) icon.innerHTML = atBottom ? '<polyline points="18 15 12 9 6 15"/>' : '<polyline points="6 9 12 15 18 9"/>';
   }
 
   window.addEventListener("scroll", update, { passive: true });
   button.addEventListener("click", function () {
-    window.scrollTo({ top: atBottom ? 0 : document.body.scrollHeight, behavior: "smooth" });
+    window.scrollTo({ top: 0, behavior: prefersReducedMotion ? "auto" : "smooth" });
   });
   update();
 })();

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -4128,10 +4128,6 @@ html[data-theme="dark"] .btn-view-code-sm {
   border-color: rgba(99, 102, 241, 0.4);
 }
 
-#scroll-top-btn.visible {
-    display: flex;
-}
-
 /* DARK MODE */
 body.dark-theme {
   background: #0b1120;

--- a/src/templates/compare.html
+++ b/src/templates/compare.html
@@ -231,6 +231,7 @@
     </div>
   </footer>
 
+  {% include 'partials/scroll_top_btn.html' %}
   <script src="/static/script.js"></script>
   <script src="/static/compare.js"></script>
 </body>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1262,11 +1262,7 @@
 
   <script src="/static/data/skills.js"></script>
 
-  <button id="scroll-top-btn" aria-label="Scroll to top" title="Scroll to top">
-    <svg id="scroll-btn-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-      <polyline points="18 15 12 9 6 15"/>
-    </svg>
-  </button>
+  {% include 'partials/scroll_top_btn.html' %}
 
   <script src="/static/script.js"></script>
   <script src="/static/bookmarks.js"></script>

--- a/src/templates/partials/scroll_top_btn.html
+++ b/src/templates/partials/scroll_top_btn.html
@@ -1,0 +1,5 @@
+<button type="button" id="scroll-top-btn" aria-label="Back to top" title="Back to top">
+  <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+    <polyline points="18 15 12 9 6 15"/>
+  </svg>
+</button>

--- a/src/templates/project.html
+++ b/src/templates/project.html
@@ -444,8 +444,7 @@
     </div>
   </footer>
 
-  <!-- Scroll-to-top button -->
-  <button id="scroll-top-btn" aria-label="Back to top" title="Back to top">↑</button>
+  {% include 'partials/scroll_top_btn.html' %}
 
   <script>
     var PROJECT_ID = {{ project.id | tojson }};


### PR DESCRIPTION
## Summary 

This PR adds an accessible Back to Top button for long-scroll pages. Scroll markup is consolidated into a shared Jinja partial, scroll behavior is simplified to always return to the top (removing the previous scroll-to-bottom toggle), and `prefers-reduced-motion` is respected so users who prefer reduced motion get instant scrolling instead of smooth animation.

## Related Issue 

Closes #899 

## Type of Change 

- [ ] Bug fix — resolves a broken behaviour
- [x] Feature — adds new functionality
- [ ] Data — adds new projects to `data/projects.json`
- [ ] Documentation — updates docs, README, or code comments only
- [x] Style — CSS or visual changes only, no logic change
- [x] Refactor — restructures code without changing behaviour
- [ ] Test — adds or updates tests

## What Was Changed 

| File | Change made |
|------|-------------|
| `src/templates/partials/scroll_top_btn.html` | **New** shared partial with accessible button markup (`type="button"`, `aria-label`, decorative SVG with `aria-hidden="true"`) |
| `src/templates/index.html` | Replaced inline scroll button with `{% include 'partials/scroll_top_btn.html' %}` |
| `src/templates/project.html` | Replaced text `↑` button with shared partial include |
| `src/templates/compare.html` | Added shared partial include (button was missing on this long page) |
| `src/static/script.js` | Simplified `initScrollButton()` to always scroll to top; removed dual top/bottom behavior; added `prefers-reduced-motion` support |
| `src/static/style.css` | Removed duplicate `#scroll-top-btn.visible` rule (existing Section 22 styles unchanged) |

## How to Test This PR 

1. Clone this branch: `git checkout feat/accessible-back-to-top`
2. Install dependencies: `pip install -r requirements.txt`
3. Run the app: `python src/app.py`
4. Open http://127.0.0.1:5000 and scroll down ~200px — the Back to Top button should appear in the bottom-right corner
5. Click the button — page should scroll smoothly back to the top; button should hide at the top
6. Repeat on `/project/1` and `/compare`
7. Tab to the button when visible and press Enter/Space — should scroll to top (keyboard accessible)
8. With OS “Reduce motion” enabled — scroll should be instant (no smooth animation)
9. Run the tests: `python tests/test_basic.py`

## Self-Review Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed all guidelines
- [x] My branch name follows the convention: `feat/`, `fix/`, `docs/`, `data/`, `style/`, `test/`
- [ ] I have run `python tests/test_basic.py` and all 27 tests pass
- [ ] I have run `flake8 .` locally and there are no errors
- [x] I have not introduced any `print()` or `console.log()` debug statements
- [x] Every new function I wrote has a docstring
- [x] I have not modified files outside the scope of the linked issue
- [x] If I changed the UI, I tested it at 375px (mobile) and 1280px (desktop)
- [x] If I added a project to the dataset, it has all required JSON fields
## Notes for Reviewer
- The button uses a native `<button>` element, so keyboard users can Tab to it when visible and activate with Enter/Space without extra JS.
- Short pages (`contact.html`, error pages) intentionally omit the button since content fits one viewport.
- Previous dual scroll-to-bottom behavior near the page bottom was removed in favor of a dedicated Back to Top control only.
