### PR TITLE
fix : closed unclosed SKILL_SYNONYMS dict and removed duplicate parse_skills in recommender

### DIFF
--- a/src/utils/recommender.py
+++ b/src/utils/recommender.py
@@ -105,6 +105,7 @@ SKILL_SYNONYMS = {
     "ai":            "artificial intelligence",
     "k8s":           "kubernetes",
     "tf":            "tensorflow",
+}
 
 # Common aliases and abbreviations for skills
 # This improves recommendation accuracy by normalizing user input
@@ -141,9 +142,9 @@ def parse_skills(skills_string):
     if not skills_string or not skills_string.strip():
         return []
 
-    stripped = skills_string.strip()
+    skill_entries = parse_skill_entries(skills_string)
+    return [entry["skill"] for entry in skill_entries]
 
-    # --- JSON array branch ---
 
 def parse_skill_entries(skills_string):
     """Parse skills with optional per-skill proficiency levels."""
@@ -153,18 +154,6 @@ def parse_skill_entries(skills_string):
         try:
             parsed = json.loads(stripped)
             if isinstance(parsed, list):
-                tokens = [str(s).strip().lower() for s in parsed if str(s).strip()]
-                return [SKILL_SYNONYMS.get(token, token) for token in tokens]
-        except (json.JSONDecodeError, ValueError):
-            pass  # fall through to comma-splitting
-
-    # --- Comma-separated branch ---
-    tokens = [
-        s.strip().lower()
-        for s in skills_string.split(",")
-        if s.strip()  # skip blanks produced by trailing / consecutive commas
-    ]
-    return [SKILL_SYNONYMS.get(token, token) for token in tokens]
                 entries = []
                 for item in parsed:
                     if isinstance(item, dict):
@@ -173,7 +162,6 @@ def parse_skill_entries(skills_string):
                     else:
                         skill = _normalize_skill(str(item))
                         proficiency = "Beginner"
-
                     if skill:
                         entries.append(
                             {
@@ -191,8 +179,9 @@ def parse_skill_entries(skills_string):
                         )
                 return entries
         except (json.JSONDecodeError, ValueError):
-            pass
+            pass  # fall through to comma-splitting
 
+    # --- Comma-separated branch ---
     return [
         {
             "skill": SKILL_ALIASES.get(_normalize_skill(skill), _normalize_skill(skill)),
@@ -202,13 +191,6 @@ def parse_skill_entries(skills_string):
         if skill.strip()
     ]
 
-
-def parse_skills(skills_string):
-    return [entry["skill"] for entry in parse_skill_entries(skills_string)]
-
-
-def parse_skills(skills_string):
-    return [entry["skill"] for entry in parse_skill_entries(skills_string)]
 
 _nlp_model = None
 _project_embeddings_cache = {}


### PR DESCRIPTION
## Summary of What Has Been Done
Fixed two issues in `src/utils/recommender.py`:
1. Added the missing closing `}` brace for the `SKILL_SYNONYMS` dictionary (line 72). The dict was never properly closed, causing a `SyntaxError: '{' was never closed` when importing the module.
2. Removed the duplicate `parse_skills` function that was defined twice in the file.

## Changes Made
- Added closing `}` after the last SKILL_SYNONYMS entry (`"tf": "tensorflow"`)
- Removed the duplicate `parse_skills` function definition
- Restructured `parse_skill_entries` to be a well-formed function (removed dead orphaned code)

## Impact it Made
Restores the ability to import the `recommender` module. Without this fix the entire application crashes on startup with a SyntaxError.

## Closes #1492

## Note: Please assign this PR to the `tmdeveloper007` account.
