### PR TITLE
[Fix] #768 — Filter recommendation results using relevance threshold

### DIFF
--- a/src/utils/recommender.py
+++ b/src/utils/recommender.py
@@ -337,6 +337,7 @@ def get_recommendations(skills_string, level, interest, time_availability):
     user_skills = parse_skills(skills_string)
     all_projects = load_all_projects()
     scored_projects = []
+    graph = _load_skill_graph()
     for project in all_projects:
         rule_score = score_single_project(
             project,
@@ -354,7 +355,16 @@ def get_recommendations(skills_string, level, interest, time_availability):
             all_projects,
         )
         final_score = rule_score + similarity_score
-        if final_score > 0:
+
+        # Check relevance: project must match at least one user skill,
+        # have a positive boost from the skill graph, or have a significant
+        # ML semantic match (similarity_score >= 0.15).
+        project_skills = [SKILL_ALIASES.get(s.lower(), s.lower()) for s in project.get("skills", [])]
+        matched_skills = sum(1 for skill in user_skills if skill in project_skills)
+        boost = gap_boost(user_skills, project_skills, graph)
+        is_relevant = (matched_skills > 0) or (boost > 0) or (similarity_score >= 0.15)
+
+        if final_score > 0 and is_relevant:
             scored_projects.append({
                 "project": project,
                 "score": final_score,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -373,6 +373,7 @@ def test_get_recommendations_no_match_returns_empty():
     results = get_recommendations("Rust", "Advanced", "Games", "High").get("recommendations", [])
     # Rust and Games are not in the dataset so this should be empty or minimal
     assert isinstance(results, list)
+    assert len(results) == 0
 
 
 def test_get_recommendations_result_format():


### PR DESCRIPTION
## Summary
This PR resolves issue #768 by enforcing a minimum relevance threshold on project recommendations. Previously, the engine always returned exactly 3 projects even when none matched the user's inputs, presenting low-quality/irrelevant results.

## Root Cause
In `src/utils/recommender.py`, `get_recommendations()` added all projects with a score > 0 to `scored_projects` and sliced the top 3. Because cosine similarity returns a tiny positive number for almost any input, projects with 0 matching skills were returned.

## Changes Made
- `src/utils/recommender.py`: Added is_relevant filtering logic inside `get_recommendations()` where a project is only included if it matches at least one user skill, has a positive boost from the skill graph, or has a significant ML semantic match (similarity_score >= 0.15).
- `tests/test_basic.py`: Updated `test_get_recommendations_no_match_returns_empty` to assert that `len(results) == 0`.

## How to Test
1. Run `pytest` to verify recommendation tests pass.
2. Manually verify in the UI that generating recommendations with non-matching inputs (e.g. uncommon skills not in database) displays the message: "No projects matched your inputs. Try different skills or broaden your interest area."

Closes #768