### PR TITLE
docs: fix outdated flake8 command in PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -83,7 +83,7 @@ paste output here
 - [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed all guidelines
 - [ ] My branch name follows the convention: `feat/`, `fix/`, `docs/`, `data/`, `style/`, `test/`
 - [ ] I have run `python tests/test_basic.py` and all 27 tests pass
-- [ ] I have run `flake8 .` locally and there are no errors
+- [ ] I have run `flake8 src/ tests/` locally and there are no errors
 - [ ] I have not introduced any `print()` or `console.log()` debug statements
 - [ ] Every new function I wrote has a docstring
 - [ ] I have not modified files outside the scope of the linked issue


### PR DESCRIPTION
## Summary

Fix outdated `flake8 .` command in the PR template checklist. After the project restructure into `src/`, linting should target only the source and test directories.

## Related Issue

Closes #1061

## Type of Change

- [x] Documentation

## What Was Changed

| File | Change made |
|------|-------------|
| `PULL_REQUEST_TEMPLATE.md` | Changed `flake8 .` → `flake8 src/ tests/` |

## GSSoC 2026

This contribution is part of **gssoc26** for GSSoC 2026.