### PR TITLE
fix : removed unused datetime import from discussion_routes

### DIFF
--- a/routes/discussion_routes.py
+++ b/routes/discussion_routes.py
@@ -5,7 +5,6 @@ where learners can ask questions and share knowledge about paths.
 """
 
 from flask import Blueprint, jsonify, request
-from datetime import datetime
 
 discussion_bp = Blueprint('discussions', __name__, url_prefix='/discussions')
 


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the unused `from datetime import datetime` import from `routes/discussion_routes.py`. The module imported `datetime` but never used it anywhere in the file.

## Changes Made

- Removed the line `from datetime import datetime` from `routes/discussion_routes.py`
- No other changes required since datetime is not referenced anywhere in the file

## Impact it Made

- Cleaner, more maintainable code with no unused imports
- Follows Python best practices (PEP 8: unused imports should be removed)
- Slightly faster module import time

Closes #1410.

Note: Please assign this PR to the `tmdeveloper007` account.