### PR TITLE
fix(ui): improve tag visibility and replace read-more with inner scroll

### DIFF
--- a/src/static/script.js
+++ b/src/static/script.js
@@ -614,28 +614,9 @@ updateProfileWidgets();
     title.className = "project-card-title";
     title.textContent = project.title;
 
-    var desc = document.createElement("p");
-    desc.className = "project-card-desc";
-    var descText = document.createElement("span");
-    descText.className = "project-card-desc-text";
-    descText.textContent = truncate(project.description, 120);
-    desc.appendChild(descText);
-
-    if (project.description && project.description.length > 120) {
-      var expanded = false;
-      var readMore = document.createElement("button");
-      readMore.type = "button";
-      readMore.className = "read-more-btn";
-      readMore.textContent = "Read more";
-      readMore.setAttribute("aria-expanded", "false");
-      readMore.addEventListener("click", function () {
-        expanded = !expanded;
-        descText.textContent = expanded ? project.description : truncate(project.description, 120);
-        readMore.textContent = expanded ? "Read less" : "Read more";
-        readMore.setAttribute("aria-expanded", expanded ? "true" : "false");
-      });
-      desc.appendChild(readMore);
-    }
+    var desc = document.createElement("div");
+    desc.className = "project-card-description";
+    desc.textContent = project.description;
 
     var tags = document.createElement("div");
     tags.className = "project-card-tags";

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -2270,6 +2270,56 @@ input[type="text"]:not(.skill-input-wrap input):focus {
   line-height: 1.7;
   flex: 1;
 }
+.project-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 480px;
+}
+
+.project-card-description {
+  flex: 1;
+  overflow-y: auto;
+  max-height: 140px;
+  padding-right: 0.75rem;
+  margin: 1rem 0 1.25rem 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: inherit;
+}
+
+/* Scrollbar styling */
+.project-card-description::-webkit-scrollbar {
+  width: 6px;
+}
+
+.project-card-description::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.project-card-description::-webkit-scrollbar-thumb {
+  background: #d1d5db;
+  border-radius: 3px;
+}
+
+.project-card-description::-webkit-scrollbar-thumb:hover {
+  background: #9ca3af;
+}
+
+/* Firefox scrollbar */
+.project-card-description {
+  scrollbar-width: thin;
+  scrollbar-color: #d1d5db transparent;
+}
+
+/* Dark mode scrollbar */
+[data-theme="dark"] .project-card-description::-webkit-scrollbar-thumb {
+  background: #4a5568;
+}
+
+[data-theme="dark"] .project-card-description::-webkit-scrollbar-thumb:hover {
+  background: #718096;
+}
 
 .project-card-tags {
   display: flex;
@@ -2284,7 +2334,7 @@ input[type="text"]:not(.skill-input-wrap input):focus {
   border-radius: var(--r-full);
 }
 
-.project-tag--skill        { background: var(--indigo-100); color: var(--indigo-700); }
+.project-tag--skill        { background: var(--indigo-100); color:white; }
 .project-tag--time         { background: var(--gray-100);   color: var(--gray-600);   }
 .project-tag--beginner     { background: var(--green-100);  color: #065f46; }
 .project-tag--intermediate { background: var(--yellow-100); color: #78350f; }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h3>Summary</h3><p>This PR resolves issue #1003 by improving the readability of project tags and replacing the expandable "Read More" functionality with a fixed-height, scrollable description area. The update enhances accessibility, maintains consistent project card layouts, and prevents cards from expanding when displaying longer descriptions, resulting in a cleaner and more user-friendly interface.</p><h3>Related Issue</h3><p>Closes #1003</p><h3>Type of Change</h3><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Bug fix — resolves a broken behaviour</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Style — CSS or visual changes only, no logic change</p></li></ul><h3>What Was Changed</h3>
File | Change made
-- | --
src/static/script.js | Removed the Read More/Read Less functionality and displayed project descriptions within a fixed container.
src/static/styles.css | Improved text contrast for project tags and added internal scrolling for long project descriptions.

<h3>Notes for Reviewer</h3><p>Please verify that project tags are clearly readable in both light and dark themes and that long project descriptions scroll within the card without causing layout shifts or changes in card height.</p></body></html><!--EndFragment-->
</body>
</html>