### PR TITLE
fix: read completed path topics from progress

### DIFF
--- a/utils/progress_tracker.py
+++ b/utils/progress_tracker.py
@@ -101,7 +101,7 @@ class ProgressTracker:
             cursor = self.db.execute(
                 """SELECT p.id, p.name,
                    COUNT(pt.id) as total,
-                   COUNT(CASE WHEN pt.completed = 1 THEN 1 END) as completed
+                   COUNT(CASE WHEN utp.completed = 1 THEN 1 END) as completed
                    FROM paths p
                    LEFT JOIN topics pt ON p.id = pt.path_id
                    LEFT JOIN user_topic_progress utp


### PR DESCRIPTION
## Summary
Count completed path topics from user_topic_progress, where the completion state is stored.

Closes #1457

## Validation
- python3 -m py_compile utils/progress_tracker.py