### PR TITLE
Perf: Implement in-memory caching for Graph and Cluster JSON files 1174

### DIFF
--- a/src/utils/recommender.py
+++ b/src/utils/recommender.py
@@ -18,6 +18,19 @@ _CLUSTERS_PATH = os.path.join(
     "clusters.json",
 )
 
+_cached_clusters = None
+_clusters_loaded = False
+_cached_skill_graph = None
+_skill_graph_loaded = False
+
+def clear_caches():
+    """Clear all in-memory JSON caches."""
+    global _cached_clusters, _clusters_loaded, _cached_skill_graph, _skill_graph_loaded
+    _cached_clusters = None
+    _clusters_loaded = False
+    _cached_skill_graph = None
+    _skill_graph_loaded = False
+
 VALID_LEVELS = {"beginner", "intermediate", "advanced"}
 VALID_INTERESTS = {"web", "data", "education", "automation", "games", "cybersecurity", "devops", "backend", "tools", "productivity", "business logic", "mobile", "machine learning/ai"}
 VALID_TIME_AVAILABILITY = {"low", "medium", "high"}
@@ -190,17 +203,24 @@ def score_single_project(project, user_skills, level, interest, time_availabilit
 
 def _load_skill_graph():
     """Load skill_graph.json from data/. Returns empty dict on failure."""
+    global _cached_skill_graph, _skill_graph_loaded
+    if _skill_graph_loaded:
+        return _cached_skill_graph
+        
+    _skill_graph_loaded = True
     path = os.path.join(
         os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
         "data", "skill_graph.json"
     )
     if not os.path.exists(path):
-        return {}
+        _cached_skill_graph = {}
+        return _cached_skill_graph
     try:
         with open(path, "r", encoding="utf-8") as f:
-            return json.load(f)
+            _cached_skill_graph = json.load(f)
     except (json.JSONDecodeError, OSError):
-        return {}
+        _cached_skill_graph = {}
+    return _cached_skill_graph
 
 
 def _hops_to_skill(target, user_skills, graph, max_hops=3):
@@ -288,13 +308,20 @@ def _load_clusters():
     A missing file is a soft failure — the recommender still works,
     it just won't return related projects.
     """
+    global _cached_clusters, _clusters_loaded
+    if _clusters_loaded:
+        return _cached_clusters
+        
+    _clusters_loaded = True
     if not os.path.exists(_CLUSTERS_PATH):
-        return None
+        _cached_clusters = None
+        return _cached_clusters
     try:
         with open(_CLUSTERS_PATH, "r", encoding="utf-8") as f:
-            return json.load(f)
+            _cached_clusters = json.load(f)
     except (json.JSONDecodeError, OSError):
-        return None
+        _cached_clusters = None
+    return _cached_clusters
 
 
 def _get_related(recommended_ids, all_projects, cluster_data):


### PR DESCRIPTION
## Summary

This PR addresses issue #1174 by introducing in-memory caching for the Recommender Engine's static JSON files (`clusters.json` and `skill_graph.json`). Previously, the backend executed synchronous disk I/O on every API call to read these files, creating a latency bottleneck at scale. By declaring module-level variables (`_cached_clusters` and `_cached_skill_graph`) and updating the respective load functions to serve data from memory after the initial read, we eliminate redundant disk reads entirely. A `clear_caches()` function is also provided to allow for explicit cache invalidation during unit testing.

## Related Issue

Closes #1174

## Type of Change

- [ ] Bug fix — resolves a broken behaviour
- [ ] Feature — adds new functionality
- [ ] Data — adds new projects to `data/projects.json`
- [ ] Documentation — updates docs, README, or code comments only
- [ ] Style — CSS or visual changes only, no logic change
- [x] Refactor — restructures code without changing behaviour
- [ ] Test — adds or updates tests

## What Was Changed

| File | Change made |
|------|-------------|
| `src/utils/recommender.py` | Declared global cache variables `_cached_clusters` and `_cached_skill_graph` alongside boolean initialization flags. Updated `_load_clusters()` and `_load_skill_graph()` to return the cached references instead of parsing the files off disk. Implemented `clear_caches()` to reset the global state for testing environments. |

## How to Test This PR

1. Clone this branch: `git checkout feat/issue-1174-in-memory-caching`
2. Install dependencies: `pip install -r requirements.txt`
3. Run the app: `python app.py`
4. Send a recommendation request via the frontend UI.
5. Notice that subsequent requests are processed substantially faster since the static JSON files are already stored in memory.
6. Run the tests: `python tests/test_basic.py` (or `pytest tests/test_basic.py`) to verify that the caching does not break any assertions.

Expected test output:
```
27 passed, 0 failed out of 27 tests
```

## Test Results

```
============================= test session starts ==============================
platform darwin -- Python 3.x.x, pytest-x.x.x, pluggy-x.x.x
rootdir: /Users/desireddymohithreddy/GSSOC2026DevPath/DevPathMRD
collected 27 items                                                             

tests/test_basic.py ...........................                          [100%]

============================== 27 passed in 0.12s ==============================
```

## Self-Review Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed all guidelines
- [x] My branch name follows the convention: `feat/`, `fix/`, `docs/`, `data/`, `style/`, `test/`
- [x] I have run `python tests/test_basic.py` and all 27 tests pass
- [x] I have run `flake8 .` locally and there are no errors
- [x] I have not introduced any `print()` or `console.log()` debug statements
- [x] Every new function I wrote has a docstring
- [x] I have not modified files outside the scope of the linked issue
- [ ] If I changed the UI, I tested it at 375px (mobile) and 1280px (desktop)
- [ ] If I added a project to the dataset, it has all required JSON fields

## Notes for Reviewer

None
