### PR TITLE
fix : ensure encryption key is always bytes in PrivacyManager

### DIFF
--- a/src/utils/privacy.py
+++ b/src/utils/privacy.py
@@ -10,7 +10,11 @@ class PrivacyManager:
     """Manages GDPR compliance, data encryption, and privacy controls."""
 
     def __init__(self):
-        self.encryption_key = os.getenv("ENCRYPTION_KEY", Fernet.generate_key())
+        env_key = os.getenv("ENCRYPTION_KEY")
+        if env_key:
+            self.encryption_key = env_key.encode()
+        else:
+            self.encryption_key = Fernet.generate_key()
         self.cipher = Fernet(self.encryption_key)
         self.user_consent: Dict[str, Dict] = {}
         self.data_requests: Dict[str, Dict] = {}


### PR DESCRIPTION
## Summary of What Has Been Done

In `src/utils/privacy.py`, the `PrivacyManager.__init__` was setting `self.encryption_key = os.getenv("ENCRYPTION_KEY", Fernet.generate_key())`. The problem is that `os.getenv()` returns a string (or None), while `Fernet.generate_key()` returns bytes. When an `ENCRYPTION_KEY` environment variable is set as a string, `Fernet(self.encryption_key)` would fail with a TypeError because `Fernet` requires bytes.

The fix checks whether the environment variable is set, and if so, encodes it to bytes. If not set, it falls back to `Fernet.generate_key()` which already returns bytes.

## Changes Made

In `src/utils/privacy.py`, changed the `__init__` method:

```python
# Before
self.encryption_key = os.getenv("ENCRYPTION_KEY", Fernet.generate_key())

# After
env_key = os.getenv("ENCRYPTION_KEY")
if env_key:
    self.encryption_key = env_key.encode()
else:
    self.encryption_key = Fernet.generate_key()
```

## Impact it Made

Prevents initialization failures when ENCRYPTION_KEY is provided as an environment variable string, making PrivacyManager more robust in production deployments.

## Note

Please assign this PR to the `tmdeveloper007` account.

Closes #1431.