### PR TITLE
fix: re-add missing import re in portfolio_analyzer.py and guard against undefined names in CI (#1810)

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,6 +36,10 @@ jobs:
       run: |
         flake8 . --exit-zero --max-line-length=120
 
+    - name: Check undefined names (blocking)
+      run: |
+        flake8 . --max-line-length=120 --select=F821
+
     - name: Run tests
       run: |
         PYTHONPATH=src pytest

--- a/src/utils/portfolio_analyzer.py
+++ b/src/utils/portfolio_analyzer.py
@@ -7,6 +7,7 @@
 # practiced, vs. which ones they keep skipping. Returns a diversity
 # score plus targeted project recommendations for the gaps.
 
+import re
 from collections import OrderedDict
 
 # Ordered so the dashboard always renders categories in a stable,

--- a/tests/test_portfolio_analyzer.py
+++ b/tests/test_portfolio_analyzer.py
@@ -1,0 +1,54 @@
+# tests/test_portfolio_analyzer.py
+# Smoke tests for utils/portfolio_analyzer.py.
+#
+# These exist because a "remove unused import" cleanup once deleted the
+# `import re` that _build_keyword_pattern() depends on, which made every
+# deployment that imports `app` fail with NameError.  Importing the module
+# (and the Flask app, which imports it) must never raise.
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from utils.portfolio_analyzer import analyze_portfolio
+
+
+def test_app_imports_portfolio_analyzer():
+    """Importing the Flask app must succeed (it imports portfolio_analyzer)."""
+    from app import app
+    assert app is not None
+
+
+def test_analyze_portfolio_returns_expected_structure():
+    """analyze_portfolio must return the documented keys for a valid input."""
+    result = analyze_portfolio([
+        {
+            "title": "Weather Dashboard",
+            "description": "A REST API weather app",
+            "skills": ["Python", "Flask"],
+            "tech_stack": ["Flask"],
+            "features": [],
+        }
+    ])
+    assert result["score"] >= 0
+    assert isinstance(result["covered"], list)
+    assert isinstance(result["missing"], list)
+    assert isinstance(result["categories"], list)
+    assert isinstance(result["recommendations"], list)
+
+
+def test_keyword_patterns_match_expected_domains():
+    """The compiled regex patterns must still match (re must be imported)."""
+    result = analyze_portfolio([
+        {
+            "title": "CI/CD pipeline with GitHub Actions",
+            "description": "docker deploy",
+            "skills": ["Python", "Docker"],
+            "tech_stack": [],
+            "features": [],
+        }
+    ])
+    assert "DevOps" in result["covered"]
+    assert "Deployment" in result["covered"]


### PR DESCRIPTION
## Problem

The application cannot boot at all. `src/utils/portfolio_analyzer.py` calls `re.escape(kw)` inside `_build_keyword_pattern` (line 94) but the module never imports `re` (its only import is `from collections import OrderedDict`). Because `src/app.py` imports `routes.main_routes`, which imports `utils.portfolio_analyzer`, importing the Flask app raises `NameError: name 're' is not defined` — every deployment, worker, and test that imports `app` crashes before any route can be served.

This was introduced by PR #1469, which removed the one import the module actually uses.

## Fix

- Re-added `import re` to `src/utils/portfolio_analyzer.py`.
- Added a smoke test (`tests/test_portfolio_analyzer.py`) that imports the Flask `app` (which imports `portfolio_analyzer`) so any future removal of a used import fails CI instead of breaking production.
- Enabled a blocking flake8 check for undefined names (`F821`) in `.github/workflows/python-app.yml` so "unused import" cleanup can never silently break the build again. The full lint run stays non-blocking (`--exit-zero`); only F821 (undefined names) is now blocking.

## Files changed

- `src/utils/portfolio_analyzer.py` — re-add `import re`.
- `tests/test_portfolio_analyzer.py` — new smoke tests (import + basic analysis + keyword pattern matching).
- `.github/workflows/python-app.yml` — add blocking `flake8 --select=F821` CI step.

## Testing

- `python -m pytest tests/test_portfolio_analyzer.py` — 3 passed.
- `flake8 src tests --max-line-length=120 --select=F821` — clean (exit 0).
- Full suite runs: previously it could not even start because importing `app` raised `NameError`; with this fix the import succeeds and all tests execute.

Closes #1810
