### PR TITLE
feat: add "Show More Projects" functionality for recommendations

### DIFF
--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -139,7 +139,7 @@ def recommend():
             "message": "No projects are currently available for this interest area. Please check back later."
         }), 200
 
-    recommendations_data = get_recommendations(skills, level, interest, time_availability)
+    recommendations_data = get_recommendations(skills, level, interest, time_availability, max_results=None)
     results = recommendations_data.get("recommendations", [])
 
     if not results:

--- a/src/static/script.js
+++ b/src/static/script.js
@@ -404,6 +404,7 @@ updateProfileWidgets();
   var btnLoading = document.getElementById("btn-loading");
   var resultsSection = document.getElementById("results-section");
   var resultsGrid = document.getElementById("results-grid");
+  var showMoreBtn = document.getElementById("show-more-btn");
   var resultsLoadingEl = document.getElementById("results-loading");
   var resultsEmptyEl = document.getElementById("results-empty");
   var emptyMessageEl = document.getElementById("empty-message");
@@ -674,11 +675,17 @@ updateProfileWidgets();
     return card;
   }
 
+  var allProjects = [];
+  var visibleProjectCount = 3;
+
+  var PROJECTS_PER_LOAD = 3;
+
   function renderResults(projects, message) {
     resultsSection.style.display = "block";
     resultsLoadingEl.style.display = "none";
     resultsGrid.innerHTML = "";
     if (!projects || projects.length === 0) {
+      showMoreBtn.style.display = "none";
       resultsGrid.style.display = "none";
       resultsEmptyEl.style.display = "block";
       if (emptyMessageEl) {
@@ -692,6 +699,19 @@ updateProfileWidgets();
     projects.forEach(function (project) { resultsGrid.appendChild(buildProjectCard(project)); });
     resultsSection.scrollIntoView({ behavior: "smooth" });
   }
+  if (showMoreBtn) {
+      showMoreBtn.addEventListener("click", function () {
+        visibleProjectCount += PROJECTS_PER_LOAD;
+        
+        renderResults(
+          allProjects.slice(0, visibleProjectCount)
+        );
+        
+        if (visibleProjectCount >= allProjects.length) {
+          showMoreBtn.style.display = "none";
+        }
+      });
+    }
 
   skillsInput.setAttribute("role", "combobox");
   skillsInput.setAttribute("aria-expanded", "false");
@@ -774,6 +794,9 @@ updateProfileWidgets();
     clearAllErrors();
     hideSuggestions();
     resultsSection.style.display = "none";
+    showMoreBtn.style.display = "none";
+    allProjects = [];
+    visibleProjectCount = PROJECTS_PER_LOAD;
     if (skillsInput) skillsInput.focus();
   }
 
@@ -840,7 +863,20 @@ updateProfileWidgets();
       .then(function (data) {
         setLoadingState(false);
         recordSearch();
-        renderResults(data.projects || [], data.message);
+        
+        allProjects = data.projects || [];
+        visibleProjectCount = PROJECTS_PER_LOAD;
+
+        renderResults(
+          allProjects.slice(0, visibleProjectCount),
+          data.message
+        );
+
+        if (allProjects.length > visibleProjectCount) {
+          showMoreBtn.style.display = "inline-block";
+        } else {
+          showMoreBtn.style.display = "none";
+        }
       })
       .catch(function (err) {
         setLoadingState(false);

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1100,6 +1100,16 @@
 
       <div class="results-grid" id="results-grid"></div>
 
+      <div class="show-more-container" style="text-align:center; margin-top:2rem;">
+        <button
+          id="show-more-btn"
+          class="btn-submit"
+          style="display:none;"
+          type="button">
+          Show More Projects
+        </button>
+      </div>
+
       <div class="saved-projects-panel" id="saved-projects-panel">
         <div class="saved-projects-header">
           <div>

--- a/src/utils/recommender.py
+++ b/src/utils/recommender.py
@@ -333,7 +333,7 @@ def _get_related(recommended_ids, all_projects, cluster_data):
 # Public API
 # ---------------------------------------------------------------------------
 
-def get_recommendations(skills_string, level, interest, time_availability):
+def get_recommendations(skills_string, level, interest, time_availability,  max_results=None):
     user_skills = parse_skills(skills_string)
     all_projects = load_all_projects()
     scored_projects = []
@@ -363,9 +363,12 @@ def get_recommendations(skills_string, level, interest, time_availability):
     # most relevant recommendations appear first.
     scored_projects.sort(key=lambda item: (item["score"], item["project"].get("id", 0)), reverse=True)
     
-    top_projects = [item["project"] for item in scored_projects[:MAX_RESULTS]]
+    if max_results is None:
+        top_projects = [item["project"] for item in scored_projects]
+    else:
+        top_projects = [item["project"] for item in scored_projects[:max_results]]
     top_ids = [p["id"] for p in top_projects]
-    
+
     cluster_data = _load_clusters()
     related = _get_related(top_ids, all_projects, cluster_data) if cluster_data else []
     


### PR DESCRIPTION
## Summary

This PR adds a **"Show More Projects"** feature to improve project exploration. Instead of limiting users to only the top three recommendations, the application now progressively loads additional matching projects on demand. This provides a smoother browsing experience while keeping the initial recommendations clean and uncluttered.

---

## Related Issue

Closes #324

---

## Type of Change

- [ ] Bug fix — resolves a broken behaviour
- [x] Feature — adds new functionality
- [ ] Data — adds new projects to `data/projects.json`
- [ ] Documentation — updates docs, README, or code comments only
- [ ] Style — CSS or visual changes only, no logic change
- [ ] Refactor — restructures code without changing behaviour
- [ ] Test — adds or updates tests

---

## What Was Changed

| File | Change made |
|------|-------------|
| `src/utils/recommender.py` | Made the recommendation limit configurable and added support for returning all matching recommendations. |
| `src/routes/main_routes.py` | Updated the recommendation API to return all matching projects for progressive loading. |
| `src/static/script.js` | Added client-side state management for recommendations, implemented progressive loading (3 projects per click), and automatically hid the button when all projects were displayed. |
| `src/templates/index.html` | Added the **Show More Projects** button below the recommendation results section. |

---

## How to Test This PR

1. Checkout this branch:
   ```bash
   git checkout feature/show-more-projects-v2
   ```

2. Install dependencies:
   ```bash
   pip install -r requirements.txt
   ```

3. Run the application:
   ```bash
   python src/app.py
   ```

4. Open:
   ```
   http://127.0.0.1:5000
   ```

5. Generate recommendations that return more than three projects.

6. Verify:
   - Only the first three recommendations are displayed initially.
   - Clicking **Show More Projects** loads three additional recommendations.
   - The button automatically disappears once all recommendations are displayed.
   - Searches with three or fewer recommendations do not display the button.
   - Clearing the form resets the recommendation state.

---

## Test Results

```
The existing root-level recommender test file references the pre-refactor
module path (utils.recommender), while the project has since been
restructured under src/.

Manual testing completed successfully:

✓ Initial recommendations limited to 3
✓ "Show More Projects" loads 3 additional recommendations per click
✓ Button hides after all recommendations are displayed
✓ Button remains hidden when 3 or fewer recommendations exist
✓ Recommendation state resets correctly on a new search and when clearing the form
```

---

## Screenshots

(Add your before/after screenshots or GIF here.)

| Before | After |
|--------|-------|
| *(Upload screenshot)* | *(Upload screenshot/GIF)* |

---

## Self-Review Checklist

- [x] I have read CONTRIBUTING.md and followed all guidelines
- [ ] My branch name follows the convention: `feat/`, `fix/`, `docs/`, `data/`, `style/`, `test/`
- [ ] I have run `python tests/test_basic.py` and all 27 tests pass
- [ ] I have run `flake8 .` locally and there are no errors
- [x] I have not introduced any `print()` or `console.log()` debug statements
- [x] Every new function I wrote has a docstring
- [x] I have not modified files outside the scope of the linked issue
- [x] If I changed the UI, I tested it at 375px (mobile) and 1280px (desktop)
- [ ] If I added a project to the dataset, it has all required JSON fields

---

## Notes for Reviewer

The project was recently refactored into the `src/` directory. The existing root-level recommender test script still imports the previous module path (`utils.recommender`), so I verified this feature through manual end-to-end testing instead.