### PR TITLE
feat: add skill proficiency levels

### DIFF
--- a/src/static/script.js
+++ b/src/static/script.js
@@ -433,6 +433,7 @@ updateProfileWidgets();
   var skillWrap = document.getElementById("skill-input-wrap");
   var quickPickChips = Array.prototype.slice.call(document.querySelectorAll(".skill-chip"));
   var selectedSkills = [];
+  var skillProficiencies = {};
   var availableSkills = (typeof skills !== "undefined" && Array.isArray(skills))
     ? skills.map(function (item) { return item.label; }).filter(Boolean)
     : quickPickChips.map(function (chip) { return chip.getAttribute("data-skill"); });
@@ -473,7 +474,7 @@ updateProfileWidgets();
     selectedSkills.forEach(function (skill) {
       var chip = document.createElement("span");
       chip.className = "skill-chip-selected";
-      chip.appendChild(document.createTextNode(skill));
+      chip.appendChild(document.createTextNode(skill + " (" + (skillProficiencies[skill] || "Beginner") + ")"));
       var button = document.createElement("button");
       button.type = "button";
       button.className = "skill-chip-remove";
@@ -492,6 +493,8 @@ updateProfileWidgets();
     var skill = canonicalSkill(rawSkill);
     if (!skill || isSelected(skill)) return;
     selectedSkills.push(skill);
+    var proficiencySelect = document.getElementById("skill-proficiency");
+    skillProficiencies[skill] = proficiencySelect ? proficiencySelect.value : "Beginner";
     renderSelectedChips();
     syncSkillsHiddenInput();
     updateQuickPickState();
@@ -501,6 +504,7 @@ updateProfileWidgets();
 
   function removeSkill(skill) {
     selectedSkills = selectedSkills.filter(function (item) { return normalize(item) !== normalize(skill); });
+    delete skillProficiencies[skill];
     renderSelectedChips();
     syncSkillsHiddenInput();
     updateQuickPickState();
@@ -884,7 +888,12 @@ updateProfileWidgets();
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        skills: JSON.stringify(selectedSkills),
+        skills: JSON.stringify(selectedSkills.map(function (skill) {
+          return {
+            skill: skill,
+            proficiency: skillProficiencies[skill] || "Beginner"
+          };
+        })),
         level: document.getElementById("level").value,
         interest: document.getElementById("interest").value,
         time: document.getElementById("time").value,

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -957,6 +957,16 @@
 
             <div class="form-row">
               <div class="form-group">
+                <label for="skill-proficiency">Skill Proficiency</label>
+                <div class="select-wrap">
+                  <select id="skill-proficiency" name="skill-proficiency">
+                    <option value="Beginner">Beginner</option>
+                    <option value="Intermediate" selected>Intermediate</option>
+                    <option value="Advanced">Advanced</option>
+                  </select>
+                </div>
+                <span class="form-hint">Selected level is assigned to newly added skills.</span>
+
                 <label for="level">Experience Level</label>
                 <div class="select-wrap">
                   <select id="level" name="level">

--- a/src/utils/recommender.py
+++ b/src/utils/recommender.py
@@ -59,31 +59,47 @@ SKILL_ALIASES = {
     "web dev": "javascript",
 }
 
-def parse_skills(skills_string):
-    """
-    Convert a raw skills string into a normalized lowercase list.
-    Accepts either a JSON array (e.g. '["Python","React"]') or a
-    comma-separated string (e.g. "JS, HTML5, CSS3").
-
-    Example:
-        '["Python","React"]' -> ["python", "react"]
-        "JS, HTML5, CSS3"   -> ["javascript", "html", "css"]
-    """
+def parse_skill_entries(skills_string):
+    """Parse skills with optional per-skill proficiency levels."""
     stripped = skills_string.strip()
+
     if stripped.startswith("["):
         try:
             parsed = json.loads(stripped)
             if isinstance(parsed, list):
-                raw_skills = [str(s).strip().lower() for s in parsed if str(s).strip()]
-                return [SKILL_ALIASES.get(skill, skill) for skill in raw_skills]
+                entries = []
+                for item in parsed:
+                    if isinstance(item, dict):
+                        skill = str(item.get("skill", "")).strip().lower()
+                        proficiency = str(item.get("proficiency", "Beginner")).strip().title()
+                    else:
+                        skill = str(item).strip().lower()
+                        proficiency = "Beginner"
+
+                    if skill:
+                        entries.append({
+                            "skill": SKILL_ALIASES.get(skill, skill),
+                            "proficiency": proficiency if proficiency in ("Beginner", "Intermediate", "Advanced") else "Beginner",
+                        })
+                return entries
         except (json.JSONDecodeError, ValueError):
             pass
-    raw_skills = [
-        s.strip().lower()
-        for s in skills_string.split(",")
-        if s.strip()
+
+    return [
+        {
+            "skill": SKILL_ALIASES.get(skill, skill),
+            "proficiency": "Beginner",
+        }
+        for skill in (
+            s.strip().lower()
+            for s in skills_string.split(",")
+            if s.strip()
+        )
     ]
-    return [SKILL_ALIASES.get(skill, skill) for skill in raw_skills]
+
+
+def parse_skills(skills_string):
+    return [entry["skill"] for entry in parse_skill_entries(skills_string)]
 
 def _tokenize(text):
     return re.findall(r"[a-z0-9]+", str(text).lower())
@@ -151,7 +167,7 @@ def ml_similarity_score(project, user_skills, level, interest, time_availability
 
     return _cosine_similarity(user_vector, project_vector)
 
-def score_single_project(project, user_skills, level, interest, time_availability):
+def score_single_project(project, user_skills, level, interest, time_availability, skill_proficiencies=None):
     TIME_RANKS = ["low", "medium", "high"]
 
     user_time    = time_availability.strip().lower()
@@ -168,11 +184,22 @@ def score_single_project(project, user_skills, level, interest, time_availabilit
     # Compare user's skills against the project's required skills
     project_skills = [SKILL_ALIASES.get(s.lower(), s.lower()) for s in project.get("skills", [])]
     matched_skills = sum(1 for skill in user_skills if skill in project_skills)
+    proficiency_weights = {
+        "beginner": 1.0,
+        "intermediate": 1.5,
+        "advanced": 2.0,
+    }
+    skill_proficiencies = skill_proficiencies or {}
+    weighted_skill_score = sum(
+        proficiency_weights.get(skill_proficiencies.get(skill, "Beginner").lower(), 1.0)
+        for skill in user_skills
+        if skill in project_skills
+    )
     if project_skills:
         coverage = matched_skills / len(project_skills)
-        score += matched_skills * SCORING_WEIGHTS["skill"] * coverage
+        score += weighted_skill_score * SCORING_WEIGHTS["skill"] * coverage
     else:
-        score += matched_skills * SCORING_WEIGHTS["skill"]
+        score += weighted_skill_score * SCORING_WEIGHTS["skill"]
 
     level_match = False
     if project.get("level", "").lower() == level.lower():
@@ -384,7 +411,12 @@ def project_matches_tech(project, tech_stack):
 
 
 def get_recommendations(skills_string, level, interest, time_availability, tech_stack="all"):
-    user_skills = parse_skills(skills_string)
+    skill_entries = parse_skill_entries(skills_string)
+    user_skills = [entry["skill"] for entry in skill_entries]
+    skill_proficiencies = {
+        entry["skill"]: entry["proficiency"]
+        for entry in skill_entries
+    }
     all_projects = load_all_projects()
     
     if tech_stack and tech_stack.lower() != "all":
@@ -399,6 +431,7 @@ def get_recommendations(skills_string, level, interest, time_availability, tech_
             level,
             interest,
             time_availability,
+            skill_proficiencies,
         )
         if isinstance(score_result, tuple):
             rule_score, match_details = score_result


### PR DESCRIPTION
## Description

Adds skill proficiency levels to improve personalized project recommendations.

## Changes

* Added Beginner, Intermediate, and Advanced skill proficiency levels.
* Stores proficiency for each selected skill.
* Displays proficiency alongside selected skills.
* Added backward-compatible handling for existing skill data.
* Updated recommendation scoring to give different weights based on skill proficiency.
* Advanced skills have a stronger recommendation influence than Beginner skills.

## Testing

* Python syntax validation passed.
* `git diff --check` passed.
* Verified proficiency-based scoring:

  * Beginner score: 8.0
  * Advanced score: 11.0
* Existing upstream dataset validation issue related to missing `tech_stack` remains unrelated to this feature.

Closes #1288


