### PR TITLE
[Feat] #761 — Add shareable results URL via query parameters

### DIFF
--- a/src/static/script.js
+++ b/src/static/script.js
@@ -841,6 +841,16 @@ updateProfileWidgets();
         setLoadingState(false);
         recordSearch();
         renderResults(data.projects || [], data.message);
+
+        // Update URL query parameters so the result is shareable
+        try {
+          var params = new URLSearchParams();
+          params.set("skills", JSON.stringify(selectedSkills));
+          params.set("level", document.getElementById("level").value);
+          params.set("interest", document.getElementById("interest").value);
+          params.set("time", document.getElementById("time").value);
+          window.history.replaceState(null, "", "?" + params.toString());
+        } catch (e) {}
       })
       .catch(function (err) {
         setLoadingState(false);
@@ -1053,6 +1063,65 @@ updateProfileWidgets();
       recordCompletion(PROJECT_ID, typeof PROJECT_TITLE !== "undefined" ? PROJECT_TITLE : "");
       showAchievementToast("Project completed", "Nice work finishing this project.");
     });
+  }
+
+  // Handle shareable results URL via query parameters
+  function parseUrlQueryParams() {
+    var params = new URLSearchParams(window.location.search);
+    var skillsParam = params.get("skills");
+    var levelParam = params.get("level");
+    var interestParam = params.get("interest");
+    var timeParam = params.get("time");
+
+    var hasParams = false;
+
+    if (skillsParam) {
+      hasParams = true;
+      try {
+        var parsed = JSON.parse(skillsParam);
+        if (Array.isArray(parsed)) {
+          parsed.forEach(function (skill) {
+            window.addSkill(skill);
+          });
+        } else if (typeof parsed === "string") {
+          parsed.split(",").forEach(function (skill) {
+            window.addSkill(skill.trim());
+          });
+        }
+      } catch (e) {
+        skillsParam.split(",").forEach(function (skill) {
+          window.addSkill(skill.trim());
+        });
+      }
+    }
+
+    if (levelParam) {
+      hasParams = true;
+      var levelEl = document.getElementById("level");
+      if (levelEl) levelEl.value = levelParam;
+    }
+
+    if (interestParam) {
+      hasParams = true;
+      var interestEl = document.getElementById("interest");
+      if (interestEl) interestEl.value = interestParam;
+    }
+
+    if (timeParam) {
+      hasParams = true;
+      var timeEl = document.getElementById("time");
+      if (timeEl) timeEl.value = timeParam;
+    }
+
+    if (hasParams && form) {
+      setTimeout(function () {
+        form.dispatchEvent(new Event("submit"));
+      }, 100);
+    }
+  }
+
+  if (form) {
+    parseUrlQueryParams();
   }
 })();
 


### PR DESCRIPTION
## Summary
This PR implements Issue #761, enabling users to save, bookmark, and share their recommendation results via URL query parameters.

## Root Cause
Previously, whenever a user generated project recommendations, the state was kept in memory only. Refreshing the page or sharing the link with others would reset the form and lose the generated recommendations.

## Changes Made
- `src/static/script.js`:
  - Updated the form submission success handler to encode the selected `skills`, `level`, `interest`, and `time` inputs into the browser address bar as query parameters using `window.history.replaceState` on every generation.
  - Added a `parseUrlQueryParams` function that runs on page load, extracts the query parameters, populates the respective form fields, and automatically triggers the recommendation query to display matching projects.

## How to Test
1. Go to the homepage and search for some skills (e.g. `Python`), select intermediate level, Web interest, and medium time, and click "Generate My Projects".
2. Notice that the URL query parameters update instantly in the address bar (e.g. `?skills=%5B%22python%22%5D&level=Intermediate&interest=Web&time=Medium`).
3. Reload the page. Verify that the form values are restored and the recommendations load automatically on page load.
4. Copy the URL, open a new tab/incognito window, and paste the URL. Verify that it displays the correct search state and recommendations.

Closes #761