### PR TITLE
fix : removed duplicate header comment in data_loader.py

### DIFF
--- a/src/utils/data_loader.py
+++ b/src/utils/data_loader.py
@@ -1,5 +1,4 @@
 # utils/data_loader.py
-# utils/data_loader.py
 import json
 import os
 import threading


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the duplicate `# utils/data_loader.py` header comment at the top of `src/utils/data_loader.py`. The file had the header comment appearing twice in consecutive lines.

## Changes Made

- Removed the duplicate `# utils/data_loader.py` line from `src/utils/data_loader.py`

## Impact it Made

- Cleaner, less redundant file header
- Follows the project's own conventions for module headers
- Reduces noise during code navigation

Closes #1347

## Note: please assign this PR to the `tmdeveloper007` account.
