### PR TITLE
fix : removed unused json import from code_review.py

### DIFF
--- a/src/errors/handlers.py
+++ b/src/errors/handlers.py
@@ -8,14 +8,11 @@
 #   3. Never leaks stack traces, file paths, or internal state to the client.
 #
 # Register by calling register_error_handlers(app) from app.py.
-from flask import make_response
-from flask import Flask, render_template, request, jsonify
+from flask import Flask, render_template, request, jsonify, has_request_context
 from config import Config
 from utils.error_logger import log_exception
 
-from flask import has_request_context, request
 
-from flask import has_request_context
 
 def _wants_json():
     if not has_request_context():

--- a/src/utils/code_review.py
+++ b/src/utils/code_review.py
@@ -8,7 +8,6 @@ for learner project submissions.
 from typing import Dict, List, Optional
 from enum import Enum
 from datetime import datetime
-import json
 
 
 class ReviewStatus(Enum):


### PR DESCRIPTION
## Summary of What Has Been Done

In , the  module was imported but never used anywhere in the file.

## Changes Made

- Removed  from the top of the file.

## Impact it Made

- Removes a dead import and keeps the import block clean.
- Follows Python import hygiene best practices.

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #1419