### PR TITLE
fix : added missing import math for explore pagination

### DIFF
--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -27,6 +27,7 @@ from utils.code_review import CodeReviewManager
 from config import Config
 from utils.portfolio_analyzer import analyze_portfolio
 import os
+import math
 from models import db, ProjectProgress, UserGameProgress
 
 _skill_validator = SkillProgressionValidator()


### PR DESCRIPTION
## Summary of What Has Been Done

Added the missing `import math` statement to `src/routes/main_routes.py`, which is required by the `math.ceil()` call used for pagination calculation in the explore route.

## Changes Made

- `src/routes/main_routes.py`: Added `import math` to the module imports.

## Impact it Made

- Fixes NameError when navigating to the explore route with pagination.
- Ensures pagination page count is calculated correctly.

Note: Please assign this PR to the `tmdeveloper007` account.