### PR TITLE
fix : replaced deprecated datetime.utcnow with timezone-aware alternative in skill_progression

### DIFF
--- a/src/utils/skill_progression.py
+++ b/src/utils/skill_progression.py
@@ -7,7 +7,7 @@ recommendations to ensure users develop foundational knowledge before advancing.
 
 from typing import Dict, List, Set, Optional, Tuple
 from enum import Enum
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class SkillDifficulty(Enum):
@@ -194,7 +194,7 @@ class SkillProgressionValidator:
 
         skill_data = self.user_skills[user_id][skill_name]
         skill_data["difficulty"] = difficulty
-        skill_data["completed_at"] = datetime.utcnow().isoformat()
+        skill_data["completed_at"] = datetime.now(timezone.utc).isoformat()
         skill_data["assessment_score"] = assessment_score
         skill_data["progression_history"].append(
             {


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced the deprecated `datetime.utcnow()` with the timezone-aware `datetime.now(timezone.utc)` in `src/utils/skill_progression.py`.

## Changes Made

In `src/utils/skill_progression.py`:
- Added `timezone` to the datetime import
- Replaced `datetime.utcnow()` with `datetime.now(timezone.utc)` in `record_skill_completion`

## Impact it Made

- Eliminates Python 3.12+ deprecation warnings for `datetime.utcnow()`
- Uses the recommended timezone-aware datetime approach
- Correct timestamp generation for skill completion tracking

Closes #1401.

Note: Please assign this PR to the `tmdeveloper007` account.
