### PR TITLE
[Fix] #724 — Fix unclosed form tag causing mobile menu click form submit

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -391,9 +391,9 @@
               d="M21 21l-4.35-4.35m1.85-5.15a7 7 0 11-14 0 7 7 0 0114 0z" />
           </svg>
         </button>
-      </div>
+      </form>
 
-      <button class="nav-mobile-toggle" id="nav-mobile-toggle" aria-label="Toggle navigation"
+      <button class="nav-mobile-toggle" id="nav-mobile-toggle" type="button" aria-label="Toggle navigation"
         aria-expanded="false" aria-controls="nav-mobile-menu">
         <span></span><span></span><span></span>
       </button>


### PR DESCRIPTION
## Summary
This PR resolves issue #724 where the hamburger menu button on mobile was unresponsive and triggered a page reload with `?` appended to the URL.

## Root Cause
In `src/templates/index.html`, the navbar search form `form#topic-search-form` had a mismatched closing `</div>` tag instead of `</form>`. The browser automatically closed the form at a later point, wrapping the mobile hamburger button inside the open form. Since the button had no `type="button"`, it acted as a submit button, reloading the page on click.

## Changes Made
- `src/templates/index.html`: Fixed the unclosed `form#topic-search-form` by replacing the closing `</div>` with `</form>`. Also added `type="button"` to `#nav-mobile-toggle` for extra robustness.

## How to Test
1. Load the page and simulate mobile view (width < 640px).
2. Tap the hamburger menu toggle.
3. Verify that the mobile menu slides in/out smoothly and does not reload the page or append `?` to the URL.

Closes #724