### PR TITLE
feat: add configurable rate limiting to recommend API

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,0 +1,1 @@
+RECOMMEND_RATE_LIMIT=60 per minute

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,9 @@
 #   pip install -r requirements.txt pytest
 
 # Web framework (only runtime dependency)
-Flask==3.0.3
+Flask==3.1.3
 
 # Testing (optional but recommended for contributors)
 pytest==8.2.2
 flake8==7.0.0
+Flask-Limiter==3.12

--- a/src/app.py
+++ b/src/app.py
@@ -20,15 +20,23 @@ from flask import Flask
 from routes.main_routes import main
 from config import Config
 from errors.handlers import register_error_handlers
-
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 app = Flask(__name__)
 
 # Load config settings into Flask's internal config manager properly
 app.config.from_object(Config)
+# Configure request rate limiting
+limiter = Limiter(
+    key_func=get_remote_address,
+    default_limits=[],
+)
 
+limiter.init_app(app)
 # Register all routes defined in the main Blueprint (This handles your '/' route!)
 app.register_blueprint(main)
-
+# Make limiter accessible from the Blueprint module if needed
+app.limiter = limiter
 # Register the global error boundary (handles 400, 403, 404, 405, 429, 500,
 # and any unhandled Exception).  Must be called after Blueprint registration
 # so Blueprint-level error handlers take precedence where defined.

--- a/src/config.py
+++ b/src/config.py
@@ -6,25 +6,35 @@
 
 import os
 
+
 class Config:
     """Base configuration class with sensible defaults."""
-    
+
     # Base URL for the application - used for OG tags and canonical URLs
     # Can be overridden via environment variable for different deployments
     BASE_URL = os.getenv("BASE_URL", "https://mydevpath-github.vercel.app")
-    
+
     # Application metadata for OG tags
     SITE_NAME = "DevPath"
-    SITE_DESCRIPTION = "Get personalized coding project recommendations with step-by-step roadmaps and starter code."
-    
+    SITE_DESCRIPTION = (
+        "Get personalized coding project recommendations "
+        "with step-by-step roadmaps and starter code."
+    )
+
     # OG image path (relative to static folder)
     OG_IMAGE_PATH = "/static/og-banner.png"
-    
+
+    # Rate limit for recommendation API
+    RECOMMEND_RATE_LIMIT = os.getenv(
+        "RECOMMEND_RATE_LIMIT",
+        "30 per minute",
+    )
+
     @classmethod
     def get_og_image_url(cls):
         """Return the full URL for the OG banner image."""
         return f"{cls.BASE_URL.rstrip('/')}{cls.OG_IMAGE_PATH}"
-    
+
     @classmethod
     def get_base_url(cls):
         """Return the base URL without trailing slash."""

--- a/src/extensions.py
+++ b/src/extensions.py
@@ -1,0 +1,7 @@
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+
+limiter = Limiter(
+    key_func=get_remote_address,
+    default_limits=[],
+)

--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -18,8 +18,8 @@ from utils.learning_path import (
     AuthorizationError,
 )
 from config import Config
+from extensions import limiter
 import os
-
 # Interest categories that currently have no project recommendations available
 NO_PROJECT_INTERESTS = {
     "machine learning/ai",
@@ -100,6 +100,7 @@ def health_check():
 
 
 @main.route("/api/recommend", methods=["POST"])
+@limiter.limit(Config.RECOMMEND_RATE_LIMIT)
 def recommend():
     """
     Accept a JSON body with user inputs and return matching project recommendations.


### PR DESCRIPTION
### Summary
Adds rate limiting protection to the /api/recommend endpoint using Flask-Limiter.

### Changes
- Added Flask-Limiter integration via extensions.py
- Applied configurable rate limits to /api/recommend
- Added RECOMMEND_RATE_LIMIT configuration with a default of 30 requests/minute
- Leveraged existing 429 handlers to return JSON responses for API clients

### Outcome
Prevents API abuse, improves backend stability, and makes the endpoint safer for public usage and GSSoC traffic.


added env.example 