### PR TITLE
fix : replaced count-based reply_id and answer_id with uuid in community.py

### DIFF
--- a/src/utils/community.py
+++ b/src/utils/community.py
@@ -1,5 +1,6 @@
 """Community and peer support system."""
 
+import uuid
 from typing import Dict, List, Optional
 from datetime import datetime
 
@@ -39,7 +40,7 @@ class CommunityManager:
             raise ValueError(f"Discussion {discussion_id} not found")
 
         reply = {
-            "reply_id": f"reply_{len(self.discussions[discussion_id]['replies'])}",
+            "reply_id": f"reply_{uuid.uuid4().hex[:8]}",
             "user_id": user_id,
             "content": reply_content,
             "created_at": datetime.utcnow().isoformat(),
@@ -83,7 +84,7 @@ class CommunityManager:
             raise ValueError(f"Question {question_id} not found")
 
         answer = {
-            "answer_id": f"answer_{len(self.questions[question_id]['answers'])}",
+            "answer_id": f"answer_{uuid.uuid4().hex[:8]}",
             "user_id": user_id,
             "content": answer_content,
             "created_at": datetime.utcnow().isoformat(),


### PR DESCRIPTION
## Summary of What Has Been Done

In `src/utils/community.py`, the `reply_to_discussion` and `answer_question` methods were generating reply/answer IDs using a count-based approach (`len(replies)` / `len(answers)`). This would cause ID collisions if a reply or answer was ever deleted, as the count would decrease and subsequent IDs could collide with deleted ones.

The fix replaces the count-based ID generation with `uuid.uuid4().hex[:8]` which guarantees uniqueness regardless of deletion operations.

## Changes Made

- Added `import uuid` to `src/utils/community.py`
- Changed `reply_id` from `f"reply_{len(self.discussions[discussion_id]['replies'])}"` to `f"reply_{uuid.uuid4().hex[:8]}"`
- Changed `answer_id` from `f"answer_{len(self.questions[question_id]['answers'])}"` to `f"answer_{uuid.uuid4().hex[:8]}"`

## Impact it Made

Ensures reply and answer IDs are always unique within their respective threads, preventing potential ID collisions that could cause data confusion or application errors.

## Note

Please assign this PR to the `tmdeveloper007` account.

Closes #1429.
Closes #1430.