### PR TITLE
fix: correct _URL_RE typo causing 500 on /project/<id> routes

### DIFF
--- a/src/utils/url_validator.py
+++ b/src/utils/url_validator.py
@@ -39,7 +39,7 @@ def is_valid_url(url: str) -> bool:
     """
     if not url or not isinstance(url, str):
         return False
-    return bool(_URL_RE.match(url.strip()))
+    return bool(URL_RE.match(url.strip()))
 
 
 def parse_resource(raw: str) -> dict:


### PR DESCRIPTION
<!--
  Pull Request Template — DevPath
  --------------------------------
  Delete sections that do not apply.
  Every section marked [required] must be completed before review begins.
  PRs with empty required sections will be returned without review.
-->

## Summary [required]
`/project/<id>` was returning a 500 Internal Server Error for *every* request — valid or invalid — instead of either rendering the project page or the app's existing 404 page. The root cause was a `NameError` in `utils/url_validator.py`: `is_valid_url()` referenced `_URL_RE`, but the compiled regex was actually defined as `URL_RE` (no leading underscore). This crashed project validation on every load, which cascaded up through `load_all_projects()` and `find_project_by_id()`. This PR fixes the typo so the route correctly falls through to the app's existing 404 handler for invalid project IDs.

## Related Issue [required]
Closes #1221

## Type of Change [required]
- [x] Bug fix — resolves a broken behaviour

## What Was Changed [required]
| File | Change made |
|------|-------------|
| `src/utils/url_validator.py` | Fixed typo: `_URL_RE.match(...)` → `URL_RE.match(...)` on line 42, matching the actual compiled regex name defined on line 19 |

## How to Test This PR [required]
1. Clone this branch: `git checkout fix/project-detail-500-on-invalid-id`
2. Install dependencies: `pip install -r requirements.txt`
3. Run the app: `python src/app.py`
4. Visit `http://127.0.0.1:5000/project/999` (nonexistent ID) and `http://127.0.0.1:5000/project/abc` (non-integer) — both should render the styled 404 page, not a 500 error
5. Visit `http://127.0.0.1:5000/project/1` (a real project) — should load normally
6. Run the tests: `python tests/test_basic.py`

## Test Results [required]

<!-- Check all that apply. -->

- [x] Bug fix — resolves a broken behaviour
The one failure, `test_score_coverage_ratio_exact_values`, is pre-existing and unrelated to this change — it fails with `missing 1 required positional argument: 'monkeypatch'`, a pytest-fixture issue in `utils/recommender.py` scoring tests, not in `url_validator.py`. I confirmed it fails identically on `main` before my change. The two tests directly relevant to this fix, `test_project_detail_found` and `test_project_detail_not_found`, both pass.

## Self-Review Checklist [required]
- [x] I have read CONTRIBUTING.md and followed all guidelines
- [x] My branch name follows the convention: `fix/project-detail-500-on-invalid-id`
- [ ] I have run `python tests/test_basic.py` and all tests pass — 77/78 pass; the 1 failure is pre-existing and unrelated (see Test Results above)
- [x] I have run `flake8 src/utils/url_validator.py` locally — no new errors introduced by this change (3 pre-existing style warnings on unrelated lines 29, 50, 74 were left untouched, out of scope for this fix)
- [x] I have not introduced any `print()` or `console.log()` debug statements
- [x] Every new function I wrote has a docstring (no new functions added — single-line fix)
- [x] I have not modified files outside the scope of the linked issue
- [ ] If I changed the UI, I tested it at 375px (mobile) and 1280px (desktop) — N/A, no UI change
- [ ] If I added a project to the dataset, it has all required JSON fields — N/A

## Notes for Reviewer
Issue #1221 originally proposed adding a Flask 404 handler and `templates/404.html` from scratch, but both already exist on `main` (`src/errors/handlers.py` + `src/templates/404.html`) and are correctly wired up via `register_error_handlers(app)`. The actual reason `/project/999` looked "blank/broken" was this typo causing a 500 before the existing 404 logic could run — so this PR fixes the real root cause rather than re-implementing infrastructure that's already there. Happy to also file the pre-existing `monkeypatch` test failure as a separate issue if useful — left it out of scope here.
