### PR TITLE
fix : added TTL-based cache invalidation to data_loader

### DIFF
--- a/src/utils/data_loader.py
+++ b/src/utils/data_loader.py
@@ -4,6 +4,7 @@ import json
 import os
 import threading
 import logging
+import time
 from pathlib import Path
 
 from utils.url_validator import is_valid_url, parse_resource
@@ -12,6 +13,15 @@ from models import Project
 logger = logging.getLogger("devpath.data_loader")
 
 _projects_cache = None
+_projects_cache_time = 0.0
+_CACHE_TTL_SECONDS = 300  # 5 minutes
+
+
+def _cache_expired():
+    """Return True if the cache is missing or older than _CACHE_TTL_SECONDS."""
+    if _projects_cache is None:
+        return True
+    return (time.time() - _projects_cache_time) > _CACHE_TTL_SECONDS
 
 
 def validate_projects(projects):
@@ -77,10 +87,11 @@ def validate_projects(projects):
 
 def load_all_projects():
     """Read and return the full list of projects from the database."""
-    global _projects_cache
-    if _projects_cache is None:
+    global _projects_cache, _projects_cache_time
+    if _cache_expired():
         projects = Project.query.all()
         _projects_cache = [p.to_dict() for p in projects]
+        _projects_cache_time = time.time()
     return _projects_cache
 
 def get_available_levels():
@@ -119,5 +130,6 @@ def get_project_stats():
 
 def clear_cache():
     """Reset the in-memory project cache (used in tests)."""
-    global _projects_cache
+    global _projects_cache, _projects_cache_time
     _projects_cache = None
+    _projects_cache_time = 0.0


### PR DESCRIPTION
## Summary of What Has Been Done

Added time-based cache expiration to `load_all_projects()` in `src/utils/data_loader.py` so the in-memory project cache does not serve stale data indefinitely.

## Changes Made

- Added `_projects_cache_time` global to track when the cache was last populated
- Added `_CACHE_TTL_SECONDS = 300` (5-minute TTL constant)
- Added `_cache_expired()` helper that returns `True` when the cache is missing or older than the TTL
- Updated `load_all_projects()` to use `_cache_expired()` instead of a bare `None` check, and to record `time.time()` on cache miss
- Updated `clear_cache()` to also reset `_projects_cache_time` to 0

## Impact it Made

Users will always see project data that is at most 5 minutes old instead of potentially stale cached data from when the app started. This fixes a data consistency bug where database updates were invisible to running instances.

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #1318