### PR TITLE
fix : replaced deprecated datetime.utcnow with timezone-aware alternative in ui_enhancement

### DIFF
--- a/src/utils/ui_enhancement.py
+++ b/src/utils/ui_enhancement.py
@@ -2,7 +2,7 @@
 
 from typing import Dict, List, Optional
 from enum import Enum
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class AccessibilityLevel(Enum):
@@ -132,5 +132,5 @@ class UIEnhancementManager:
             "user_id": user_id,
             "from": from_page,
             "to": to_page,
-            "timestamp": str(datetime.utcnow()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced the deprecated `datetime.utcnow()` with the timezone-aware `datetime.now(timezone.utc)` in `src/utils/ui_enhancement.py`.

## Changes Made

In `src/utils/ui_enhancement.py`:
- Added `timezone` to the datetime import
- Replaced `str(datetime.utcnow())` with `datetime.now(timezone.utc).isoformat()` in the `track_navigation_flow` method

## Impact it Made

- Eliminates Python 3.12+ deprecation warnings for `datetime.utcnow()`
- Uses the recommended timezone-aware datetime approach
- Correct timestamp generation for navigation flow tracking

Closes #1399.

Note: Please assign this PR to the `tmdeveloper007` account.
