### PR TITLE
fix : removed debug print() statement from recommender.py

### DIFF
--- a/src/utils/recommender.py
+++ b/src/utils/recommender.py
@@ -138,7 +138,6 @@ def get_nlp_model():
             from sentence_transformers import SentenceTransformer
             _nlp_model = SentenceTransformer('all-MiniLM-L6-v2')
         except Exception as e:
-            print(f"Error loading NLP model: {e}")
             pass
     return _nlp_model
 


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the debug `print()` statement from `src/utils/recommender.py` that was leaking error details to stdout.

## Changes Made

Removed `print(f"Error loading NLP model: {e}")` from the `_get_nlp_model` function's exception handler.

## Impact it Made

- Prevents internal error messages from being written to stdout in production
- Follows the logging pattern established elsewhere in the codebase

Closes #1442

Note: Please assign this PR to the `tmdeveloper007` account.