### PR TITLE
fix : replaced deprecated datetime.utcnow with timezone-aware alternative in code_review

### DIFF
--- a/src/utils/code_review.py
+++ b/src/utils/code_review.py
@@ -7,7 +7,7 @@ for learner project submissions.
 
 from typing import Dict, List, Optional
 from enum import Enum
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 
 
@@ -101,7 +101,7 @@ class CodeReviewManager:
             "code": code,
             "language": language,
             "description": description or "",
-            "submitted_at": datetime.utcnow().isoformat(),
+            "submitted_at": datetime.now(timezone.utc).isoformat(),
             "review_status": ReviewStatus.PENDING.value,
             "review_count": 0,
             "metrics": {},
@@ -129,13 +129,13 @@ class CodeReviewManager:
             raise ValueError(f"Submission {submission_id} not found")
 
         submission = self.submissions[submission_id]
-        review_id = f"review_{submission_id}_{datetime.utcnow().timestamp()}"
+        review_id = f"review_{submission_id}_{datetime.now(timezone.utc).timestamp()}"
 
         review = {
             "review_id": review_id,
             "submission_id": submission_id,
             "reviewer_id": reviewer_id,
-            "started_at": datetime.utcnow().isoformat(),
+            "started_at": datetime.now(timezone.utc).isoformat(),
             "completed_at": None,
             "status": ReviewStatus.IN_PROGRESS.value,
             "overall_score": None,
@@ -179,7 +179,7 @@ class CodeReviewManager:
             "code_snippet": code_snippet,
             "feedback": feedback,
             "severity": severity,
-            "created_at": datetime.utcnow().isoformat(),
+            "created_at": datetime.now(timezone.utc).isoformat(),
         }
 
         self.feedback_comments[review_id].append(comment)
@@ -250,7 +250,7 @@ class CodeReviewManager:
         scores = [s["score"] for s in review["category_scores"].values()]
         overall_score = sum(scores) / len(scores) if scores else 0
 
-        review["completed_at"] = datetime.utcnow().isoformat()
+        review["completed_at"] = datetime.now(timezone.utc).isoformat()
         review["overall_score"] = round(overall_score, 2)
         review["summary"] = summary
         review["status"] = (


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced all occurrences of the deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)` in `src/utils/code_review.py`.

## Changes Made

- Changed `from datetime import datetime` to `from datetime import datetime, timezone` in the import statement
- Replaced `datetime.utcnow()` with `datetime.now(timezone.utc)` in 5 locations across the following methods:
  - `submit_code` method (submitted_at timestamp)
  - `start_review` method (review_id generation and started_at timestamp)
  - `add_feedback_comment` method (created_at timestamp)
  - `complete_review` method (completed_at timestamp)

## Impact it Made

- Eliminates Python 3.12+ deprecation warnings for `datetime.utcnow()`
- Uses the recommended timezone-aware datetime approach throughout the code review module
- Correct timestamp generation for code submissions, reviews, and feedback

Closes #1407.

Note: Please assign this PR to the `tmdeveloper007` account.