### PR TITLE
fix: redundant ternary condition in bookmarks.js saved count display

### DIFF
--- a/src/static/bookmarks.js
+++ b/src/static/bookmarks.js
@@ -139,7 +139,7 @@ var DevPathBookmarks = (function () {
     if (!list || !count || !panel) return;
 
     var saved = getSaved();
-    count.textContent = saved.length + (saved.length === 1 ? " saved" : " saved");
+    count.textContent = saved.length + (saved.length === 1 ? " project saved" : " projects saved");
 
     // Show panel only when there is at least one saved project
     panel.style.display = saved.length ? "block" : "none";


### PR DESCRIPTION
## Summary

Fixed a redundant ternary in `bookmarks.js` where both branches returned the identical string `" saved"`. The new code displays grammatically correct output: "1 project saved" for singular and "N projects saved" for plural.

## Related Issue

Closes #1075

## Type of Change

- [x] Bug fix — resolves a broken behaviour

## What Was Changed

| File | Change made |
|------|-------------|
| `src/static/bookmarks.js` | Fixed ternary to use "project saved" / "projects saved" instead of identical " saved" / " saved" |

## GSSoC 2026

This contribution is part of **gssoc26** for GSSoC 2026.
