### PR TITLE
fix: redundant ternary condition in bookmarks.js saved count display

### DIFF
--- a/src/static/bookmarks.js
+++ b/src/static/bookmarks.js
@@ -139,8 +139,7 @@ var DevPathBookmarks = (function () {
     if (!list || !count || !panel) return;
 
     var saved = getSaved();
-    count.textContent = saved.length + (saved.length === 1 ? " saved" : " saved");
-
+    count.textContent = saved.length === 1 ? "1 project saved" : `${saved.length} projects saved`;
     // Show panel only when there is at least one saved project
     panel.style.display = saved.length ? "block" : "none";
 


### PR DESCRIPTION
## Summary

This PR fixes a redundant ternary condition in `src/static/bookmarks.js` where both branches returned the same string (`" saved"`), making the conditional logic unnecessary.

Additionally, the saved projects counter has been updated to display grammatically correct text based on the number of saved projects:

- `1 project saved`
- `N projects saved`

This improves the clarity and readability of the saved projects panel without affecting any existing functionality.

## Related Issue

Closes #1075

## Type of Change

- [x] Bug fix — resolves a broken behaviour
- [ ] Feature — adds new functionality
- [ ] Data — adds new projects to `data/projects.json`
- [ ] Documentation — updates docs, README, or code comments only
- [ ] Style — CSS or visual changes only, no logic change
- [ ] Refactor — restructures code without changing behaviour
- [ ] Test — adds or updates tests

## What Was Changed

| File | Change made |
|------|-------------|
| `src/static/bookmarks.js` | Removed the redundant ternary condition and updated the saved project count display to use proper singular/plural grammar (`1 project saved` vs `N projects saved`). |

## How to Test This PR

1. Checkout this branch.
2. Run the application locally.
3. Save one project.
4. Verify the counter displays: `1 project saved`.
5. Save additional projects.
6. Verify the counter displays: `2 projects saved`, `3 projects saved`, etc.
7. Remove saved projects and verify the counter updates correctly.

### Expected Result

The saved projects count should display grammatically correct text for both singular and plural values.

## Test Results

```text
Manually tested:

✓ 1 project saved
✓ Multiple projects saved
✓ Count updates correctly when projects are removed
```

## Self-Review Checklist

- [x] I have read CONTRIBUTING.md and followed all guidelines
- [x] My branch name follows the convention: `fix/`
- [ ] I have run `python tests/test_basic.py` and all 27 tests pass
- [ ] I have run `flake8 .` locally and there are no errors
- [x] I have not introduced any `print()` or `console.log()` debug statements
- [x] I have not modified files outside the scope of the linked issue
- [x] If I changed the UI, I tested it at 375px (mobile) and 1280px (desktop)
- [ ] If I added a project to the dataset, it has all required JSON fields

## Notes for Reviewer

This is a small UI text improvement that removes unnecessary conditional logic and ensures the saved projects counter displays clear and grammatically correct text for both singular and plural counts.