### PR TITLE
fix : rename misleading cache_hits to cached_items in ml_recommender

### DIFF
--- a/src/utils/ml_recommender.py
+++ b/src/utils/ml_recommender.py
@@ -99,11 +99,7 @@ class MLRecommender:
         """Get ML model performance metrics."""
         return {
             "features_count": len(self.model_state),
-            "cache_hits": self._count_cache_hits(),
+            "cached_items": len(self.cache),
             "average_score": 0.85,
             "model_accuracy": 0.92,
         }
-
-    def _count_cache_hits(self) -> int:
-        """Count cache hits (simplified)."""
-        return len(self.cache)


### PR DESCRIPTION
## Summary of What Has Been Done
Fixed the misleading `cache_hits` field in `src/utils/ml_recommender.py` `get_model_metrics` method. The field was returning `len(self.cache)` (the current number of cached items) instead of actual cache hit counts.

## Changes Made
- Renamed `cache_hits` to `cached_items` in `get_model_metrics` to accurately reflect what the metric measures
- Removed the now-unused `_count_cache_hits` helper method

## Impact it Made
- Ensures API consumers understand the metric represents cached items, not hit counts
- Removes dead code (`_count_cache_hits` method is no longer needed)
- Provides accurate naming that matches the actual data returned

## Note
Please assign this PR to the `tmdeveloper007` account.
