### PR TITLE
fix : replaced deprecated datetime.utcnow with timezone-aware alternative in community

### DIFF
--- a/src/utils/community.py
+++ b/src/utils/community.py
@@ -1,7 +1,7 @@
 """Community and peer support system."""
 
 from typing import Dict, List, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class CommunityManager:
@@ -23,7 +23,7 @@ class CommunityManager:
             "course_id": course_id,
             "title": title,
             "content": content,
-            "created_at": datetime.utcnow().isoformat(),
+            "created_at": datetime.now(timezone.utc).isoformat(),
             "replies": [],
             "likes": 0,
         }
@@ -42,7 +42,7 @@ class CommunityManager:
             "reply_id": f"reply_{len(self.discussions[discussion_id]['replies'])}",
             "user_id": user_id,
             "content": reply_content,
-            "created_at": datetime.utcnow().isoformat(),
+            "created_at": datetime.now(timezone.utc).isoformat(),
             "likes": 0,
         }
         self.discussions[discussion_id]["replies"].append(reply)
@@ -66,7 +66,7 @@ class CommunityManager:
             "title": title,
             "content": content,
             "tags": tags,
-            "created_at": datetime.utcnow().isoformat(),
+            "created_at": datetime.now(timezone.utc).isoformat(),
             "answers": [],
             "views": 0,
             "upvotes": 0,
@@ -86,7 +86,7 @@ class CommunityManager:
             "answer_id": f"answer_{len(self.questions[question_id]['answers'])}",
             "user_id": user_id,
             "content": answer_content,
-            "created_at": datetime.utcnow().isoformat(),
+            "created_at": datetime.now(timezone.utc).isoformat(),
             "upvotes": 0,
             "is_accepted": False,
         }
@@ -104,7 +104,7 @@ class CommunityManager:
             "name": name,
             "course_id": course_id,
             "members": [creator_id],
-            "created_at": datetime.utcnow().isoformat(),
+            "created_at": datetime.now(timezone.utc).isoformat(),
             "description": "",
             "schedule": None,
         }


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced all occurrences of the deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)` in `src/utils/community.py`.

## Changes Made

- Changed `from datetime import datetime` to `from datetime import datetime, timezone` in the import statement
- Replaced 5 occurrences of `datetime.utcnow()` with `datetime.now(timezone.utc)` in the following methods:
  - `create_discussion` (created_at timestamp)
  - `reply_to_discussion` (created_at timestamp)
  - `ask_question` (created_at timestamp)
  - `answer_question` (created_at timestamp)
  - `create_study_group` (created_at timestamp)

## Impact it Made

- Eliminates Python 3.12+ deprecation warnings for `datetime.utcnow()`
- Uses the recommended timezone-aware datetime approach throughout the community module
- Correct timestamp generation for discussions, questions, answers, and study groups

Closes #1408.

Note: Please assign this PR to the `tmdeveloper007` account.