### PR TITLE
docs: add missing routes to architecture documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,13 +55,25 @@ Each route handler follows the same pattern:
 
 Routes defined:
 
-| Method | Path                          | Description                       |
-|--------|-------------------------------|-----------------------------------|
-| GET    | `/`                           | Render homepage                   |
-| POST   | `/api/recommend`              | Return matching project JSON      |
-| GET    | `/project/<id>`               | Render project detail page        |
-| GET    | `/project/<id>/code`          | Return starter code content JSON  |
-| GET    | `/project/<id>/download`      | Serve starter code as download    |
+| Method | Path                               | Description                          |
+|--------|------------------------------------|--------------------------------------|
+| GET    | `/`                                | Render homepage                      |
+| GET    | `/contact`                         | Render contact page                  |
+| GET    | `/compare`                         | Render roadmap comparison page       |
+| GET    | `/health`                          | Health check endpoint                |
+| POST   | `/api/recommend`                   | Return matching project JSON         |
+| GET    | `/project/<id>`                    | Render project detail page           |
+| GET    | `/project/<id>/code`               | Return starter code content JSON     |
+| GET    | `/project/<id>/download`           | Serve starter code as download       |
+| GET    | `/api/project/<id>/resources`      | Return project learning resources    |
+| GET    | `/api/roadmaps`                    | List all career roadmaps             |
+| GET    | `/api/compare`                     | JSON comparison data                 |
+| GET    | `/api/search?q=`                   | Search projects by keyword           |
+| GET    | `/sitemap.xml`                     | XML sitemap for SEO                  |
+| GET    | `/robots.txt`                      | Robots exclusion file                |
+| POST   | `/api/learning-path/<path_id>`     | Create a learning path               |
+| GET    | `/api/learning-path/<path_id>`     | Get learning path progress           |
+| PUT    | `/api/learning-path/<path_id>`     | Update learning path progress        |
 
 ---
 


### PR DESCRIPTION
## Summary

Update the route table in `docs/architecture.md` to reflect all 17 routes currently registered in `main_routes.py`. The previous table only listed 5 routes, missing many endpoints that contributors need to know about.

## Related Issue

Closes #1067

## Type of Change

- [x] Documentation

## What Was Changed

| File | Change made |
|------|-------------|
| `docs/architecture.md` | Expanded route table from 5 to 17 entries |

## GSSoC 2026

This contribution is part of **gssoc26** for GSSoC 2026.
