### PR TITLE
fix : ensure encryption key is always bytes in PrivacyManager

### DIFF
--- a/src/utils/privacy.py
+++ b/src/utils/privacy.py
@@ -10,7 +10,13 @@ class PrivacyManager:
     """Manages GDPR compliance, data encryption, and privacy controls."""
 
     def __init__(self):
-        self.encryption_key = os.getenv("ENCRYPTION_KEY", Fernet.generate_key())
+        raw_key = os.getenv("ENCRYPTION_KEY")
+        if raw_key is None:
+            self.encryption_key = Fernet.generate_key()
+        elif isinstance(raw_key, str):
+            self.encryption_key = raw_key.encode()
+        else:
+            self.encryption_key = raw_key
         self.cipher = Fernet(self.encryption_key)
         self.user_consent: Dict[str, Dict] = {}
         self.data_requests: Dict[str, Dict] = {}


### PR DESCRIPTION
## Summary of What Has Been Done
Fixed the encryption key initialization in `src/utils/privacy.py` to ensure the key is always bytes before passing to `Fernet()`.

The previous code used `os.getenv("ENCRYPTION_KEY", Fernet.generate_key())`. Since `os.getenv()` always returns a string (or None), if `ENCRYPTION_KEY` is set as an environment variable, `Fernet(string_key)` would crash with a TypeError. `Fernet.generate_key()` returns bytes, but only when the env var is NOT set.

## Changes Made
- `src/utils/privacy.py`: Changed key initialization to explicitly handle string env vars by encoding them to bytes:
```python
raw_key = os.getenv("ENCRYPTION_KEY")
if raw_key is None:
    self.encryption_key = Fernet.generate_key()
elif isinstance(raw_key, str):
    self.encryption_key = raw_key.encode()
else:
    self.encryption_key = raw_key
```

## Impact it Made
- Prevents crash when `ENCRYPTION_KEY` environment variable is set as a string
- Ensures consistent bytes-based key for Fernet regardless of how the key is provided
- Maintains backward compatibility with existing code

## Note
Please assign this PR to the `tmdeveloper007` account.

Closes #1326
