### PR TITLE
[BUG]: wrong year is replaced with correct one.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 DevPath Contributors
+Copyright (c) 2026 DevPath Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/templates/compare.html
+++ b/src/templates/compare.html
@@ -222,7 +222,7 @@
 
   <footer class="footer">
     <div class="footer-inner">
-      <p class="footer-copy">&copy; 2025 DevPath. Built for learners.</p>
+      <p class="footer-copy">&copy; 2026 DevPath. Built for learners.</p>
       <ul class="footer-links">
         <li><a href="/">Home</a></li>
         <li><a href="/compare">Compare Roadmaps</a></li>


### PR DESCRIPTION
## Summary [required]

This PR updates outdated 2025 copyright references to 2026 so DevPath’s legal notice and site footer reflect the current year. The change is limited to text updates in `LICENSE` and the compare page footer, with no impact on app logic, routing, or styling.

## Related Issue [required]

Closes #1005 

## Type of Change [required]

- [ ] Bug fix — resolves a broken behaviour
- [ ] Feature — adds new functionality
- [ ] Data — adds new projects to `data/projects.json`
- [x] Documentation — updates docs, README, or code comments only
- [ ] Style — CSS or visual changes only, no logic change
- [ ] Refactor — restructures code without changing behaviour
- [ ] Test — adds or updates tests

## What Was Changed [required]

| File | Change made |
|------|-------------|
| `LICENSE` | Updated copyright year from `2025` to `2026` |
| `src/templates/compare.html` | Updated footer copyright from `© 2025` to `© 2026` |

## How to Test This PR [required]

1. Clone this branch: `git checkout feat/correct_year`
2. Install dependencies: `pip install -r requirements.txt`
3. Open `LICENSE` and confirm it reads: `Copyright (c) 2026 DevPath Contributors`
4. Run the app: `python src/app.py`
5. Open http://127.0.0.1:5000/compare and scroll to the footer — confirm it shows `© 2026 DevPath. Built for learners.`
6. Run the tests: `python tests/test_basic.py`

Expected test output:
77 passed, 0 failed out of 77 tests

## Test Results [required]
PASS test_compare_api PASS test_compare_api_missing_params PASS test_compare_api_not_found PASS test_sitemap_includes_compare

77 passed, 1 failed out of 78 tests

FAIL test_score_coverage_ratio_exact_values: test_score_coverage_ratio_exact_values() missing 1 required positional argument: 'monkeypatch'


> The failing test is pre-existing and unrelated to this PR.

## Screenshots (if UI change)

| Before | After |
|--------|-------|
| Footer shows `© 2025 DevPath` | Footer shows `© 2026 DevPath` |

## Self-Review Checklist [required]

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed all guidelines
- [x] My branch name follows the convention: `feat/`, `fix/`, `docs/`, `data/`, `style/`, `test/`
- [ ] I have run `python tests/test_basic.py` and all 27 tests pass
- [x] I have run `flake8 .` locally and there are no errors
- [x] I have not introduced any `print()` or `console.log()` debug statements
- [x] Every new function I wrote has a docstring
- [x] I have not modified files outside the scope of the linked issue
- [x] If I changed the UI, I tested it at 375px (mobile) and 1280px (desktop)
- [x] If I added a project to the dataset, it has all required JSON fields

## Notes for Reviewer

Align LICENSE and compare page footer with the current year.

- Scope is limited to year/copyright text only — no logic, styling, or routing changes.
- `README.md` already references GSSoC 2026; no change needed there.
- Only `compare.html` contains a hardcoded footer year in templates; other pages do not use a dated copyright line.