### PR TITLE
fix: correct mobile navigation "Find Project" link target

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -414,7 +414,7 @@
       <a href="#home" class="nav-mobile-link" role="menuitem">Home</a>
       <a href="#how-it-works" class="nav-mobile-link" role="menuitem">How It Works</a>
       <a href="#features" class="nav-mobile-link" role="menuitem">Features</a>
-      <a href="#find-project" class="nav-mobile-link" role="menuitem">Find Project</a>
+      <a href="#the-project" class="nav-mobile-link" role="menuitem">Find Project</a>
       <a href="/compare" class="nav-mobile-link" role="menuitem">Compare</a>
       <a href="/contact" class="nav-mobile-link" role="menuitem">Contact</a>
       <a href="https://github.com/komalharshita/DevPath" target="_blank" rel="noopener noreferrer"


### PR DESCRIPTION
## Summary

This PR fixes a broken navigation issue in the mobile menu. The "Find Project" navigation item was linked to the non-existent `#find-project` anchor, preventing mobile users from navigating directly to the project recommendation form. The link has been updated to point to the existing `#the-project` section, ensuring consistent and functional navigation across mobile devices.

## Related Issue

Closes #1146

## Type of Change

* [x] Bug fix — resolves a broken behaviour
* [ ] Feature — adds new functionality
* [ ] Data — adds new projects to `data/projects.json`
* [ ] Documentation — updates docs, README, or code comments only
* [ ] Style — CSS or visual changes only, no logic change
* [ ] Refactor — restructures code without changing behaviour
* [ ] Test — adds or updates tests

## What Was Changed

| File                       | Change made                                                                                                                                        |
| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
| `src/templates/index.html` | Updated the mobile navigation "Find Project" link from `#find-project` to `#the-project` to match the existing project recommendation form section |

## How to Test This PR

1. Clone this branch: `git checkout <branch-name>`
2. Install dependencies: `pip install -r requirements.txt`
3. Run the application: `py src/app.py`
4. Open `http://127.0.0.1:5000`
5. Open Developer Tools (`F12`) and enable mobile view (`Ctrl + Shift + M`)
6. Select a mobile device (e.g., iPhone 14 Pro)
7. Open the mobile navigation menu using the hamburger icon
8. Click the **Find Project** navigation item

# Expected Result:

* The page scrolls directly to the **Find The Project** form section.
* Navigation works correctly without redirecting to an invalid location.

## Test Results

```text
Manual Testing:

✓ Mobile navigation menu opens successfully.
✓ "Find Project" link redirects to the correct section.
✓ Project recommendation form section is reached successfully.
✓ No other mobile navigation links were affected.
```

## Self-Review Checklist

* [x] I have read CONTRIBUTING.md and followed all guidelines
* [x] My branch name follows the convention: `fix/`, `feat/`, `docs/`, `data/`, `style/`, or `test/`
* [ ] I have run `python tests/test_basic.py` and all 27 tests pass
* [x] I have run `flake8 .` locally and there are no errors
* [x] I have not introduced any `print()` or `console.log()` debug statements
* [x] I have not modified files outside the scope of the linked issue
* [x] If I changed the UI, I tested it at 375px (mobile) and 1280px (desktop)

## Notes for Reviewer

The issue was caused by the mobile navigation referencing a non-existent anchor (`#find-project`). This PR updates the link to use the existing `#the-project` section, restoring correct navigation behavior for mobile users.
