### PR TITLE
fix : removed duplicate jsonify import in main_routes.py

### DIFF
--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -25,7 +25,6 @@ from utils.skill_progression import (
 )
 from utils.code_review import CodeReviewManager
 from config import Config
-from flask import jsonify
 from utils.portfolio_analyzer import analyze_portfolio
 import os
 from models import db, ProjectProgress


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the duplicate `from flask import jsonify` import from `src/routes/main_routes.py`. The import appeared twice (lines 6 and 28), which is redundant and follows Python import best practices.

## Changes Made

- Removed the duplicate `from flask import jsonify` statement from `src/routes/main_routes.py`

## Impact it Made

- Eliminates redundant import in the main routes module
- Follows DRY (Do Not Repeat Yourself) principle
- Cleaner and more maintainable code

Closes #1397.

Note: Please assign this PR to the `tmdeveloper007` account.
