### PR TITLE
docs: fix outdated run command in PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -49,7 +49,7 @@ Closes #
 
 1. Clone this branch: `git checkout your-branch-name`
 2. Install dependencies: `pip install -r requirements.txt`
-3. Run the app: `python app.py`
+3. Run the app: `python src/app.py`
 4. Open http://127.0.0.1:5000 and...
 5. Run the tests: `python tests/test_basic.py`
 


### PR DESCRIPTION
## Summary

Fix outdated `python app.py` command in the PR template. The entry point moved to `src/app.py` after the layered architecture refactor.

## Related Issue

Closes #1059

## Type of Change

- [x] Documentation

## What Was Changed

| File | Change made |
|------|-------------|
| `PULL_REQUEST_TEMPLATE.md` | Changed `python app.py` → `python src/app.py` in test instructions |

## GSSoC 2026

This contribution is part of **gssoc26** for GSSoC 2026.