### PR TITLE
fix : remove unused current_app import from auth_routes.py

### DIFF
--- a/src/routes/auth_routes.py
+++ b/src/routes/auth_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, session, redirect, url_for, current_app
+from flask import Blueprint, session, redirect, url_for
 from models import db, User
 
 # We import github from app, but since it's instantiated there, it might cause circular import.


### PR DESCRIPTION
## Summary of What Has Been Done

In `src/routes/auth_routes.py`, the import statement `from flask import Blueprint, session, redirect, url_for, current_app` included `current_app`, but `current_app` is never used anywhere in the file. This is an unused import that has been removed.

## Changes Made

Removed `current_app` from the import statement in `src/routes/auth_routes.py`.

## Impact it Made

Keeps the codebase clean and reduces unnecessary imports. No functional change.

## Note

Please assign this PR to the `tmdeveloper007` account.

Closes #1432.