### PR TITLE
fix : simplified log_exception traceback handling in error_logger.py

### DIFF
--- a/src/utils/error_logger.py
+++ b/src/utils/error_logger.py
@@ -63,11 +63,7 @@ def log_exception(
     correlation_id = uuid.uuid4().hex[:8]
 
     exc_type = type(exc).__name__ if exc is not None else "UnknownError"
-    tb = (
-        "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
-        if exc is not None
-        else "No traceback available"
-    )
+    tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)) if exc else "No traceback available"
 
     logger.error(
         "status=%d id=%s type=%s context=%r\n%s",


### PR DESCRIPTION
## Summary of What Has Been Done

Simplified the traceback handling in `log_exception` in `src/utils/error_logger.py` by using a truthiness check (`if exc`) instead of an explicit `is not None` comparison.

## Changes Made

```python
# Before:
tb = (
    "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
    if exc is not None
    else "No traceback available"
)

# After:
tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)) if exc else "No traceback available"
```

## Impact it Made

- Cleaner, more idiomatic Python code
- No functional change for intended use cases (exceptions and None)
- Improved code readability

Closes #1340

Note: Please assign this PR to the `tmdeveloper007` account.