### PR TITLE
style: update read more/read less button styling

### DIFF
--- a/src/static/style.css
+++ b/src/static/style.css
@@ -2271,6 +2271,34 @@ input[type="text"]:not(.skill-input-wrap input):focus {
   flex: 1;
 }
 
+.read-more-btn {
+  display: inline;
+  background: none;
+  border: none;
+  padding: 0;
+  margin-left: 4px;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: 600;
+  color: var(--indigo-500);
+  cursor: pointer;
+  text-decoration: none;
+  transition: color var(--t);
+}
+
+.read-more-btn:hover {
+  color: var(--indigo-700);
+  text-decoration: underline;
+}
+
+[data-theme="dark"] .read-more-btn {
+  color: #818cf8;
+}
+
+[data-theme="dark"] .read-more-btn:hover {
+  color: #a5b4fc;
+}
+
 .project-card-tags {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary

This PR styles the dynamically generated "Read more" and "Read less" buttons within the project recommendation cards. Previously, these buttons rendered with browser-default styling (gray backgrounds, borders, and system fonts). They have been redesigned to match website aesthetic.

## Related Issue
Closes #1108 

## Type of Change 

<!-- Check all that apply. -->
- [x] Style — CSS or visual changes only, no logic change


## What Was Changed 
| File | Change made |
|------|-------------|
| `src/static/style.css` | Added base class styling for .read-more-btn |


## How to Test This PR

1. Clone this branch: git checkout fix/read-more-button-styling
2. Install dependencies: pip install -r requirements.txt
3. Run the development server: python src/app.py
4. Open http://127.0.0.1:5000/ and generate recommendations where project descriptions are longer than 120 characters (e.g. Weather Dashboard or Flashcard Study App).
5. Verify the "Read more" link flows naturally with the card description. Click it to confirm the "Read less" toggle has matching aesthetics

## Screenshots (if UI change)

| Before | After |
|--------|-------|
|<img width="1515" height="652" alt="Screenshot 2026-06-22 235824" src="https://github.com/user-attachments/assets/c726f972-782b-40ba-8884-42edc0f34879" />| <img width="1131" height="422" alt="Screenshot 2026-06-23 004055" src="https://github.com/user-attachments/assets/6478d303-49df-420f-a3c8-f5ccb98db6f0" />|

## Self-Review Checklist [required]

<!-- Complete every item before requesting review. -->
<!-- Do not submit a PR you would not approve yourself. -->

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed all guidelines
- [x] My branch name follows the convention: `feat/`, `fix/`, `docs/`, `data/`, `style/`, `test/`
- [x] I have not introduced any `print()` or `console.log()` debug statements
- [x] I have not modified files outside the scope of the linked issue
- [x] If I changed the UI, I tested it at 375px (mobile) and 1280px (desktop)




