### PR TITLE
fix : replace emoji icons with text alternatives in portfolio_analyzer.py

### DIFF
--- a/src/utils/portfolio_analyzer.py
+++ b/src/utils/portfolio_analyzer.py
@@ -15,51 +15,51 @@ from collections import OrderedDict
 # OrderedDict just makes that intent explicit).
 PROJECT_CATEGORIES = OrderedDict([
     ("Frontend", {
-        "icon": "🎨",
+        "icon": "[FE]",
         "keywords": ["react", "vue", "angular", "html", "css", "javascript",
                      "tailwind", "bootstrap", "frontend", "ui"],
     }),
     ("Backend", {
-        "icon": "⚙️",
+        "icon": "[BE]",
         "keywords": ["flask", "django", "express", "node", "spring",
                      "fastapi", "backend", "server"],
     }),
     ("Database", {
-        "icon": "🗄️",
+        "icon": "[DB]",
         "keywords": ["mysql", "mongodb", "postgresql", "sqlite", "firebase",
                      "database", "sql", "nosql"],
     }),
     ("Authentication", {
-        "icon": "🔐",
+        "icon": "[AUTH]",
         "keywords": ["jwt", "oauth", "login", "authentication", "auth",
                      "signup", "session"],
     }),
     ("API Integration", {
-        "icon": "🔌",
+        "icon": "[API]",
         "keywords": ["api", "rest", "graphql", "axios", "fetch", "webhook"],
     }),
     ("Testing", {
-        "icon": "🧪",
+        "icon": "[TEST]",
         "keywords": ["pytest", "jest", "testing", "unit test", "unittest",
                      "test coverage", "tdd"],
     }),
     ("Deployment", {
-        "icon": "🚀",
+        "icon": "[DEPLOY]",
         "keywords": ["docker", "vercel", "netlify", "aws", "render",
                      "heroku", "deployment", "deploy"],
     }),
     ("AI/ML", {
-        "icon": "🤖",
+        "icon": "[AI]",
         "keywords": ["machine learning", "tensorflow", "opencv", "ai", "ml",
                      "pytorch", "scikit", "nlp", "llm"],
     }),
     ("DevOps", {
-        "icon": "🛠️",
+        "icon": "[DO]",
         "keywords": ["kubernetes", "github actions", "jenkins", "ci/cd",
                      "ci-cd", "pipeline", "devops"],
     }),
     ("Real-time", {
-        "icon": "💬",
+        "icon": "[RT]",
         "keywords": ["socket", "websocket", "chat", "firebase realtime",
                      "real-time", "realtime", "live"],
     }),


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced all emoji characters in the `PROJECT_CATEGORIES` OrderedDict in `src/utils/portfolio_analyzer.py` with plain-text abbreviations to comply with the project style guidelines.

## Changes Made

- `Frontend` icon: "\U0001f3a8" -> "[FE]"
- `Backend` icon: "\U00002699" -> "[BE]"
- `Database` icon: "\U0001f5c4" -> "[DB]"
- `Authentication` icon: "\U0001f510" -> "[AUTH]"
- `API Integration` icon: "\U0001f50c" -> "[API]"
- `Testing` icon: "\U0001f9ea" -> "[TEST]"
- `Deployment` icon: "\U0001f680" -> "[DEPLOY]"
- `AI/ML` icon: "\U0001f916" -> "[AI]"
- `DevOps` icon: "\U0001f9e0" -> "[DO]"
- `Real-time` icon: "\U0001f4ac" -> "[RT]"

## Impact it Made

- Consistent emoji-free codebase style
- No rendering/encoding issues in environments without emoji support
- Cleaner log and diagnostic output

Closes #1308

## Note: Please assign this PR to the `tmdeveloper007` account.