### PR TITLE
fix : removed unused datetime import from certificate_routes

### DIFF
--- a/routes/certificate_routes.py
+++ b/routes/certificate_routes.py
@@ -5,7 +5,6 @@ learning paths, and verifying certificate authenticity.
 """
 
 from flask import Blueprint, jsonify, render_template_string, request
-from datetime import datetime
 import json
 
 certificate_bp = Blueprint('certificates', __name__, url_prefix='/certificates')


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the unused `from datetime import datetime` import from `routes/certificate_routes.py`. The module imported `datetime` but never used it anywhere in the file.

## Changes Made

- Removed the line `from datetime import datetime` from `routes/certificate_routes.py`
- No other changes required since datetime is not referenced anywhere in the file

## Impact it Made

- Cleaner, more maintainable code with no unused imports
- Follows Python best practices (PEP 8: unused imports should be removed)
- Slightly faster module import time

Closes #1411.

Note: Please assign this PR to the `tmdeveloper007` account.