### PR TITLE
fix : replaced deprecated datetime.utcnow with timezone-aware alternative in ui_enhancement.py

### DIFF
--- a/src/utils/ui_enhancement.py
+++ b/src/utils/ui_enhancement.py
@@ -2,7 +2,7 @@
 
 from typing import Dict, List, Optional
 from enum import Enum
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class AccessibilityLevel(Enum):
@@ -132,5 +132,5 @@ class UIEnhancementManager:
             "user_id": user_id,
             "from": from_page,
             "to": to_page,
-            "timestamp": str(datetime.utcnow()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced the deprecated `datetime.utcnow()` usage in `src/utils/ui_enhancement.py` with the timezone-aware `datetime.now(timezone.utc)`.

## Changes Made

1. Updated `from datetime import datetime` to `from datetime import datetime, timezone`
2. Replaced `str(datetime.utcnow())` with `datetime.now(timezone.utc).isoformat()` in `track_navigation`

## Impact it Made

- Eliminates Python 3.12+ deprecation warnings
- Produces ISO 8601 formatted timestamps instead of the non-standard `str(datetime.utcnow())` output

Closes #1441

Note: Please assign this PR to the `tmdeveloper007` account.