### PR TITLE
fix : remove or True that makes test assertion always pass in test_tiebreaker.py

### DIFF
--- a/tests/test_tiebreaker.py
+++ b/tests/test_tiebreaker.py
@@ -30,7 +30,7 @@ def test_equal_score_tiebreaker_uses_id():
     result = get_recommendations("python", "Beginner", "web", "low")
     recs = result["recommendations"]
     for i in range(len(recs) - 1):
-        assert recs[i]["id"] <= recs[i + 1]["id"] or True, (
+        assert recs[i]["id"] <= recs[i + 1]["id"], (
             "Tie-breaker not applied — equal-scored projects not ordered by id"
         )
 


### PR DESCRIPTION
## Summary of What Has Been Done

In `tests/test_tiebreaker.py`, the `test_equal_score_tiebreaker_uses_id` test had an assertion on line 33 that always passed due to `or True` appended to the condition:

```python
assert recs[i]["id"] <= recs[i + 1]["id"] or True, (...)
```

This made the test useless for detecting regressions in tie-breaking behavior. The `or True` has been removed so the assertion actually validates the tie-breaker condition.

## Changes Made

Removed `or True` from the assertion in `tests/test_tiebreaker.py`:

```python
# Before
assert recs[i]["id"] <= recs[i + 1]["id"] or True, (...)

# After
assert recs[i]["id"] <= recs[i + 1]["id"], (...)
```

## Impact it Made

Makes the test meaningful -- it will correctly fail if the tie-breaker is not working as expected.

## Note

Please assign this PR to the `tmdeveloper007` account.

Closes #1433.