### PR TITLE
fix: reduce oversized X button on selected skill tags #1102

### DIFF
--- a/src/static/style.css
+++ b/src/static/style.css
@@ -1746,12 +1746,13 @@ label {
   border: none;
   cursor: pointer;
   color: var(--indigo-500);
-  font-size: 1rem;
+  font-size: 0.7rem;
   line-height: 1;
   padding: 0;
   display: flex;
   align-items: center;
   transition: color var(--t);
+  font-weight:500;
 }
 
 .skill-chip-remove:hover {


### PR DESCRIPTION
## Summary
This PR fixes the oversized X (remove) button on selected skill tags in the "Your Skills" input section. The close button was disproportionately large relative to the tag pill size, making the UI look unbalanced. Fixed by reducing font-size to 0.7rem and setting font-weight to 500 on `.skill-chip-remove` class.

## Related Issue
Closes #1102

## Type of Change
- [x] Bug fix — resolves a broken behaviour
- [x] Style — CSS or visual changes only, no logic change

## What Was Changed
| File | Change made |
| `src/static/style.css` | Reduced font-size to 0.7rem and set font-weight to 500 on `.skill-chip-remove` to make X button proportional to tag size |

## How to Test This PR
1. Clone this branch: `git checkout fix/skill-tag-x-button-size`
2. Install dependencies: `pip install -r requirements.txt`
3. Run the app: `cd src && python app.py`
4. Open http://127.0.0.1:5000 and navigate to the Find The Project section
5. Click "Your Skills" and select 2-3 skills
6. Observe the X remove button is now proportional to the tag size

## Test Results
77 passed, 1 failed out of 78 tests

Note: The 1 failing test (test_score_coverage_ratio_exact_values) is a

pre-existing issue unrelated to this PR  it fails on main branch as well

due to a missing monkeypatch argument.

## Screenshots (if UI change)
| Before |
<img width="1920" height="910" alt="Screenshot 2026-06-22 210911" src="https://github.com/user-attachments/assets/e224afc8-df39-415d-a3a4-c44cfc561891" />
| After |
<img width="1920" height="901" alt="Screenshot 2026-06-24 064156" src="https://github.com/user-attachments/assets/cf6a1082-8457-4f9f-884b-4627d3fda0fc" />



## Self-Review Checklist
- [x] I have read CONTRIBUTING.md and followed all guidelines
- [x] My branch name follows the convention: `fix/skill-tag-x-button-size`
- [x] I have run `python tests/test_basic.py`
- [x] I have not introduced any `print()` or `console.log()` debug statements
- [x] I have not modified files outside the scope of the linked issue
- [x] I tested UI at 375px (mobile) and 1280px (desktop)

## Notes for Reviewer
CSS-only change targeting `.skill-chip-remove` class. Only `font-size` and `font-weight` were adjusted. No logic or functionality modified.