### PR TITLE
Feature/issue 1088

### DIFF
--- a/src/static/recently-viewed.js
+++ b/src/static/recently-viewed.js
@@ -1,0 +1,213 @@
+/**
+ * static/recently-viewed.js
+ * Recently Viewed Projects tracking utility for DevPath.
+ *
+ * Responsibilities
+ * ----------------
+ * 1. Track project views - record when users click on or visit projects
+ * 2. Persist data - store in localStorage across browser sessions
+ * 3. Deduplication - if same project viewed again, move to top, don't duplicate
+ * 4. Render panel - display up to 5 most recent projects
+ * 5. Clear history - remove all tracked projects
+ *
+ * Public API
+ * ----------
+ * RecentlyViewed.trackView(project)    – track a project view
+ * RecentlyViewed.getRecentlyViewed()   – get array of all tracked projects
+ * RecentlyViewed.isTracked(id)         – boolean check if project is tracked
+ * RecentlyViewed.clearHistory()        – remove all tracked projects
+ * RecentlyViewed.renderPanel()         – redraw the recently viewed panel
+ */
+
+var RecentlyViewed = (function () {
+  "use strict";
+
+  /* ------------------------------------------------------------------ */
+  /* Constants                                                            */
+  /* ------------------------------------------------------------------ */
+  var STORAGE_KEY = "devpathRecentlyViewed";
+  var MAX_ITEMS = 10;           // Store max 10 items in localStorage
+  var DISPLAY_ITEMS = 5;        // Display max 5 in UI
+  var PANEL_ID = "recently-viewed-panel";
+  var LIST_ID = "recently-viewed-list";
+
+  /* ------------------------------------------------------------------ */
+  /* Safe localStorage helpers                                            */
+  /* ------------------------------------------------------------------ */
+  function lsGet(key) {
+    try {
+      return JSON.parse(localStorage.getItem(key) || "null");
+    } catch (err) {
+      console.warn("[RecentlyViewed] localStorage read error:", err);
+      return null;
+    }
+  }
+
+  function lsSet(key, value) {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+      return true;
+    } catch (err) {
+      console.warn("[RecentlyViewed] localStorage write error:", err);
+      return false;
+    }
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Time formatting utilities                                            */
+  /* ------------------------------------------------------------------ */
+  function formatTimeAgo(timestamp) {
+    if (!timestamp) return "Recently viewed";
+
+    var now = Date.now();
+    var diff = now - timestamp;
+    var seconds = Math.floor(diff / 1000);
+    var minutes = Math.floor(seconds / 60);
+    var hours = Math.floor(minutes / 60);
+    var days = Math.floor(hours / 24);
+
+    if (seconds < 60) return "Just now";
+    if (minutes < 60) return minutes + " min ago";
+    if (hours < 24) return hours + " hour" + (hours > 1 ? "s" : "") + " ago";
+    if (days === 1) return "Yesterday";
+    if (days < 7) return days + " days ago";
+    if (days < 30) return Math.floor(days / 7) + " weeks ago";
+
+    // Format as date for older items
+    var date = new Date(timestamp);
+    return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Recently Viewed Data Management                                      */
+  /* ------------------------------------------------------------------ */
+  function getRecentlyViewed() {
+    var data = lsGet(STORAGE_KEY);
+    return Array.isArray(data) ? data : [];
+  }
+
+  function isTracked(projectId) {
+    return getRecentlyViewed().some(function (p) {
+      return String(p.id) === String(projectId);
+    });
+  }
+
+  function trackView(project) {
+    if (!project || !project.id) return false;
+
+    var projectId = project.id;
+    var viewed = getRecentlyViewed();
+
+    // Check if already tracked - if so, remove old entry and re-add at top
+    viewed = viewed.filter(function (p) {
+      return String(p.id) !== String(projectId);
+    });
+
+    // Add to top with current timestamp
+    var newEntry = {
+      id: projectId,
+      title: project.title || "Project " + projectId,
+      interest: project.interest || "General",
+      timestamp: Date.now()
+    };
+
+    viewed.unshift(newEntry);
+
+    // Keep only the last MAX_ITEMS
+    if (viewed.length > MAX_ITEMS) {
+      viewed = viewed.slice(0, MAX_ITEMS);
+    }
+
+    lsSet(STORAGE_KEY, viewed);
+    renderPanel();
+    return true;
+  }
+
+  function clearHistory() {
+    lsSet(STORAGE_KEY, []);
+    renderPanel();
+    return true;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Rendering                                                            */
+  /* ------------------------------------------------------------------ */
+  function renderPanel() {
+    var panel = document.getElementById(PANEL_ID);
+    if (!panel) return;
+
+    var viewed = getRecentlyViewed();
+    var list = document.getElementById(LIST_ID);
+
+    if (!list) return;
+
+    // Clear the list
+    list.innerHTML = "";
+
+    // If no recently viewed projects, hide the panel or show empty state
+    if (viewed.length === 0) {
+      panel.style.display = "none";
+      return;
+    }
+
+    panel.style.display = "block";
+
+    // Show only the first DISPLAY_ITEMS
+    var displayItems = viewed.slice(0, DISPLAY_ITEMS);
+
+    displayItems.forEach(function (project) {
+      var card = buildProjectCard(project);
+      list.appendChild(card);
+    });
+  }
+
+  function buildProjectCard(project) {
+    var card = document.createElement("div");
+    card.className = "recently-viewed-card";
+    card.setAttribute("data-project-id", project.id);
+
+    var link = document.createElement("a");
+    link.href = "/project/" + project.id;
+    link.className = "recently-viewed-link";
+
+    var title = document.createElement("div");
+    title.className = "recently-viewed-title";
+    title.textContent = project.title;
+
+    var meta = document.createElement("div");
+    meta.className = "recently-viewed-meta";
+
+    var interest = document.createElement("span");
+    interest.className = "recently-viewed-interest";
+    interest.textContent = project.interest;
+
+    var time = document.createElement("span");
+    time.className = "recently-viewed-time";
+    time.textContent = formatTimeAgo(project.timestamp);
+
+    meta.appendChild(interest);
+    meta.appendChild(time);
+
+    link.appendChild(title);
+    link.appendChild(meta);
+
+    card.appendChild(link);
+    return card;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Public API                                                            */
+  /* ------------------------------------------------------------------ */
+  return {
+    trackView: trackView,
+    getRecentlyViewed: getRecentlyViewed,
+    isTracked: isTracked,
+    clearHistory: clearHistory,
+    renderPanel: renderPanel
+  };
+})();
+
+// Initialize on DOM ready
+document.addEventListener("DOMContentLoaded", function () {
+  RecentlyViewed.renderPanel();
+});

--- a/src/static/recently_viewed.css
+++ b/src/static/recently_viewed.css
@@ -1,0 +1,210 @@
+/**
+ * static/recently-viewed.css
+ * Styling for the Recently Viewed Projects panel.
+ * Matches the design of the saved projects panel for consistency.
+ */
+
+/* Recently Viewed Panel Container */
+.recently-viewed-panel {
+  margin-bottom: 2rem;
+  padding: 1.5rem;
+  background: var(--card-bg, #ffffff);
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 1rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.recently-viewed-panel[style*="display: none"] {
+  display: none !important;
+}
+
+/* Header with title and count */
+.recently-viewed-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border, #e5e7eb);
+}
+
+.recently-viewed-header > div {
+  flex: 1;
+}
+
+.recently-viewed-header h3 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin: 0 0 0.25rem 0;
+  color: var(--text-heading, #1f2937);
+}
+
+.recently-viewed-header p {
+  font-size: 0.875rem;
+  color: var(--text-muted, #6b7280);
+  margin: 0;
+}
+
+.recently-viewed-count {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-muted, #6b7280);
+  white-space: nowrap;
+}
+
+/* List of recently viewed cards */
+.recently-viewed-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* Individual recently viewed card */
+.recently-viewed-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.recently-viewed-link {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+  background: var(--gray-50, #f9fafb);
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 0.75rem;
+  text-decoration: none;
+  color: inherit;
+  transition: all 0.2s ease;
+  cursor: pointer;
+}
+
+.recently-viewed-link:hover {
+  background: var(--gray-100, #f3f4f6);
+  border-color: var(--accent, #6366f1);
+  box-shadow: 0 4px 12px rgba(99, 102, 241, 0.1);
+  transform: translateY(-2px);
+}
+
+/* Title of recently viewed project */
+.recently-viewed-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-heading, #1f2937);
+  margin: 0 0 0.75rem 0;
+  word-break: break-word;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* Meta information (interest + time) */
+.recently-viewed-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.recently-viewed-interest {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #6366f1;
+  background: rgba(99, 102, 241, 0.1);
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  text-transform: capitalize;
+  white-space: nowrap;
+}
+
+.recently-viewed-time {
+  font-size: 0.75rem;
+  color: var(--text-muted, #6b7280);
+  white-space: nowrap;
+}
+
+/* Dark mode support */
+[data-theme="dark"] .recently-viewed-panel {
+  background: var(--card-bg-dark, #1f2937);
+  border-color: var(--border-dark, #374151);
+}
+
+[data-theme="dark"] .recently-viewed-link {
+  background: var(--gray-700, #374151);
+  border-color: var(--border-dark, #4b5563);
+}
+
+[data-theme="dark"] .recently-viewed-link:hover {
+  background: var(--gray-600, #4b5563);
+  border-color: var(--accent, #818cf8);
+  box-shadow: 0 4px 12px rgba(129, 140, 248, 0.2);
+}
+
+[data-theme="dark"] .recently-viewed-title {
+  color: var(--text-light, #f3f4f6);
+}
+
+[data-theme="dark"] .recently-viewed-meta {
+  color: var(--text-muted-dark, #9ca3af);
+}
+
+[data-theme="dark"] .recently-viewed-interest {
+  background: rgba(129, 140, 248, 0.15);
+  color: #a5b4fc;
+}
+
+[data-theme="dark"] .recently-viewed-time {
+  color: var(--text-muted-dark, #9ca3af);
+}
+
+/* Mobile responsiveness */
+@media (max-width: 768px) {
+  .recently-viewed-list {
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 0.75rem;
+  }
+
+  .recently-viewed-header {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .recently-viewed-count {
+    align-self: flex-start;
+  }
+
+  .recently-viewed-link {
+    padding: 0.75rem;
+  }
+
+  .recently-viewed-title {
+    font-size: 0.875rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .recently-viewed-meta {
+    font-size: 0.7rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .recently-viewed-list {
+    grid-template-columns: 1fr;
+  }
+
+  .recently-viewed-link {
+    padding: 1rem;
+  }
+
+  .recently-viewed-meta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
+}

--- a/src/static/script.js
+++ b/src/static/script.js
@@ -665,6 +665,12 @@ updateProfileWidgets();
     link.className = "btn-details";
     link.textContent = "View Full Project";
     link.href = "/project/" + project.id;
+    
+    link.addEventListener("click", function() {
+      if (typeof RecentlyViewed !== "undefined") {
+        RecentlyViewed.trackView(project);
+      }
+    });
     footer.appendChild(link);
 
     card.appendChild(title);
@@ -774,9 +780,11 @@ updateProfileWidgets();
     clearAllErrors();
     hideSuggestions();
     resultsSection.style.display = "none";
+    if (typeof RecentlyViewed !== "undefined") {
+    RecentlyViewed.clearHistory();
+    }
     if (skillsInput) skillsInput.focus();
-  }
-
+  }  
   var clearBtn = document.getElementById("clear-filters-btn");
   if (clearBtn) {
     clearBtn.addEventListener("click", resetFormAndState);
@@ -911,6 +919,17 @@ updateProfileWidgets();
 (function initDetailPage() {
   if (typeof PROJECT_ID === "undefined") return;
   recordProjectView();
+  
+if (typeof RecentlyViewed !== "undefined") {
+  var projectTitle = typeof PROJECT_TITLE !== "undefined" ? PROJECT_TITLE : "Project " + PROJECT_ID;
+  var projectInterest = document.querySelector("[data-project-interest]");
+  var interest = projectInterest ? projectInterest.getAttribute("data-project-interest") : "General";
+  RecentlyViewed.trackView({
+    id: PROJECT_ID,
+    title: projectTitle,
+    interest: interest
+  });
+  }
 
   var codePanel = document.getElementById("code-panel");
   var codePanelOverlay = document.getElementById("code-panel-overlay");

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -58,6 +58,7 @@
   {% include 'partials/theme_head.html' %}
   <link rel="stylesheet" href="/static/style.css" />
   <link rel="stylesheet" href="/static/bookmarks.css" />
+  <link rel="stylesheet" href="/static/recently-viewed.css" />
   <link
     href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@400;500;600&display=swap"
     rel="stylesheet" />
@@ -1100,6 +1101,17 @@
 
       <div class="results-grid" id="results-grid"></div>
 
+      <div class="recently-viewed-panel" id="recently-viewed-panel">
+        <div class="recently-viewed-header">
+          <div>
+            <h3>Recently Viewed</h3>
+            <p>Projects you've checked out recently.</p>
+          </div>
+          <span class="recently-viewed-count" id="recently-viewed-count">0 viewed</span>
+        </div>
+        <div class="recently-viewed-list" id="recently-viewed-list"></div>
+      </div>
+
       <div class="saved-projects-panel" id="saved-projects-panel">
         <div class="saved-projects-header">
           <div>
@@ -1270,6 +1282,7 @@
 
   <script src="/static/script.js"></script>
   <script src="/static/bookmarks.js"></script>
+  <script src="/static/recently-viewed.js"></script>
   
   <script>
     // Tab switching for leaderboard/achievements (adds to your existing JS)


### PR DESCRIPTION
## Summary [required]

This PR implements the "Recently Viewed Projects" feature for DevPath (Issue #1088). Users can now track which projects they've viewed, with the 5 most recent projects displayed in a dedicated panel on the homepage. The feature uses browser localStorage for persistence, deduplicates projects (revisits move to top), and clears when filters are reset. The UI matches the existing saved projects styling with full dark/light mode and mobile responsiveness support.

## Related Issue [required]

Closes #1088

## Type of Change [required]

- [x] Feature — adds new functionality

## What Was Changed [required]

| File | Change made |
|------|-------------|
| `src/static/recently-viewed.js` | NEW: Core tracking logic, localStorage management, deduplication, time formatting, and panel rendering (213 lines) |
| `src/static/recently-viewed.css` | NEW: Responsive styling for recently viewed panel with dark/light mode support (210 lines) |
| `src/templates/index.html` | Modified: Added CSS link, HTML panel markup for recently viewed section, and script import |
| `src/static/script.js` | Modified: Added 3 integration points - track card clicks, track detail page views, and clear on filter reset |

## How to Test This PR [required]

1. Clone this branch: `git checkout feature/issue-1088`
2. Install dependencies: `pip install -r requirements.txt`
3. Run the app: `python src/app.py`
4. Open http://127.0.0.1:5000 and:
   - Search for projects using the form
   - Click "View Full Project" on any project card
   - Verify the project appears in the "Recently Viewed" section
   - Refresh the page - data should persist
   - Click the same project again - it should move to top (no duplicate)
   - Click "Clear Filters" - Recently Viewed section should clear
   - Toggle dark/light mode - section should look good in both
   - Test on mobile (375px width) - responsive layout should work
5. Run the tests: `python -m pytest tests/test_basic.py -v`

Expected: All 80 tests pass ✅

## Test Results [required]

All 80 tests PASSED ✅

## Screenshots (if UI change)

| Before | After |
|--------|-------|
| No "Recently Viewed" section | "Recently Viewed" section appears below search results with up to 5 most recent project cards |
| N/A | Cards show project title, interest area, and time viewed ("5 min ago", "yesterday", etc.) |

## Self-Review Checklist [required]

- [x] I have read CONTRIBUTING.md and followed all guidelines
- [x] My branch name follows the convention: `feature/issue-1088`
- [x] I have run `python -m pytest tests/test_basic.py -v` and all 80 tests pass
- [x] No debug