### PR TITLE
docs: fix outdated run commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ source venv/bin/activate
 
 pip install -r requirements.txt
 
-python app.py
+python src/app.py
 ```
 
 ### Windows Setup
@@ -170,7 +170,7 @@ venv\Scripts\activate
 
 pip install -r requirements.txt
 
-python app.py
+python src/app.py
 ```
 
 ## Verify Everything Works


### PR DESCRIPTION
## Summary

Fix outdated run commands in the README. The entry point has moved to `src/app.py` after the project restructure.

## Related Issue

Closes #1063

## Type of Change

- [x] Documentation

## What Was Changed

| File | Change made |
|------|-------------|
| `README.md` | Changed `python app.py` → `python src/app.py` in both Linux and Windows setup sections |

## GSSoC 2026

This contribution is part of **gssoc26** for GSSoC 2026.