### PR TITLE
Fix skills dropdown UI overlap issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,4 +20,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- No fixes recorded yet
+- Correct skills suggestions dropdown overlapping with available skill chips and resolve white background conflict in dark theme

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -1682,6 +1682,11 @@ html[data-theme="dark"] .theme-toggle-label::before {
   margin-bottom: 24px;
 }
 
+.form-group-skills {
+  position: relative;
+  z-index: 100;
+}
+
 .form-row {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -1834,54 +1839,57 @@ label {
 .skills-dropdown .suggestion-item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
+  position: relative;
+  border-left: 3px solid transparent;
+  transition: border-color 0.15s ease, background 0.15s ease;
 }
 
+/* Hidden by default — no visible checkbox for unselected items */
 .skills-dropdown .suggestion-item::before {
   content: '';
-  display: inline-block;
-  width: 16px;
-  height: 16px;
-  border: 1.5px solid var(--gray-300);
-  border-radius: 3px;
-  flex-shrink: 0;
-  transition: all 0.15s ease;
+  display: none;
 }
 
+/* Show a filled indigo checkmark dot when the item is selected */
 .skills-dropdown .suggestion-item.selected::before {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
   background: var(--indigo-600);
-  border-color: var(--indigo-600);
-  box-shadow: inset 0 0 0 2px var(--white);
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 
 .skills-dropdown .suggestion-item:hover {
   background: var(--indigo-50);
+  border-left-color: var(--indigo-400);
 }
 
 /*suggestions dropdown*/
-/* Suggestions dropdown */
+/* Suggestions dropdown container */
 .skills-suggestions {
   position: absolute;
   top: 100%;
   left: 0;
   right: 0;
   background: var(--surface);
-  border: 1.5px solid var(--indigo-100);
-  border-top: none;
+  border: 1.5px solid var(--indigo-200);
+  border-top: 2px solid var(--indigo-400);
   border-radius: 0 0 var(--r-sm) var(--r-sm);
   margin-top: -1px;
-  max-height: 280px;
+  max-height: 240px;
   overflow-y: auto;
   z-index: 1000;
   display: none;
-  box-shadow: 0 8px 24px rgba(79, 110, 247, 0.15);
+  box-shadow: 0 8px 20px rgba(79, 110, 247, 0.12), 0 2px 6px rgba(0, 0, 0, 0.06);
 }
 
 .suggestion-item {
-  padding: 12px 14px;
+  padding: 8px 14px;
   cursor: pointer;
   transition: background 0.15s ease, color 0.15s ease;
-  font-size: 0.9rem;
+  font-size: 0.875rem;
   color: var(--gray-700);
   border-bottom: 1px solid var(--gray-100);
 }
@@ -1894,7 +1902,8 @@ label {
 .suggestion-item--active {
   background: var(--indigo-50);
   color: var(--indigo-700);
-  font-weight: 500;
+  font-weight: 600;
+  border-left-color: var(--indigo-500);
 }
 
 /* Scrollbar styling for suggestions dropdown */

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -859,7 +859,7 @@
             </div>
             <button type="button" class="share-prefill-banner-close" id="share-prefill-banner-close" aria-label="Dismiss banner">&times;</button>
           </div>
-            <div class="form-group">
+            <div class="form-group form-group-skills">
               <div class="form-label-row" style="display: flex; justify-content: space-between; align-items: flex-end; margin-bottom: 8px;">
                 <label for="skills-input">
                   Your Skills
@@ -904,7 +904,7 @@
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"></polyline></svg>
                   </button>
                 </div>
-                <div id="skills-suggestions" class="skills-suggestions skills-dropdown" style="display: none; max-height: 250px; overflow-y: auto; border: 1px solid var(--color-border); border-top: none; background: white; position: absolute; width: 100%; margin-top: -2px; z-index: 10;"></div>
+                <div id="skills-suggestions" class="skills-suggestions skills-dropdown"></div>
 
               </div>
               <input type="hidden" id="skills" name="skills" />


### PR DESCRIPTION
## Summary

When a user opens the **Your Skills** dropdown on the homepage form, the suggestion list was rendering behind the available skill chip buttons (Python, JavaScript, etc.), causing them to visually overlap and making skill selection confusing and unusable. The root cause was a two-part CSS layering issue: (1) the `.form-group` container wrapping the skills input had no explicit stacking context, so the adjacent `.skill-chips-row` — which gains a stacking context from the entry animation's `transform: translate3d()` — painted over the dropdown; (2) the `#skills-suggestions` element carried inline styles (`background: white; z-index: 10;`) that overrode the correct themed stylesheet values, breaking dark-mode and keeping `z-index` too low. This PR fixes the stacking context, removes the conflicting inline overrides, and polishes the dropdown's visual design.

## Related Issue

Closes #

## Type of Change

- [x] Bug fix — resolves a broken behaviour
- [x] Style — CSS or visual changes only, no logic change

## What Was Changed

| File | Change made |
|------|-------------|
| `src/templates/index.html` | Added `form-group-skills` class to the skills form group; removed all inline styles from `#skills-suggestions` so stylesheet properties (`z-index: 1000`, `background: var(--surface)`) apply correctly |
| `src/static/style.css` | Added `.form-group-skills` rule (`position: relative; z-index: 100`) to fix stacking context; polished dropdown items — removed empty checkbox squares, reduced padding from `12px` to `8px`, added left-border hover accent; updated container with visible indigo top border |
| `CHANGELOG.md` | Added entry under `### Fixed` documenting the dropdown overlap and dark-mode background conflict |

## How to Test This PR

1. `git checkout fix/skills-dropdown-overlap`
2. `pip install -r requirements.txt`
3. `python src/app.py`
4. Open http://127.0.0.1:5000 and scroll to **Find The Project**
5. Click the **▾ dropdown button** on the Your Skills input
6. Verify the list appears **above** all skill chips with no overlap
7. Hover an item — confirm the indigo left-border accent appears
8. Click a skill — confirm the chip is added and the item is removed from the list
9. `python -m pytest tests/`

## Test Results

============================= test session starts ============================= platform win32 -- Python 3.14.5, pytest-8.2.2, pluggy-1.6.0 rootdir: C:\Users\malla_8ojbljk\OneDrive\Desktop\DevPath collected 281 items

tests\test_basic.py .................................................... [ 18%] ............................ [ 28%] tests\test_bookmarks.py ................................ [ 39%] tests\test_error_handling.py ......................... [ 48%] tests\test_learning_path.py ........................................ [ 62%] tests\test_no_results_reset.py .................. [ 69%] tests\test_og_tags.py ................... [ 76%] tests\test_progress_calculation.py .......................... [ 85%] tests\test_resource_url_validation.py .................................. [ 97%] ....... [100%]

============================= 281 passed in 8.91s =============================

## Screenshots (if UI change)

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="300" src="https://github.com/user-attachments/assets/4c458b0c-3a2f-42ec-83ef-e693471ca21f" /></td>
    <td><img width="300" src="https://github.com/user-attachments/assets/91264c58-0c6a-4431-8ff5-60a7c6308a91" /></td>
  </tr>
  <tr>
    <td>Dropdown hidden behind skill chips; white background in dark mode</td>
    <td>Dropdown floats above all elements; compact rows with indigo hover accent</td>
  </tr>
</table>


## Self-Review Checklist

- [x] I have read CONTRIBUTING.md and followed all guidelines
- [x] My branch name follows the convention: `fix/skills-dropdown-overlap`
- [x] I have run `python -m pytest tests/` and all **281 tests pass**
- [x] I have not introduced any `print()` or `console.log()` debug statements
- [x] I have not modified files outside the scope of the linked issue
- [x] I tested the UI at both 375px (mobile) and 1280px (desktop)

## Notes for Reviewer

Fix is intentionally minimal — no JavaScript was changed. The two changes work together: `.form-group-skills { position: relative; z-index: 100; }` creates a stacking context above the animated chip row, and removing the inline `style` attribute from `#skills-suggestions` lets the existing CSS rule (`z-index: 1000`, `background: var(--surface)`) take effect — which also fixes the white-background-in-dark-mode regression those inline styles caused.
