### PR TITLE
[Fix] #1023 — "Try Different Inputs" button throws scrollIntoView null error

### DIFF
--- a/src/templates/compare.html
+++ b/src/templates/compare.html
@@ -23,7 +23,7 @@
       <div class="nav-links">
         <a href="/" class="nav-link">Home</a>
         <a href="/compare" class="nav-link nav-link--active">Compare</a>
-        <a href="/#find-project" class="nav-link">Find Project</a>
+        <a href="/#the-project" class="nav-link">Find Project</a>
         <a href="/contact" class="nav-link">Contact</a>
         <a href="https://github.com/komalharshita/DevPath" target="_blank" rel="noopener noreferrer"
           class="nav-btn-outline">GitHub</a>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -414,7 +414,7 @@
       <a href="#home" class="nav-mobile-link" role="menuitem">Home</a>
       <a href="#how-it-works" class="nav-mobile-link" role="menuitem">How It Works</a>
       <a href="#features" class="nav-mobile-link" role="menuitem">Features</a>
-      <a href="#find-project" class="nav-mobile-link" role="menuitem">Find Project</a>
+      <a href="#the-project" class="nav-mobile-link" role="menuitem">Find Project</a>
       <a href="/compare" class="nav-mobile-link" role="menuitem">Compare</a>
       <a href="/contact" class="nav-mobile-link" role="menuitem">Contact</a>
       <a href="https://github.com/komalharshita/DevPath" target="_blank" rel="noopener noreferrer"
@@ -826,7 +826,7 @@
           <a href="#the-project" class="feature-card-link">Get starter code</a>
           <p>Download a working template for every project. Skip the blank-page problem and start building immediately.
           </p>
-          <a href="#find-project" class="feature-card-link">Get starter code</a>
+          <a href="#the-project" class="feature-card-link">Get starter code</a>
         </div>
       </div>
     </div>
@@ -1094,7 +1094,7 @@
           </div>
           <h3>No Projects Found</h3>
           <p id="empty-message">Try adjusting your skills or selecting a different interest area.</p>
-          <button class="btn-try-again" onclick="document.getElementById('find-project').scrollIntoView({behavior:'smooth'})">Try Different Inputs</button>
+          <button class="btn-try-again" onclick="document.getElementById('the-project').scrollIntoView({behavior:'smooth'})">Try Different Inputs</button>
         </div>
       </div>
 
@@ -1174,7 +1174,7 @@
           <li><a href="#how-it-works">How It Works</a></li>
           <li><a href="#features">Features</a></li>
           <li><a href="#the-project">Find Project</a></li>
-          <li><a href="#find-project">Find Project</a></li>
+          <li><a href="#the-project">Find Project</a></li>
           <li><a href="/contact">Contact Us</a></li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
Fixed the JavaScript scrollIntoView runtime crash on clicking "Try Different Inputs" after receiving zero project recommendations.

## Root Cause
The "Try Different Inputs" button onclick handler attempted to call `scrollIntoView()` on an element with ID `find-project`. However, the section containing the recommendation form in `index.html` is actually identified by `id="the-project"`. This mismatch caused `document.getElementById('find-project')` to return `null`, resulting in a `TypeError`.

## Changes Made
- `src/templates/index.html`: Updated the onclick scroll handler of `.btn-try-again` to point to `the-project` instead of `find-project`. Updated navigation, feature card, and footer links referencing `#find-project` to `#the-project`.
- `src/templates/compare.html`: Corrected the "Find Project" navigation link reference from `/#find-project` to `/#the-project`.

## How to Test
1. Start the server and navigate to the homepage.
2. Select options that yield no projects (e.g. no skills, DevOps interest).
3. Generate recommendations and wait for the "No Projects Found" state.
4. Click **Try Different Inputs**.
5. Verify that the page scrolls smoothly to the search form without throwing any JavaScript errors in the browser console.

## Related Issue
Closes #1023