### PR TITLE
[Feat] #771 — Lock Project Completed button until all roadmap steps checked and expand step details

### DIFF
--- a/src/static/script.js
+++ b/src/static/script.js
@@ -349,8 +349,24 @@ function updateProfileWidgets() {
   }
   if (completionBtn && typeof PROJECT_ID !== "undefined") {
     var completed = projectIsCompleted(PROJECT_ID);
-    completionBtn.textContent = completed ? "Project Completed" : "Mark Project Complete";
-    completionBtn.disabled = completed;
+    if (completed) {
+      completionBtn.textContent = "Project Completed";
+      completionBtn.disabled = true;
+    } else {
+      var checkboxes = document.querySelectorAll(".roadmap-checkbox");
+      var total = checkboxes.length;
+      var checkedCount = 0;
+      for (var i = 0; i < total; i++) {
+        if (checkboxes[i].checked) checkedCount++;
+      }
+      if (total > 0 && checkedCount === total) {
+        completionBtn.textContent = "Mark Project Complete";
+        completionBtn.disabled = false;
+      } else {
+        completionBtn.textContent = "Complete All Steps First";
+        completionBtn.disabled = true;
+      }
+    }
   }
 }
 
@@ -1021,8 +1037,8 @@ updateProfileWidgets();
 
   function updateRoadmapProgress() {
     if (!roadmapCheckboxes.length) return;
-    var completed = roadmapCheckboxes.filter(function (checkbox) { return checkbox.checked; }).length;
-    var percent = Math.round((completed / roadmapCheckboxes.length) * 100);
+    var completedCount = roadmapCheckboxes.filter(function (checkbox) { return checkbox.checked; }).length;
+    var percent = Math.round((completedCount / roadmapCheckboxes.length) * 100);
     roadmapCheckboxes.forEach(function (checkbox) {
       var step = checkbox.closest(".roadmap-step");
       if (step) step.classList.toggle("completed", checkbox.checked);
@@ -1030,6 +1046,26 @@ updateProfileWidgets();
     if (progressFill) progressFill.style.width = percent + "%";
     if (progressText) progressText.textContent = percent + "% completed";
     if (progressBar) progressBar.setAttribute("aria-valuenow", String(percent));
+
+    // Disable completion button unless all steps are completed
+    var completionBtn = document.getElementById("btn-mark-complete");
+    if (completionBtn && typeof PROJECT_ID !== "undefined") {
+      var isAlreadyCompleted = projectIsCompleted(PROJECT_ID);
+      if (isAlreadyCompleted) {
+        completionBtn.textContent = "Project Completed";
+        completionBtn.disabled = true;
+      } else {
+        var allChecked = completedCount === roadmapCheckboxes.length;
+        if (allChecked) {
+          completionBtn.textContent = "Mark Project Complete";
+          completionBtn.disabled = false;
+        } else {
+          completionBtn.textContent = "Complete All Steps First";
+          completionBtn.disabled = true;
+        }
+      }
+    }
+
     try {
       localStorage.setItem(roadmapStorageKey, JSON.stringify(roadmapCheckboxes.map(function (checkbox) {
         return checkbox.checked;
@@ -1047,6 +1083,51 @@ updateProfileWidgets();
     checkbox.addEventListener("change", updateRoadmapProgress);
   });
   updateRoadmapProgress();
+
+  // Initialize expandable roadmap details
+  var stepToggles = document.querySelectorAll(".btn-step-details-toggle");
+  var stepTexts = document.querySelectorAll(".roadmap-step-text");
+  var stepGuidances = document.querySelectorAll(".step-detailed-guidance");
+
+  var guidanceRules = [
+    { pattern: /set\s*up|folder|create|initialize/i, text: "Initialize your project workspace. Create a dedicated directory, initialize Git version control, and set up your configuration or main script files (e.g., main.py, index.html). Plan your module structure." },
+    { pattern: /design|structure|database|schema|model/i, text: "Determine the data entities and attributes. Write down the schema or dictionary layout, choose key-value pairs, and decide on database or memory storage mechanism." },
+    { pattern: /function|logic|write|implement|calculate|process/i, text: "Draft helper functions with clear inputs and outputs. Focus on clean implementation of core business logic first, keeping functions modular, clean, and testable." },
+    { pattern: /api|fetch|endpoint|route|request|http/i, text: "Implement routes/controllers for handling HTTP requests. Verify correct status codes, JSON formats, and integrate error handling for network or request failures." },
+    { pattern: /ui|interface|frontend|view|css|style|render|display/i, text: "Build a responsive interface using semantic HTML and clean styling. Design for mobile-first views and verify interactive component states (hover, focus, disabled)." },
+    { pattern: /test|bug|mock|assert|verify/i, text: "Write test cases (unit/integration) or manually test inputs to verify the code handles edge cases, empty values, and invalid format errors gracefully." }
+  ];
+
+  function getGuidanceText(stepText) {
+    for (var i = 0; i < guidanceRules.length; i++) {
+      if (guidanceRules[i].pattern.test(stepText)) {
+        return guidanceRules[i].text;
+      }
+    }
+    return "Break down this milestone into smaller tasks. Research best libraries or methods, implement a prototype, and review for performance and correctness.";
+  }
+
+  stepTexts.forEach(function (el, index) {
+    if (stepGuidances[index]) {
+      stepGuidances[index].textContent = getGuidanceText(el.textContent);
+    }
+  });
+
+  stepToggles.forEach(function (btn, index) {
+    btn.addEventListener("click", function (event) {
+      event.preventDefault();
+      var guidance = stepGuidances[index];
+      if (!guidance) return;
+      var isHidden = guidance.style.display === "none";
+      guidance.style.display = isHidden ? "block" : "none";
+      var label = btn.querySelector("span");
+      if (label) label.textContent = isHidden ? "Hide Details" : "Show Details";
+      var chevron = btn.querySelector(".chevron-icon");
+      if (chevron) {
+        chevron.style.transform = isHidden ? "rotate(180deg)" : "rotate(0deg)";
+      }
+    });
+  });
 
   if (completionBtn) {
     completionBtn.addEventListener("click", function () {

--- a/src/templates/project.html
+++ b/src/templates/project.html
@@ -256,6 +256,13 @@
                         <p class="roadmap-step-text">
                             {{ step | replace("Step " ~ loop.index ~ ": ", "") }}
                         </p>
+                        <button type="button" class="btn-step-details-toggle" style="background:none; border:none; color:var(--accent); font-size:0.8rem; cursor:pointer; padding:0; margin-top:4px; display:inline-flex; align-items:center; gap:4px;">
+                            <span>Show Details</span>
+                            <svg class="chevron-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="transition: transform 0.2s;">
+                                <polyline points="6 9 12 15 18 9"></polyline>
+                            </svg>
+                        </button>
+                        <div class="step-detailed-guidance" style="display:none; margin-top:8px; font-size:0.825rem; color:var(--text-muted); line-height:1.4;"></div>
                     </div>
                 </label>
             </div>


### PR DESCRIPTION
## Summary
This PR implements Issue #771 to prevent users from marking a project complete before checking off all roadmap milestones, and introduces expandable/collapsible detailed guidance for each roadmap step.

## Root Cause
Previously:
1. The **Mark Project Complete** button was immediately functional and clickable, even at 0% checklist completion.
2. The roadmap steps only displayed high-level goals without detailed instructions, making it harder for beginners to know how to approach each step.

## Changes Made
- `src/templates/project.html`: Integrated details toggle buttons and collapsible `.step-detailed-guidance` containers under each roadmap step within the loop.
- `src/static/script.js`:
  - Updated `updateProfileWidgets()` and `updateRoadmapProgress()` to check if all checkboxes are checked. If not, it disables the completion button and updates its text to "Complete All Steps First". Once all checkboxes are checked, it enables the button with "Mark Project Complete".
  - Created a client-side keyword-based step details populator that fills the guidance container dynamically on project page load based on the step text (e.g. workspace setup, database schema design, logic implementation, testing, etc.) and handles click toggles (rotating the chevrons and swapping show/hide labels).

## How to Test
1. Open any project detail page (e.g. `/project/1`).
2. Verify that the "Mark Project Complete" button at the bottom of the sidebar is disabled with the label "Complete All Steps First".
3. Click "Show Details" on any roadmap step and verify that the descriptive guidance expands/collapses smoothly.
4. Check off all the roadmap steps one by one. Verify that the progress bar reaches 100% and the completion button becomes enabled with the text "Mark Project Complete". Click it and verify completion is recorded.

Closes #771