### PR TITLE
fix : replaced deprecated datetime.utcnow with timezone-aware alternative in ml_recommender

### DIFF
--- a/src/utils/ml_recommender.py
+++ b/src/utils/ml_recommender.py
@@ -1,7 +1,7 @@
 """ML-accelerated recommendation system with caching and batching."""
 
 from typing import Dict, List, Optional
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import hashlib
 
 
@@ -27,14 +27,14 @@ class MLRecommender:
 
         if use_cache and cache_key in self.cache:
             cached = self.cache[cache_key]
-            if datetime.utcnow() < cached["expires_at"]:
+            if datetime.now(timezone.utc) < cached["expires_at"]:
                 return cached["data"]
 
         recommendations = self._ml_score(skills, difficulty, interest)
 
         self.cache[cache_key] = {
             "data": recommendations,
-            "expires_at": datetime.utcnow() + timedelta(seconds=self.cache_ttl),
+            "expires_at": datetime.now(timezone.utc) + timedelta(seconds=self.cache_ttl),
         }
 
         return recommendations
@@ -92,7 +92,7 @@ class MLRecommender:
         """Add new ML feature with weights."""
         self.model_state[feature_name] = {
             "weights": weights,
-            "added_at": datetime.utcnow().isoformat(),
+            "added_at": datetime.now(timezone.utc).isoformat(),
         }
 
     def get_model_metrics(self) -> Dict:


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced all occurrences of the deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)` in `src/utils/ml_recommender.py`.

## Changes Made

- Changed `from datetime import datetime, timedelta` to `from datetime import datetime, timedelta, timezone` in the import statement
- Replaced 3 occurrences of `datetime.utcnow()` with `datetime.now(timezone.utc)` in the following locations:
  - `generate_recommendations` method: cache expiry check comparison (both sides updated to timezone-aware)
  - `generate_recommendations` method: cache entry expires_at timestamp
  - `add_ml_feature` method: added_at timestamp

## Impact it Made

- Eliminates Python 3.12+ deprecation warnings for `datetime.utcnow()`
- Uses the recommended timezone-aware datetime approach for ML recommendation caching
- Consistent timezone-aware cache TTL calculations

Closes #1409.

Note: Please assign this PR to the `tmdeveloper007` account.