### PR TITLE
docs: fix outdated paths in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,13 +56,13 @@ The following are out of scope:
 
 ### Development server
 
-`python app.py` starts Flask in debug mode. The debug server must never be
+`python src/app.py` starts Flask in debug mode. The debug server must never be
 exposed to the public internet. For production deployment, use a WSGI server
 such as Gunicorn behind a reverse proxy.
 
 ### Path traversal mitigation
 
-The `utils/file_server.py` module uses `os.path.basename()` to strip any
+The `src/utils/file_server.py` module uses `os.path.basename()` to strip any
 directory components from starter code paths before resolving them. This
 prevents a crafted `starter_code` value in `projects.json` from reading
 arbitrary files.


### PR DESCRIPTION
## Summary

Fix outdated file paths in SECURITY.md that still point to root-level files before the `src/` directory restructure.

## Related Issue

Closes #1069

## Type of Change

- [x] Documentation

## What Was Changed

| File | Change made |
|------|-------------|
| `SECURITY.md` | Changed `python app.py` to `python src/app.py` |
| `SECURITY.md` | Changed `utils/file_server.py` to `src/utils/file_server.py` |

## GSSoC 2026

This contribution is part of **gssoc26** for GSSoC 2026.
