### PR TITLE
docs: fix outdated references in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Required tools:
 
 ```
 devpath/
-|-- app.py                  Entry point. Creates the Flask app. Do not add logic here.
+|-- src/app.py              Entry point. Creates the Flask app. Do not add logic here.
 |-- routes/
 |   |-- main_routes.py      All HTTP routes. Thin — no business logic.
 |-- utils/
@@ -104,7 +104,7 @@ pip install -r requirements.txt
 ### Step 4: Run the app
 
 ```bash
-python app.py
+python src/app.py
 ```
 
 Open http://127.0.0.1:5000 in your browser. You should see the DevPath homepage.


### PR DESCRIPTION
## Summary

Fix outdated references in CONTRIBUTING.md that still point to root-level  after the project restructured into .

## Related Issue

Closes #1065

## Type of Change

- [x] Documentation

## What Was Changed

| File | Change made |
|------|-------------|
| CONTRIBUTING.md | Changed  to  in project structure and run command |

## GSSoC 2026

This contribution is part of **gssoc26** for GSSoC 2026.