### PR TITLE
test: add unit tests for invalid review ID handling in CodeReviewManager

### DIFF
--- a/tests/test_code_review.py
+++ b/tests/test_code_review.py
@@ -118,6 +118,33 @@ class TestCodeReviewManager:
                 reviewer_id="reviewer_001",
             )
 
+    def test_add_feedback_invalid_review_id(self, review_manager):
+        """Test adding feedback to a non-existent review."""
+        with pytest.raises(ValueError):
+            review_manager.add_feedback_comment(
+                review_id="invalid_review",
+                line_number=1,
+                code_snippet="x = 1",
+                feedback="Test feedback",
+            )
+
+    def test_score_category_invalid_review_id(self, review_manager):
+        """Test scoring a non-existent review."""
+        with pytest.raises(ValueError):
+            review_manager.score_category(
+                review_id="invalid_review",
+                category="functionality",
+                score=80,
+            )
+
+    def test_complete_review_invalid_review_id(self, review_manager):
+        """Test completing a non-existent review."""
+        with pytest.raises(ValueError):
+            review_manager.complete_review(
+                review_id="invalid_review",
+                summary="Review completed",
+            )
+
     def test_add_feedback_comment(self, review_manager):
         """Test adding feedback comments to a review."""
         review_manager.submit_code(


### PR DESCRIPTION
## Summary

This PR improves the test coverage of the `CodeReviewManager` by adding unit tests that verify the existing validation behavior when an invalid `review_id` is provided.

## Changes

Added the following unit tests:

- `test_add_feedback_invalid_review_id`
  - Verifies that `add_feedback_comment()` raises `ValueError` when an invalid `review_id` is provided.

- `test_score_category_invalid_review_id`
  - Verifies that `score_category()` raises `ValueError` when an invalid `review_id` is provided.

- `test_complete_review_invalid_review_id`
  - Verifies that `complete_review()` raises `ValueError` when an invalid `review_id` is provided.

## Why

These tests improve coverage of the existing validation logic by ensuring invalid review identifiers are handled consistently across the code review workflow. This change only adds test coverage and does not modify production code or existing functionality.

## Testing

Executed the following command:

```bash
python -m pytest tests/test_code_review.py -v
```

Result:

- All tests in `tests/test_code_review.py` passed successfully.

## Related Issue

Closes #1280