### PR TITLE
Fix unclosed form tag causing UI bugs (#698)

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -391,7 +391,7 @@
               d="M21 21l-4.35-4.35m1.85-5.15a7 7 0 11-14 0 7 7 0 0114 0z" />
           </svg>
         </button>
-      </div>
+      </form>
 
       <button class="nav-mobile-toggle" id="nav-mobile-toggle" aria-label="Toggle navigation"
         aria-expanded="false" aria-controls="nav-mobile-menu">


### PR DESCRIPTION
Fixes #698

### Description
This PR addresses three critical UI failures on the homepage:
1. Skill pool chips could not be selected
2. The recommendation form submission reloaded the page instead of showing results
3. The "Import from GitHub" button was non-functional

**Root Cause & Fix:**
The underlying cause of all these issues was a malformed HTML tag in the navbar. The `topic-search-form` was incorrectly closed with a `</div>` instead of a `</form>`. Because HTML doesn't allow nested forms, the browser dropped the subsequent `recommend-form` element from the DOM entirely during parsing.

As a result, `document.getElementById("recommend-form")` returned `null`, causing the main initialization script (`initIndexPage()` in `script.js`) to abort early before any of the event listeners for the skill chips, form submission, and GitHub modal were attached.

Changing the closing `</div>` to `</form>` correctly scopes the search form, restoring the `recommend-form` to the DOM and allowing all JavaScript event listeners to initialize properly.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have performed a self-review of my code
- [x] I have verified that the bug is fixed and all three affected UI components now function as expected
