### PR TITLE
feat: add rate limiting across recommend, search, download, and learning-path routes

### DIFF
--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -9,6 +9,7 @@ from utils.recommender import get_recommendations, validate_recommendation_input
 from utils.data_loader import find_project_by_id, load_all_projects, get_available_levels, get_project_stats
 from utils.roadmap_comparer import load_all_career_roadmaps, compare_roadmaps
 from utils.file_server import read_starter_code, resolve_starter_file, get_starter_code_dir
+from utils.rate_limiter import rate_limit
 from utils.learning_path import (
     create_learning_path,
     get_learning_path,
@@ -100,6 +101,7 @@ def health_check():
 
 
 @main.route("/api/recommend", methods=["POST"])
+@rate_limit(max_requests=10, window_seconds=60)
 def recommend():
     """
     Accept a JSON body with user inputs and return matching project recommendations.
@@ -225,6 +227,7 @@ def view_code(project_id):
 
 
 @main.route("/project/<int:project_id>/download")
+@rate_limit(max_requests=20, window_seconds=60)
 def download_code(project_id):
     """Serve the starter code file as a downloadable attachment."""
     project = find_project_by_id(project_id)
@@ -269,6 +272,7 @@ def robots():
     return send_from_directory("static", "robots.txt", mimetype="text/plain")
 
 @main.route("/api/search")
+@rate_limit(max_requests=30, window_seconds=60)
 def search_projects():
     """Return projects matching the user's search query."""
 
@@ -321,6 +325,7 @@ def _extract_token(req):
 
 
 @main.route("/api/learning-path/<path_id>", methods=["POST"])
+@rate_limit(max_requests=10, window_seconds=60)
 def create_path(path_id):
     """Create a new learning path and bind it to the supplied token.
 
@@ -357,6 +362,7 @@ def create_path(path_id):
 
 
 @main.route("/api/learning-path/<path_id>", methods=["GET"])
+@rate_limit(max_requests=20, window_seconds=60)
 def read_path(path_id):
     """Return the data payload for a learning path.
 
@@ -386,6 +392,7 @@ def read_path(path_id):
 
 
 @main.route("/api/learning-path/<path_id>", methods=["PUT"])
+@rate_limit(max_requests=10, window_seconds=60)
 def update_path(path_id):
     """Overwrite the data payload for an existing learning path.
 

--- a/src/utils/rate_limiter.py
+++ b/src/utils/rate_limiter.py
@@ -1,0 +1,59 @@
+# utils/rate_limiter.py
+# Lightweight, dependency-free rate limiting for DevPath.
+#
+# Tracks request timestamps per (client IP, route) in a sliding window, using
+# only a module-level dict (no flask-limiter/Redis, keeping Flask as the only
+# runtime dependency). When a client exceeds the limit, it raises
+# werkzeug's TooManyRequests, which Flask routes to the existing 429
+# handler in errors/handlers.py — so this module just decides allow/deny
+# and leaves response-building to the code that already does it. Note
+# this is single-process only: running multiple workers means each one
+# tracks its own counters.
+
+import time
+from collections import defaultdict
+from functools import wraps
+
+from flask import request
+from werkzeug.exceptions import TooManyRequests
+
+# (client_id, endpoint) -> list[float] of request timestamps in the window.
+_request_log = defaultdict(list)
+
+
+def _client_identifier() -> str:
+    """Identify the caller for rate-limiting purposes (by IP)."""
+    return request.remote_addr or "unknown"
+
+
+def rate_limit(max_requests: int = 10, window_seconds: int = 60):
+    """Decorator: limit a view to `max_requests` per `window_seconds`."""
+    def decorator(view_func):
+        @wraps(view_func)
+        def wrapped(*args, **kwargs):
+            # Keyed by (client, endpoint) so one route's traffic can't
+            # consume another route's budget for the same client.
+            key = (_client_identifier(), request.endpoint)
+            now = time.time()
+            window_start = now - window_seconds
+
+            timestamps = _request_log[key]
+            # Drop timestamps outside the current window.
+            timestamps[:] = [t for t in timestamps if t > window_start]
+
+            if len(timestamps) >= max_requests:
+                raise TooManyRequests(
+                    description="Rate limit exceeded. Please slow down."
+                )
+
+            timestamps.append(now)
+            return view_func(*args, **kwargs)
+
+        return wrapped
+
+    return decorator
+
+
+def reset_rate_limits() -> None:
+    """Clear all tracked timestamps (for use between tests)."""
+    _request_log.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 import pytest
 from app import app
+from utils.rate_limiter import reset_rate_limits
 
 
 @pytest.fixture
@@ -18,3 +19,15 @@ def client():
     app.config['TESTING'] = True
     with app.test_client() as client:
         yield client
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter_state():
+    """Clear rate-limit counters before every test.
+ 
+    Without this, tests across different files that hit the same rate-limited route 
+    would exhaust each other's request budget depending on test execution order, causing
+    order-dependent 429 failures unrelated to what each test is actually checking.
+    """
+    reset_rate_limits()
+    yield

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,98 @@
+# tests/test_rate_limiter.py
+# Tests for the in-memory sliding-window rate limiter.
+#
+# Tests:
+#   - Requests within the limit succeed
+#   - The request that exceeds the limit returns 429
+#   - Routes without the decorator are unaffected
+#   - Different client IPs are tracked independently
+#   - reset_rate_limits() clears state between tests
+
+import pytest
+from flask import Flask
+
+from utils.rate_limiter import rate_limit, reset_rate_limits
+
+
+
+# Fixtures
+
+@pytest.fixture
+def app():
+    """Minimal Flask app with one rate-limited test route."""
+    app = Flask(__name__)
+
+    @app.route("/limited")
+    @rate_limit(max_requests=3, window_seconds=60)
+    def limited():
+        return "ok", 200
+
+    @app.route("/unlimited")
+    def unlimited():
+        return "ok", 200
+
+    yield app
+    reset_rate_limits()  # don't leak state into the next test
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+# Core limiting behavior
+
+def test_requests_within_limit_succeed(client):
+    """The first N requests (N = max_requests) should all succeed."""
+    for _ in range(3):
+        resp = client.get("/limited")
+        assert resp.status_code == 200
+
+
+def test_request_over_limit_returns_429(client):
+    """The (N+1)th request in the window should be rejected with 429."""
+    for _ in range(3):
+        client.get("/limited")
+
+    resp = client.get("/limited")
+    assert resp.status_code == 429
+
+
+def test_unrelated_route_is_not_rate_limited(client):
+    """A route without the decorator should be unaffected."""
+    for _ in range(10):
+        resp = client.get("/unlimited")
+        assert resp.status_code == 200
+
+
+# Per-client isolation
+
+def test_different_clients_have_independent_limits(app):
+    """Two different client IPs should not share the same counter."""
+    client_a = app.test_client()
+    client_b = app.test_client()
+
+    for _ in range(3):
+        resp = client_a.get("/limited", environ_overrides={"REMOTE_ADDR": "1.1.1.1"})
+        assert resp.status_code == 200
+
+    # Client A is now at its limit...
+    resp = client_a.get("/limited", environ_overrides={"REMOTE_ADDR": "1.1.1.1"})
+    assert resp.status_code == 429
+
+    # ...but client B should still be allowed.
+    resp = client_b.get("/limited", environ_overrides={"REMOTE_ADDR": "2.2.2.2"})
+    assert resp.status_code == 200
+
+
+# State reset
+
+def test_reset_rate_limits_clears_state(client):
+    """reset_rate_limits() should allow a previously-blocked client through again."""
+    for _ in range(3):
+        client.get("/limited")
+    assert client.get("/limited").status_code == 429
+
+    reset_rate_limits()
+
+    assert client.get("/limited").status_code == 200


### PR DESCRIPTION
## Summary [required]

Adds a reusable, dependency-free rate-limiting decorator and applies it to six routes that do meaningful work per request: the recommendation engine, search, starter-code download, and all three learning-path endpoints. Exceeding a route's limit raises werkzeug's TooManyRequests, which is routed into the existing 429 handler in errors/handlers.py, so no new response-building logic was needed.

## Related Issue [required]

Closes #1141

## Type of Change [required]

<!-- Check all that apply. -->

- [ ] Bug fix — resolves a broken behaviour
- [x] Feature — adds new functionality
- [ ] Data — adds new projects to `data/projects.json`
- [ ] Documentation — updates docs, README, or code comments only
- [ ] Style — CSS or visual changes only, no logic change
- [ ] Refactor — restructures code without changing behaviour
- [x] Test — adds or updates tests

## What Was Changed [required]

| File | Change made |
|------|-------------|
| `src/utils/rate_limiter.py` | New file. Sliding-window rate limiter keyed by (client IP, route), raises `TooManyRequests` on limit exceeded. |
| `src/routes/main_routes.py` | Added `@rate_limit(...)` decorator to `recommend`, `search_projects`, `download_code`, `create_path`, `read_path`, and `update_path`. |
| `tests/test_rate_limiter.py` | New file. 5 tests covering within-limit success, over-limit 429, unrelated-route isolation, per-client isolation, and state reset. |
| `tests/conftest.py` | Added an `autouse` fixture that resets rate-limiter state before every test, so tests in different files that hit the same rate-limited route don't exhaust each other's budget depending on execution order. |

## How to Test This PR [required]

1. Clone this branch: `git checkout feat/rate-limiting`
2. Install dependencies: `pip install -r requirements.txt`
3. Run the full test suite: `pytest tests/ -v`

Expected test output:
```
285 passed, 1 skipped
```

## Test Results [required]

```
285 passed, 1 skipped in 3.41s
```

## Self-Review Checklist [required]

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed all guidelines
- [x] My branch name follows the convention: `feat/`, `fix/`, `docs/`, `data/`, `style/`, `test/`
- [x] I have run `python tests/test_basic.py` and all 285 tests pass
- [x] I have run `flake8 .` locally and there are no errors
- [x] I have not introduced any `print()` or `console.log()` debug statements
- [x] Every new function I wrote has a docstring
- [x] I have not modified files outside the scope of the linked issue
- [ ] If I changed the UI, I tested it at 375px (mobile) and 1280px (desktop)
- [ ] If I added a project to the dataset, it has all required JSON fields

## Notes for Reviewer

This PR is part of GSSoC '26.

The 1 skipped test (test_og_tags.py) requires PIL/Pillow, which isn't installed in my environment and isn't in requirements.txt. This is pre-existing and unrelated to this PR, confirmed it skips identically on main without my changes.
