### PR TITLE
fix : replaced deprecated datetime.utcnow with timezone-aware alternative in testing_utils

### DIFF
--- a/src/utils/testing_utils.py
+++ b/src/utils/testing_utils.py
@@ -1,7 +1,7 @@
 """Testing infrastructure and CI/CD utilities."""
 
 from typing import Dict, List, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class TestMetrics:
@@ -27,7 +27,7 @@ class TestMetrics:
             "status": status,
             "duration_ms": duration_ms,
             "error": error,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         self.test_results[test_id] = result
         return result
@@ -87,7 +87,7 @@ class TestMetrics:
             "status": status,
             "test_summary": test_summary,
             "coverage": coverage,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         self.ci_runs.append(run)
         return run


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced the deprecated `datetime.utcnow()` with the timezone-aware `datetime.now(timezone.utc)` in `src/utils/testing_utils.py`.

## Changes Made

In `src/utils/testing_utils.py`:
- Added `timezone` to the datetime import
- Replaced `datetime.utcnow()` with `datetime.now(timezone.utc)` in `record_test_result` and `record_ci_run` methods

## Impact it Made

- Eliminates Python 3.12+ deprecation warnings for `datetime.utcnow()`
- Uses the recommended timezone-aware datetime approach
- Correct timestamp generation for test metrics and CI run records

Closes #1403.

Note: Please assign this PR to the `tmdeveloper007` account.
