### PR TITLE
Fix: Course progress not saving when switching devices

### DIFF
--- a/migrations/005_create_user_game_progress.sql
+++ b/migrations/005_create_user_game_progress.sql
@@ -1,0 +1,11 @@
+-- Migration: Create user game progress table
+-- Syncs gamification progress (searches, views, completions, badges) across devices
+
+CREATE TABLE IF NOT EXISTS user_game_progress (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL UNIQUE,
+  data TEXT NOT NULL DEFAULT '{}',
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_game_progress_user_id ON user_game_progress(user_id);

--- a/src/models.py
+++ b/src/models.py
@@ -71,3 +71,12 @@ class ProjectProgress(db.Model):
 
     user = db.relationship('User', backref=db.backref('progress', lazy=True, cascade="all, delete-orphan"))
     project = db.relationship('Project')
+
+class UserGameProgress(db.Model):
+    __tablename__ = 'user_game_progress'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False, unique=True)
+    data = db.Column(db.JSON, nullable=False, default=dict)
+
+    user = db.relationship('User', backref=db.backref('game_progress', uselist=False, cascade="all, delete-orphan"))

--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -28,7 +28,7 @@ from config import Config
 from flask import jsonify
 from utils.portfolio_analyzer import analyze_portfolio
 import os
-from models import db, ProjectProgress
+from models import db, ProjectProgress, UserGameProgress
 
 _skill_validator = SkillProgressionValidator()
 _code_review_manager = CodeReviewManager()
@@ -888,6 +888,35 @@ def update_project_progress(project_id):
 
     db.session.commit()
     return jsonify({"message": "Progress saved successfully"}), 200
+@main.route("/api/user-progress", methods=["GET"])
+def get_user_game_progress():
+    user_id = session.get("user_id")
+    if not user_id:
+        return jsonify({"error": "Unauthorized"}), 401
+
+    progress = UserGameProgress.query.filter_by(user_id=user_id).first()
+    return jsonify({"data": progress.data if progress else {}}), 200
+
+@main.route("/api/user-progress", methods=["POST"])
+def save_user_game_progress():
+    user_id = session.get("user_id")
+    if not user_id:
+        return jsonify({"error": "Unauthorized"}), 401
+
+    payload = request.get_json(silent=True)
+    if not payload or "data" not in payload:
+        return jsonify({"error": "Invalid payload. Expected 'data'."}), 400
+
+    progress = UserGameProgress.query.filter_by(user_id=user_id).first()
+    if progress:
+        progress.data = payload["data"]
+    else:
+        progress = UserGameProgress(user_id=user_id, data=payload["data"])
+        db.session.add(progress)
+
+    db.session.commit()
+    return jsonify({"message": "Progress saved successfully"}), 200
+
 @main.route("/api/portfolio-analysis", methods=["POST"])
 def portfolio_analysis():
     """

--- a/src/static/script.js
+++ b/src/static/script.js
@@ -238,6 +238,33 @@ function loadProgressState() {
   } catch (err) {
     console.warn("Unable to load progress state", err);
   }
+
+  fetch("/api/user-progress")
+    .then(function (r) {
+      if (!r.ok) throw new Error("Not authenticated");
+      return r.json();
+    })
+    .then(function (data) {
+      if (data.data && Object.keys(data.data).length > 0) {
+        var serverSaved = data.data;
+        if (typeof serverSaved === "object") {
+          var merged = {};
+          Object.keys(progress).forEach(function (k) {
+            if (Array.isArray(progress[k]) && Array.isArray(serverSaved[k])) {
+              merged[k] = serverSaved[k].length > progress[k].length ? serverSaved[k] : progress[k];
+            } else if (typeof progress[k] === "object" && progress[k] !== null && typeof serverSaved[k] === "object" && serverSaved[k] !== null) {
+              merged[k] = Object.assign({}, progress[k], serverSaved[k]);
+            } else {
+              merged[k] = serverSaved[k] !== undefined ? serverSaved[k] : progress[k];
+            }
+          });
+          progress = Object.assign(progress, merged);
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(progress));
+          updateProfileWidgets();
+        }
+      }
+    })
+    .catch(function () {});
 }
 
 function saveProgressState() {
@@ -247,6 +274,12 @@ function saveProgressState() {
   } catch (err) {
     console.warn("Unable to save progress state", err);
   }
+
+  fetch("/api/user-progress", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ data: progress }),
+  }).catch(function () {});
 }
 
 function computeProgressPoints() {


### PR DESCRIPTION
## Description
Course progress (searches, views, completions, badges, achievements) now syncs across devices via server-side persistence.

## Changes
- Added `UserGameProgress` model to persist gamification progress in the database
- Added `GET /api/user-progress` and `POST /api/user-progress` API endpoints
- Updated `loadProgressState()` to fetch server data on page load and merge with local state
- Updated `saveProgressState()` to POST progress to the server when authenticated
- Smart merge logic: prefers longer arrays (more data) on conflict
- Added migration `005_create_user_game_progress.sql`

Fixes #393