### PR TITLE
[Fix] #1022 — ML/AI and DevOps interests return "No Projects Found"

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -463,7 +463,7 @@
       "JavaScript"
     ],
     "level": "Intermediate",
-    "interest": "Data",
+    "interest": "Machine Learning/AI",
     "time": "High",
     "description": "A Flask web app that compares a resume against a job description using TF-IDF similarity and keyword extraction. Users upload a PDF or paste text, and the app returns a match score, a list of missing keywords, and actionable feedback — with no external AI API required.",
     "features": [
@@ -620,7 +620,7 @@
     "title": "File Organiser Script",
     "skills": ["Python"],
     "level": "Beginner",
-    "interest": "Automation",
+    "interest": "Devops",
     "time": "Low",
     "description": "A Python script that scans a folder and automatically sorts files into subfolders by type — images, documents, videos, code files. Great for learning os and shutil modules.",
     "features": [

--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -20,17 +20,6 @@ from utils.learning_path import (
 from config import Config
 import os
 
-# Interest categories that currently have no project recommendations available
-NO_PROJECT_INTERESTS = {
-    "machine learning/ai",
-    "devops",
-    "artificial intelligence",
-    "cloud computing",
-}
-
-def interest_has_no_projects(interest):
-    return interest and interest.strip().lower() in NO_PROJECT_INTERESTS
-
 # Create the Blueprint that app.py will register
 main = Blueprint("main", __name__)
 
@@ -133,11 +122,7 @@ def recommend():
         # Return only the first error to keep the UI message clean
         return jsonify({"error": errors[0]}), 400
 
-    if interest_has_no_projects(interest):
-        return jsonify({
-            "projects": [],
-            "message": "No projects are currently available for this interest area. Please check back later."
-        }), 200
+
 
     recommendations_data = get_recommendations(skills, level, interest, time_availability)
     results = recommendations_data.get("recommendations", [])

--- a/src/utils/recommender.py
+++ b/src/utils/recommender.py
@@ -19,8 +19,15 @@ _CLUSTERS_PATH = os.path.join(
 )
 
 VALID_LEVELS = {"beginner", "intermediate", "advanced"}
-VALID_INTERESTS = {"web", "data", "education", "automation", "games", "cybersecurity", "devops", "backend", "tools", "productivity", "business logic", "mobile", "machine learning/ai"}
+VALID_INTERESTS = {
+    "web", "data", "education", "automation", "games",
+    "cybersecurity", "devops", "mobile", "machine learning/ai",
+    "artificial intelligence", "cloud computing", "mobile app development",
+    "backend", "tools", "productivity", "business logic"
+}
 VALID_TIME_AVAILABILITY = {"low", "medium", "high"}
+VALID_TIMES = {"low", "medium", "high"}
+
 SCORING_WEIGHTS = {
     "skill": 3,
     "level": 2,
@@ -32,14 +39,6 @@ WEIGHT_SKILL = SCORING_WEIGHTS["skill"]
 WEIGHT_LEVEL = SCORING_WEIGHTS["level"]
 WEIGHT_INTEREST = SCORING_WEIGHTS["interest"]
 WEIGHT_TIME = SCORING_WEIGHTS["time"]
-
-VALID_INTERESTS = {
-    "web", "data", "education", "automation", "games",
-    "cybersecurity", "devops", "mobile", "machine learning/ai",
-    "artificial intelligence", "cloud computing", "mobile app development",
-    "backend", "tools", "productivity", "business logic"
-}
-VALID_TIMES = {"low", "medium", "high"}
 
 # Common aliases and abbreviations for skills
 # This improves recommendation accuracy by normalizing user input
@@ -337,6 +336,7 @@ def get_recommendations(skills_string, level, interest, time_availability):
     user_skills = parse_skills(skills_string)
     all_projects = load_all_projects()
     scored_projects = []
+    graph = _load_skill_graph()
     for project in all_projects:
         rule_score = score_single_project(
             project,
@@ -354,7 +354,13 @@ def get_recommendations(skills_string, level, interest, time_availability):
             all_projects,
         )
         final_score = rule_score + similarity_score
-        if final_score > 0:
+        
+        project_skills = [SKILL_ALIASES.get(s.lower(), s.lower()) for s in project.get("skills", [])]
+        matched_skills = sum(1 for skill in user_skills if skill in project_skills)
+        boost = gap_boost(user_skills, project_skills, graph)
+        is_relevant = (matched_skills > 0) or (boost > 0) or (similarity_score >= 0.15)
+        
+        if final_score > 0 and is_relevant:
             scored_projects.append({
                 "project": project,
                 "score": final_score,
@@ -378,13 +384,7 @@ def get_recommendations(skills_string, level, interest, time_availability):
         "progression": progression,
     }
 
-VALID_LEVELS = ["beginner", "intermediate", "advanced"]
-VALID_TIME_AVAILABILITY = ["low", "medium", "high"]
 
-
-VALID_LEVELS = ["beginner", "intermediate", "advanced"]
-VALID_INTERESTS = ["data", "web", "backend", "cybersecurity", "games", "education", "automation"]
-VALID_TIME_AVAILABILITY = ["low", "medium", "high"]
 
 
 def validate_recommendation_inputs(skills, level, interest, time_availability):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -480,20 +480,21 @@ def test_recommend_api_valid():
     assert len(data["projects"]) > 0
 
 
-def test_recommend_api_interest_not_available():
-    """The API should return no projects for blocked interest categories."""
+def test_recommend_api_interest_available():
+    """The API should return recommendations for Machine Learning/AI interest."""
     client = get_client()
     response = client.post("/api/recommend", json={
-        "skills": "Python, JavaScript",
-        "level": "Beginner",
+        "skills": "Python, scikit-learn",
+        "level": "Intermediate",
         "interest": "Machine Learning/AI",
-        "time": "Low"
+        "time": "High"
     })
     assert response.status_code == 200
     data = response.get_json()
-    assert data["projects"] == []
-    assert "message" in data
-    assert "no projects are currently available" in data["message"].lower()
+    assert len(data["projects"]) > 0
+    # Verify we recommend the AI Resume Analyzer
+    titles = [p["title"] for p in data["projects"]]
+    assert "AI Resume Analyzer" in titles
 
 
 def test_recommend_api_missing_field():

--- a/tests/test_no_results_reset.py
+++ b/tests/test_no_results_reset.py
@@ -45,9 +45,9 @@ def client():
 # ---------------------------------------------------------------------------
 
 NO_MATCH_PAYLOAD = {
-    "skills": "Python",
+    "skills": "Fortran",
     "level": "Advanced",
-    "interest": "Machine Learning/AI",
+    "interest": "Games",
     "time": "Low"
 }
 


### PR DESCRIPTION
## Summary
Unblocked and implemented recommendation matching for the `Machine Learning/AI` and `DevOps / Cloud Computing` interest categories, categorizing existing projects appropriately.

## Root Cause
1. In `src/routes/main_routes.py`, interest categories `machine learning/ai`, `devops`, `artificial intelligence`, and `cloud computing` were hard-blocked by `NO_PROJECT_INTERESTS` and immediately returned empty results.
2. In `data/projects.json`, there were no projects classified with `"interest": "Machine Learning/AI"` or `"interest": "Devops"`.
3. In `src/utils/recommender.py`, there were multiple duplicate and conflicting definitions of `VALID_INTERESTS` at the bottom of the file which overrode the valid interests.

## Changes Made
- `src/routes/main_routes.py`: Removed the `NO_PROJECT_INTERESTS` block and removed `interest_has_no_projects` checks in the recommendation route.
- `data/projects.json`: Categorized `AI Resume Analyzer` (id 13) under interest `"Machine Learning/AI"`, and `File Organiser Script` (id 17) under interest `"Devops"`.
- `src/utils/recommender.py`: Cleaned up duplicate and conflicting `VALID_INTERESTS` definitions and consolidated them at the top. Included relevance thresholding to ensure correct empty-state return.
- `tests/test_basic.py` & `tests/test_no_results_reset.py`: Updated tests to assert valid recommendations are returned for Machine Learning/AI, and updated no-match payloads to use non-matching skills (`Fortran` / `Games`).

## How to Test
1. Start the Flask server and submit a query with Python / Intermediate / Machine Learning/AI.
2. Verify that `AI Resume Analyzer` is recommended.
3. Submit a query with Python / Beginner / DevOps / Cloud Computing.
4. Verify that `File Organiser Script` is recommended.
5. Run the test suite using `pytest` to confirm 100% pass rate.

## Related Issue
Closes #1022