### PR TITLE
fix : removed duplicate jsonify import in main_routes.py

### DIFF
--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -25,7 +25,6 @@ from utils.skill_progression import (
 )
 from utils.code_review import CodeReviewManager
 from config import Config
-from flask import jsonify
 from utils.portfolio_analyzer import analyze_portfolio
 import os
 from models import db, ProjectProgress


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the duplicate `from flask import jsonify` statement in `src/routes/main_routes.py`. The file was importing `jsonify` twice: once as part of the main Flask import at line 6, and again as a standalone import at line 24. The redundant standalone import has been removed.

## Changes Made

- Removed `from flask import jsonify` (standalone line) from `src/routes/main_routes.py`
- The existing `from flask import Blueprint, render_template, request, jsonify, ...` import on line 6 already covers the `jsonify` usage

## Impact it Made

- Cleaner code with no redundant imports
- Follows Python/PEP 8 best practices
- Reduces confusion during code reviews

Closes #1346

## Note: please assign this PR to the `tmdeveloper007` account.
