### PR TITLE
[Fix] #723 — Fix broken theme toggle, duplicate SVG icons, and mobile navbar leaks

### DIFF
--- a/src/static/script.js
+++ b/src/static/script.js
@@ -7,6 +7,7 @@
   function applyTheme(theme) {
     var isDark = theme === "dark";
     html.setAttribute("data-theme", theme);
+    document.body.classList.toggle("dark-theme", isDark);
     try {
       localStorage.setItem("theme", theme);
     } catch (err) {

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -861,6 +861,10 @@ html[data-entry-anim="true"] .form-card form > .btn-submit              { animat
     display: none;
   }
 
+  .nav-links {
+    display: none;
+  }
+
   .nav-mobile-toggle {
     display: flex;
     margin-left: auto;

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -391,9 +391,13 @@
               d="M21 21l-4.35-4.35m1.85-5.15a7 7 0 11-14 0 7 7 0 0114 0z" />
           </svg>
         </button>
+      </form>
+
+      <div class="nav-links">
+        {% include 'partials/theme_toggle.html' %}
       </div>
 
-      <button class="nav-mobile-toggle" id="nav-mobile-toggle" aria-label="Toggle navigation"
+      <button class="nav-mobile-toggle" id="nav-mobile-toggle" type="button" aria-label="Toggle navigation"
         aria-expanded="false" aria-controls="nav-mobile-menu">
         <span></span><span></span><span></span>
       </button>

--- a/src/templates/partials/theme_head.html
+++ b/src/templates/partials/theme_head.html
@@ -3,5 +3,8 @@
     var saved = localStorage.getItem("theme");
     var theme = saved || (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
     document.documentElement.setAttribute("data-theme", theme);
+    document.addEventListener("DOMContentLoaded", function() {
+      document.body.classList.toggle("dark-theme", theme === "dark");
+    });
   })();
 </script>

--- a/src/templates/partials/theme_toggle.html
+++ b/src/templates/partials/theme_toggle.html
@@ -1,5 +1,5 @@
 <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" aria-pressed="false">
-  <svg class="theme-toggle-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <circle cx="12" cy="12" r="5"></circle>
     <line x1="12" y1="1" x2="12" y2="3"></line>
     <line x1="12" y1="21" x2="12" y2="23"></line>
@@ -10,7 +10,7 @@
     <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
     <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
   </svg>
-  <svg class="theme-toggle-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none">
+  <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
   </svg>
 </button>


### PR DESCRIPTION
## Summary
This PR resolves issue #723 by fixing the broken theme toggling logic, resolving duplicate navbar icons inside partial theme toggles, and correcting responsive navbar overrides on mobile viewports.

## Root Cause
1. **Theme Toggle Inoperability (Dark mode not applying)**: While the inline theme head script and client-side `script.js` successfully toggled the `data-theme` attribute on the `<html>` root element, 95% of the dark mode colors in `style.css` relied on the `body.dark-theme` class which was never added/removed.
2. **Duplicate Theme Toggle Icons**: The SVGs inside `partials/theme_toggle.html` used classes `theme-toggle-sun` / `theme-toggle-moon`, but the CSS rules to conditionally hide/show the icons expected `.icon-sun` and `.icon-moon`. Consequently, both icons rendered side by side.
3. **Responsive Navbar Leak**: Desktop navbar links and theme toggles (`.nav-links`) lacked responsive hiding on mobile devices, causing them to leak into mobile viewports, overlap with the mobile menu trigger, and push the layout off-screen.

## Changes Made
- `src/templates/partials/theme_toggle.html`: Changed SVG classes to `icon-sun` / `icon-moon` and removed the inline `style="display:none"` to leverage CSS-controlled theme switching.
- `src/templates/partials/theme_head.html`: Added a DOMContentLoaded listener to immediately apply the correct theme class to `document.body` on page load.
- `src/static/script.js`: Synchronized the `dark-theme` class on `document.body` inside `applyTheme(theme)`.
- `src/static/style.css`: Added responsive styling to hide `.nav-links` inside `@media (max-width: 768px)` blocks.
- `src/templates/index.html`: Integrated the desktop theme toggle into the homepage navbar (wrapped in `.nav-links` to hide on mobile) to restore theme selection for desktop users on the homepage.

## How to Test
1. Load the homepage on desktop: verify a single theme toggle button is present. Toggle it and ensure dark mode colors apply correctly to all elements.
2. Simulate mobile screen (width < 768px): verify that the desktop theme toggle and navbar links are hidden, leaving only the hamburger menu toggle visible and interactive.
3. Open a project detail page or error page (which include the theme toggle partial) and verify that the theme toggle correctly switches between sun and moon icons.

Closes #723