### PR TITLE
fix: import math for explore pagination

### DIFF
--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -26,6 +26,7 @@ from utils.skill_progression import (
 from utils.code_review import CodeReviewManager
 from config import Config
 from utils.portfolio_analyzer import analyze_portfolio
+import math
 import os
 from models import db, ProjectProgress, UserGameProgress
 


### PR DESCRIPTION
## Summary

- import the standard-library math module used by Explore pagination

## Testing

- .venv/bin/python -m py_compile src/routes/main_routes.py
- python tests/test_basic.py (blocked by existing upstream syntax error in src/utils/recommender.py)

Closes #1455