### PR TITLE
[Fix] #1033 — Code viewer formatting is broken and code is difficult to read

### DIFF
--- a/src/static/script.js
+++ b/src/static/script.js
@@ -930,11 +930,11 @@ updateProfileWidgets();
       var row = document.createElement("div");
       row.className = "code-line";
       var number = document.createElement("span");
-      number.className = "code-line-number";
+      number.className = "line-number";
       number.setAttribute("aria-hidden", "true");
       number.textContent = index + 1;
       var content = document.createElement("span");
-      content.className = "code-line-content";
+      content.className = "line-content";
       content.textContent = line;
       row.appendChild(number);
       row.appendChild(content);
@@ -987,7 +987,7 @@ updateProfileWidgets();
 
   if (btnCopyCode) {
     btnCopyCode.addEventListener("click", function () {
-      var code = Array.prototype.slice.call(codeContentEl.querySelectorAll(".code-line-content"))
+      var code = Array.prototype.slice.call(codeContentEl.querySelectorAll(".line-content"))
         .map(function (line) { return line.textContent; })
         .join("\n");
       if (!code) return;


### PR DESCRIPTION
## Summary
Corrected the CSS classes used inside the starter code viewer rendering function to ensure correct indentation, monospace font sizing, and line numbering alignment.

## Root Cause
In `src/static/script.js`, the code viewer elements were being assigned classes `code-line-number` and `code-line-content`. However, `src/static/style.css` defines formatting rules for `.line-number` and `.line-content` nested inside `.code-line`. This class name mismatch caused the code viewer to fall back to default, unstyled fonts and spacing.

## Changes Made
- `src/static/script.js`: Updated classes to `line-number` and `line-content` in `renderCode(code)` and updated the copy button query selector to query `.line-content`.

## How to Test
1. Navigate to a project details page (e.g. `/project/15`).
2. Click **View Code** to open the starter code modal.
3. Confirm that line numbers are aligned and code is rendered in the correct monospace styling.
4. Verify that copying the code to clipboard using the copy button still copies the correct, unnumbered code text.

## Related Issue
Closes #1033