### PR TITLE
fix(ui): improve submit button hover effect (#856)

### DIFF
--- a/src/static/style.css
+++ b/src/static/style.css
@@ -2039,10 +2039,10 @@ input[type="text"]:not(.skill-input-wrap input):focus {
   margin-top: 8px;
 }
 
-.btn-submit:hover {
+.btn-submit:hover:not(:disabled) {
   opacity: 0.93;
-  transform: translateY(-1px);
-  box-shadow: 0 6px 28px rgba(35, 53, 194, 0.42);
+  transform: translateY(-2px);
+  box-shadow: 0 10px 32px rgba(35, 53, 194, 0.6);
 }
 
 .btn-submit:focus-visible {


### PR DESCRIPTION
<!--
  Pull Request Template — DevPath
  --------------------------------
-->

## Summary [required]

This PR improves the hover interaction of the "Generate My Projects" submit button on the homepage. It adds a slight upward movement (`transform: translateY(-2px)`) and a stronger box shadow on hover to make the button pop and feel more interactive, especially for users with lower vision. The `:not(:disabled)` selector was added to ensure the disabled state remains static and unaffected.

## Related Issue [required]

Closes #856

## Type of Change [required]

- [ ] Bug fix — resolves a broken behaviour
- [ ] Feature — adds new functionality
- [ ] Data — adds new projects to `data/projects.json`
- [ ] Documentation — updates docs, README, or code comments only
- [x] Style — CSS or visual changes only, no logic change
- [ ] Refactor — restructures code without changing behaviour
- [ ] Test — adds or updates tests

## What Was Changed [required]

| File | Change made |
|------|-------------|
| `src/static/style.css` | Updated `.btn-submit:hover` to `.btn-submit:hover:not(:disabled)`. Increased `translateY` to `-2px` and strengthened the `box-shadow`. |

## How to Test This PR [required]

1. Clone this branch: `git checkout fix-btn-submit-hover`
2. Run the app: `python src/app.py` (or your local equivalent)
3. Open http://127.0.0.1:5000 and hover over the "Generate My Projects" button on the homepage.
4. Verify the upward lift and drop-shadow on hover. 
5. Verify that when the button is disabled, the hover effect does **not** trigger.

## Test Results [required]

```text
77 passed, 1 failed out of 78 tests

(Note: The single failing test is `test_score_coverage_ratio_exact_values`, which is a pre-existing fixture issue missing a `monkeypatch` argument and is entirely unrelated to this CSS UI enhancement.)
