### PR TITLE
docs: fix error handler description in architecture documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,7 @@ The entry point. Its only jobs are:
 
 - Create the Flask app instance
 - Register the `main` Blueprint from `routes/`
-- Register the 404 and 500 error handlers
+- Register error handlers for 400, 403, 404, 405, 429, 500, and an unhandled Exception catch-all
 - Start the dev server when run directly
 
 No business logic, no data access, no file handling.


### PR DESCRIPTION
## Summary

Fix inaccurate error handler description in the architecture documentation. The doc claimed only 404 and 500 handlers were registered, but the app actually registers 6 specific HTTP error handlers plus an unhandled Exception catch-all.

## Related Issue

Closes #1071

## Type of Change

- [x] Documentation

## What Was Changed

| File | Change made |
|------|-------------|
| `docs/architecture.md` | Updated error handler registration description to list all 7 handlers |

## GSSoC 2026

This contribution is part of **gssoc26** for GSSoC 2026.
