### PR TITLE
fix : removed unused get_starter_code_dir import and duplicate jsonify import from main_routes.py

### DIFF
--- a/src/errors/handlers.py
+++ b/src/errors/handlers.py
@@ -8,14 +8,11 @@
 #   3. Never leaks stack traces, file paths, or internal state to the client.
 #
 # Register by calling register_error_handlers(app) from app.py.
-from flask import make_response
-from flask import Flask, render_template, request, jsonify
+from flask import Flask, render_template, request, jsonify, has_request_context
 from config import Config
 from utils.error_logger import log_exception
 
-from flask import has_request_context, request
 
-from flask import has_request_context
 
 def _wants_json():
     if not has_request_context():

--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -8,7 +8,7 @@ from flask import Blueprint, render_template, request, jsonify, send_from_direct
 from utils.recommender import get_recommendations, validate_recommendation_inputs
 from utils.data_loader import find_project_by_id, load_all_projects, get_available_levels, get_project_stats, get_available_interests
 from utils.roadmap_comparer import load_all_career_roadmaps, compare_roadmaps
-from utils.file_server import read_starter_code, resolve_starter_file, get_starter_code_dir
+from utils.file_server import read_starter_code, resolve_starter_file
 from utils.rate_limiter import rate_limit
 from utils.learning_path import (
     create_learning_path,
@@ -25,7 +25,6 @@ from utils.skill_progression import (
 )
 from utils.code_review import CodeReviewManager
 from config import Config
-from flask import jsonify
 from utils.portfolio_analyzer import analyze_portfolio
 import os
 from models import db, ProjectProgress


### PR DESCRIPTION
## Summary of What Has Been Done

In , two import issues were fixed:
1.  was imported from  but never called anywhere in the file.
2.  was imported twice - once in the main Flask import line, and again on a separate line.

## Changes Made

1. Removed  from the  line.
2. Removed the duplicate  line (jsonify was already in the first Flask import).

## Impact it Made

- Removes dead code and fixes duplicate imports.
- Follows Python import hygiene best practices.
- Makes the file cleaner and easier to maintain.

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #1421