### PR TITLE
Perf/optimize tfidf

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,95 @@
+import time
+import math
+import re
+from collections import Counter
+from src.utils.data_loader import load_all_projects
+from src.utils.recommender import (
+    score_single_project, 
+    _tokenize, 
+    _project_text, 
+    _user_text, 
+    _idf, 
+    _tfidf_vector, 
+    _cosine_similarity, 
+    parse_skills,
+    get_recommendations as get_recommendations_optimized
+)
+
+# Re-implement the unoptimized version locally for benchmarking
+def ml_similarity_score_unoptimized(project, user_skills, level, interest, time_availability, all_projects):
+    project_documents = [_tokenize(_project_text(p)) for p in all_projects]
+    user_tokens = _tokenize(_user_text(user_skills, level, interest, time_availability))
+
+    idf_scores = _idf(project_documents + [user_tokens])
+
+    user_vector = _tfidf_vector(user_tokens, idf_scores)
+    project_vector = _tfidf_vector(_tokenize(_project_text(project)), idf_scores)
+
+    return _cosine_similarity(user_vector, project_vector)
+
+def get_recommendations_unoptimized(skills_string, level, interest, time_availability):
+    user_skills = parse_skills(skills_string)
+    all_projects = load_all_projects()
+    scored_projects = []
+    for project in all_projects:
+        rule_score = score_single_project(
+            project,
+            user_skills,
+            level,
+            interest,
+            time_availability,
+        )
+        similarity_score = ml_similarity_score_unoptimized(
+            project,
+            user_skills,
+            level,
+            interest,
+            time_availability,
+            all_projects,
+        )
+        final_score = rule_score + similarity_score
+        if final_score > 0:
+            scored_projects.append({
+                "project": project,
+                "score": final_score,
+            })
+    return scored_projects
+
+def run_benchmark():
+    # To artificially inflate the dataset size for a meaningful benchmark if needed:
+    all_projects = load_all_projects()
+    print(f"Number of projects loaded: {len(all_projects)}")
+    
+    # Let's artificially multiply the data to show the true O(N^2) effect
+    # We will mock the load_all_projects behavior to return duplicated data
+    
+    # We'll just run it on the current dataset first
+    skills = "python, react"
+    level = "intermediate"
+    interest = "web"
+    time_avail = "medium"
+    
+    # Warm up
+    _ = get_recommendations_optimized(skills, level, interest, time_avail)
+    
+    print("\n--- Benchmarking Unoptimized (O(N^2)) ---")
+    start = time.time()
+    get_recommendations_unoptimized(skills, level, interest, time_avail)
+    unoptimized_time = time.time() - start
+    print(f"Time taken: {unoptimized_time:.4f} seconds")
+    
+    print("\n--- Benchmarking Optimized (O(N)) ---")
+    start = time.time()
+    get_recommendations_optimized(skills, level, interest, time_avail)
+    optimized_time = time.time() - start
+    print(f"Time taken: {optimized_time:.4f} seconds")
+    
+    speedup = unoptimized_time / optimized_time if optimized_time > 0 else 0
+    print(f"\nSpeedup: {speedup:.2f}x faster")
+
+if __name__ == '__main__':
+    import sys
+    import os
+    # Add src to sys.path so imports work
+    sys.path.append(os.path.join(os.path.dirname(__file__), 'src'))
+    run_benchmark()

--- a/src/utils/recommender.py
+++ b/src/utils/recommender.py
@@ -133,13 +133,7 @@ def _cosine_similarity(vec_a, vec_b):
 
     return dot_product / (magnitude_a * magnitude_b)
 
-def ml_similarity_score(project, user_skills, level, interest, time_availability, all_projects):
-    project_documents = [_tokenize(_project_text(p)) for p in all_projects]
-    user_tokens = _tokenize(_user_text(user_skills, level, interest, time_availability))
-
-    idf_scores = _idf(project_documents + [user_tokens])
-
-    user_vector = _tfidf_vector(user_tokens, idf_scores)
+def ml_similarity_score(project, user_vector, idf_scores):
     project_vector = _tfidf_vector(_tokenize(_project_text(project)), idf_scores)
 
     return _cosine_similarity(user_vector, project_vector)
@@ -336,6 +330,17 @@ def _get_related(recommended_ids, all_projects, cluster_data):
 def get_recommendations(skills_string, level, interest, time_availability):
     user_skills = parse_skills(skills_string)
     all_projects = load_all_projects()
+    
+    # Pre-compute IDF scores and user vector
+    # PERFORMANCE NOTE: Pre-computing the tokenization and base idf_scores outside of the
+    # ml_similarity_score loop reduces the time complexity from O(N^2) to O(N).
+    # Benchmarking on 22 projects showed a ~15x speedup (0.15s down to 0.01s).
+    # This ensures scalable performance as the number of projects grows.
+    project_documents = [_tokenize(_project_text(p)) for p in all_projects]
+    user_tokens = _tokenize(_user_text(user_skills, level, interest, time_availability))
+    idf_scores = _idf(project_documents + [user_tokens])
+    user_vector = _tfidf_vector(user_tokens, idf_scores)
+    
     scored_projects = []
     for project in all_projects:
         rule_score = score_single_project(
@@ -347,11 +352,8 @@ def get_recommendations(skills_string, level, interest, time_availability):
         )
         similarity_score = ml_similarity_score(
             project,
-            user_skills,
-            level,
-            interest,
-            time_availability,
-            all_projects,
+            user_vector,
+            idf_scores
         )
         final_score = rule_score + similarity_score
         if final_score > 0:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -887,15 +887,22 @@ if __name__ == "__main__":
         sys.exit(1)
 
 def test_ml_similarity_score_returns_float():
-    from utils.recommender import ml_similarity_score, parse_skills
+    from utils.recommender import (
+        ml_similarity_score, parse_skills, _tokenize, 
+        _project_text, _user_text, _idf, _tfidf_vector
+    )
     projects = load_all_projects()
+    
+    project_documents = [_tokenize(_project_text(p)) for p in projects]
+    user_skills = parse_skills("Python")
+    user_tokens = _tokenize(_user_text(user_skills, "Beginner", "Data", "Low"))
+    idf_scores = _idf(project_documents + [user_tokens])
+    user_vector = _tfidf_vector(user_tokens, idf_scores)
+
     score = ml_similarity_score(
         projects[0],
-        parse_skills("Python"),
-        "Beginner",
-        "Data",
-        "Low",
-        projects,
+        user_vector,
+        idf_scores,
     )
     assert isinstance(score, float)
     assert score >= 0


### PR DESCRIPTION
### 🚀 Performance Improvements (Benchmark Results)

I wrote a benchmark script to test the time complexity of `get_recommendations` before and after moving the tokenization and `_idf` scoring outside of the single-project scoring loop.

**Testing constraints:** 22 Projects loaded in the dataset.

#### Before Optimization (O(N²))
* **Time taken:** 0.1537 seconds per request
* **Scaling:** Would grow exponentially slower as the database of projects increases.

#### After Optimization (O(N))
* **Time taken:** 0.0103 seconds per request
* **Scaling:** Linear. Safe for large datasets.

#### 📈 Result
* **Speedup:** **~14.93x faster** on just 22 projects!
