### PR TITLE
style: increase progressbar hight to make progress percentage visible

### DIFF
--- a/src/static/style.css
+++ b/src/static/style.css
@@ -3461,7 +3461,7 @@ input[type="text"]:not(.skill-input-wrap input):focus {
 
 .progress-meter {
   width: 100%;
-  height: 16px;
+  height: 20px;
   background: var(--surface-hover);
   border-radius: 999px;
   overflow: hidden;
@@ -5129,7 +5129,7 @@ body.dark-theme .theme-toggle:hover {
 .progress-meter {
   background: var(--gray-200);
   border-radius: 100px;
-  height: 8px;
+  height: 20px;
   overflow: hidden;
 }
 
@@ -5140,6 +5140,7 @@ body.dark-theme .theme-toggle:hover {
   display: block;
   width: 0%;
   transition: width 0.3s ease;
+  padding-left: 4px;
 }
 
 .stat-dashboard-footer {

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -604,8 +604,8 @@
             </svg>
           </div>
           <div class="stat-dashboard-value" id="progress-points">0</div>
-          <div class="stat-dashboard-progress">
-            <div class="progress-meter">
+          <div class="stat-dashboard-progress" >
+            <div class="progress-meter" style="height: 20px;">
               <span class="progress-meter-fill" id="progress-meter-fill" style="width: 0%;" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">0%</span>
             </div>
           </div>


### PR DESCRIPTION
<!--
  Pull Request Template — DevPath
  --------------------------------
  Delete sections that do not apply.
  Every section marked [required] must be completed before review begins.
  PRs with empty required sections will be returned without review.
-->

## Summary [required]

Resolved a visual bug where the progress percentage text was clipped and overlapping the Total Points progress bar due to restrictive container heights. This PR updates the container dimensions and applies targeted style overrides to safely bypass existing specificity constraints, ensuring the percentage typography centers accurately and remains fully visible across layout states


## Related Issue [required]

<!-- Every PR must link to an open issue. -->
<!-- If no issue exists, open one before submitting this PR. -->

Closes #1200 

## Type of Change [required]

<!-- Check all that apply. -->

- [ ] Bug fix — resolves a broken behaviour
- [ ] Feature — adds new functionality
- [ ] Data — adds new projects to `data/projects.json`
- [ ] Documentation — updates docs, README, or code comments only
- [x] Style — CSS or visual changes only, no logic change
- [ ] Refactor — restructures code without changing behaviour
- [ ] Test — adds or updates tests

## What Was Changed [required]

<!-- List every file you modified and briefly explain why. -->
 
| File | Change made |
|------|-------------|
| `src\static\style.css   |  to change css of the progressbar  |
| `src\templates\index.html` |  add  inline css  |

## How to Test This PR [required]

<!-- Exact steps a reviewer can follow to verify your change works. -->
<!-- "It works on my machine" is not sufficient. -->

1. Clone this branch: `git checkout your-branch-name`
2. Install dependencies: `pip install -r requirements.txt`
3. Run the app: `python app.py`
4. Open http://127.0.0.1:5000 and...
5. Check the UI of progress bar 

## Test Results [required]

<!-- Paste the full output of python tests/test_basic.py -->

```
============================= test session starts ==============================
platform manthan -- Python 3.9.6, pytest-8.2.2, pluggy-1.6.0
rootdir: C:\gssoc\DevPath/DevPath
collected 88 items

tests/test_basic.py .................................................... [ 59%]
....................................                                     [100%]

======================== 88 passed, 1 warning in 1.12s =========================
```

## Screenshots (if UI change)

<!-- Before and after screenshots for any visual change. -->
<!-- Remove this section if your PR has no visual change. -->

| Before | After |
|--------|-------|
| <img width="1511" height="812" alt="image" src="https://github.com/user-attachments/assets/b8f9071a-6b75-4036-a1f5-67f79cc11cec" />| <img width="1524" height="809" alt="image" src="https://github.com/user-attachments/assets/1708253e-46ba-4079-bce8-a7e7c744936a" /> |

## Self-Review Checklist [required]

<!-- Complete every item before requesting review. -->
<!-- Do not submit a PR you would not approve yourself. -->

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed all guidelines
- [x] My branch name follows the convention: `feat/`, `fix/`, `docs/`, `data/`, `style/`, `test/`
- [x] I have run `python tests/test_basic.py` and all 27 tests pass
- [x] I have run `flake8 .` locally and there are no errors
- [x] I have not introduced any `print()` or `console.log()` debug statements
- [x] Every new function I wrote has a docstring
- [x] I have not modified files outside the scope of the linked issue
- [x] If I changed the UI, I tested it at 375px (mobile) and 1280px (desktop)
- [ ] If I added a project to the dataset, it has all required JSON fields

## Notes for Reviewer
Applied the CSS updates to both the external stylesheet and as inline styles to ensure they override any competing specificity rules. ( only for  progress bar height )


