### PR TITLE
fix : removed debug print() statements from main_routes.py

### DIFF
--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -61,7 +61,6 @@ def index():
         # In development, we prefer rendering a fallback homepage rather than
         # aborting entirely. Log the error and use safe defaults so UI/layout
         # checks can proceed.
-        print("Warning: failed to load project stats:", e)
         stats = {"total_projects": 0, "unique_skills": 0, "beginner_friendly": 0}
         available_levels = ["Beginner", "Intermediate", "Advanced"]
         available_interests = []
@@ -899,8 +898,6 @@ def portfolio_analysis():
 
     if payload is None:
         return jsonify({"error": "Invalid JSON payload"}), 400
-
-    print(payload)
 
     completed_ids = payload.get("completed_projects", [])
 


### PR DESCRIPTION
## Summary of What Has Been Done

Removed debug `print()` statements from `src/routes/main_routes.py` that were leaking internal data to stdout.

## Changes Made

1. Removed `print("Warning: failed to load project stats:", e)` from the homepage route exception handler
2. Removed `print(payload)` from the project completion tracking webhook handler

## Impact it Made

- Prevents sensitive request data from being written to server stdout in production
- Cleans up debug code left in production routes

Closes #1440

Note: Please assign this PR to the `tmdeveloper007` account.