### PR TITLE
fix(explore): validate and clamp page/per_page before arithmetic (#1812)

### DIFF
--- a/src/routes/admin_routes.py
+++ b/src/routes/admin_routes.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, render_template, request, redirect, url_for, abort, session
 from models import db, Project, User
+from utils.pagination import parse_pagination
 
 admin_bp = Blueprint('admin', __name__)
 
@@ -15,9 +16,8 @@ def check_admin():
 
 @admin_bp.route('/')
 def dashboard():
-    page = request.args.get('page', 1, type=int)
-    per_page = 20
-    pagination = Project.query.order_by(Project.id.desc()).paginate(page=page, per_page=per_page, error_out=False)
+    page, _ = parse_pagination(request.args.get('page', 1, type=int), 20)
+    pagination = Project.query.order_by(Project.id.desc()).paginate(page=page, per_page=20, error_out=False)
     return render_template('admin/dashboard.html', pagination=pagination)
 
 def _get_list_from_form(field_name):

--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -26,6 +26,7 @@ from utils.skill_progression import (
 from utils.code_review import CodeReviewManager
 from config import Config
 from utils.portfolio_analyzer import analyze_portfolio
+from utils.pagination import parse_pagination
 import math
 import os
 import base64
@@ -73,8 +74,10 @@ def index():
 @main.route("/explore")
 def explore():
     """Render the explore page with server-side pagination, filtering, and sorting."""
-    page = request.args.get("page", 1, type=int)
-    per_page = request.args.get("per_page", 12, type=int)
+    page, per_page = parse_pagination(
+        request.args.get("page", 1, type=int),
+        request.args.get("per_page", 12, type=int),
+    )
     search_query = request.args.get("search", "").strip().lower()
     level_filter = request.args.get("level", "").strip().lower()
     interest_filter = request.args.get("interest", "").strip().lower()

--- a/src/utils/pagination.py
+++ b/src/utils/pagination.py
@@ -1,0 +1,38 @@
+"""Shared helpers for parsing and clamping pagination query parameters.
+
+Pagination values come straight from the query string and are used in
+arithmetic (division, slicing) before any bounds check.  That let
+``GET /explore?per_page=0`` raise a ``ZeroDivisionError`` (HTTP 500).
+Centralizing parsing/clamping here keeps every paginated route (``/explore``,
+``/admin``, future routes) behaving identically and never throwing on
+malformed input.
+"""
+
+DEFAULT_PER_PAGE = 12
+MAX_PER_PAGE = 100
+
+
+def parse_pagination(page, per_page):
+    """Clamp raw ``page``/``per_page`` values into a safe ``(page, per_page)``.
+
+    Args:
+        page: raw ``page`` query parameter (``int`` or ``None``).
+        per_page: raw ``per_page`` query parameter (``int`` or ``None``).
+
+    Returns:
+        A tuple ``(page, per_page)`` where ``page >= 1`` and
+        ``1 <= per_page <= MAX_PER_PAGE``.  Values that are missing,
+        zero, negative, or unreasonably large are replaced with a sensible
+        default or clamped to the nearest valid value.
+    """
+    if per_page is None:
+        per_page = DEFAULT_PER_PAGE
+    else:
+        per_page = max(1, min(per_page, MAX_PER_PAGE))
+
+    if page is None:
+        page = 1
+    else:
+        page = max(page, 1)
+
+    return page, per_page

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,96 @@
+﻿import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from utils.pagination import parse_pagination, DEFAULT_PER_PAGE, MAX_PER_PAGE
+
+from app import app
+
+
+def get_client():
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    return app.test_client()
+
+
+# ============================================================
+# parse_pagination helper unit tests
+# ============================================================
+
+def test_parse_pagination_defaults():
+    """Missing values fall back to (1, DEFAULT_PER_PAGE)."""
+    assert parse_pagination(None, None) == (1, DEFAULT_PER_PAGE)
+
+
+def test_parse_pagination_valid_values_passthrough():
+    assert parse_pagination(3, 10) == (3, 10)
+
+
+def test_parse_pagination_zero_per_page():
+    """per_page=0 would have caused ZeroDivisionError - must be clamped to 1."""
+    assert parse_pagination(1, 0) == (1, 1)
+
+
+def test_parse_pagination_negative_per_page():
+    assert parse_pagination(1, -5) == (1, 1)
+
+
+def test_parse_pagination_huge_per_page_clamped():
+    """per_page above MAX_PER_PAGE must be clamped, not accepted."""
+    assert parse_pagination(1, 100000) == (1, MAX_PER_PAGE)
+
+
+def test_parse_pagination_zero_page():
+    assert parse_pagination(0, 12) == (1, 12)
+
+
+def test_parse_pagination_negative_page():
+    assert parse_pagination(-3, 12) == (1, 12)
+
+
+# ============================================================
+# /explore integration tests
+# ============================================================
+
+def test_explore_per_page_zero_never_500():
+    """per_page=0 previously raised ZeroDivisionError -> must now return 200."""
+    response = get_client().get("/explore?per_page=0")
+    assert response.status_code == 200
+
+
+def test_explore_per_page_negative():
+    response = get_client().get("/explore?per_page=-5")
+    assert response.status_code == 200
+
+
+def test_explore_per_page_huge_clamped():
+    """A huge per_page must be clamped to MAX_PER_PAGE and still render."""
+    response = get_client().get("/explore?per_page=100000")
+    assert response.status_code == 200
+
+
+def test_explore_page_zero():
+    response = get_client().get("/explore?page=0")
+    assert response.status_code == 200
+
+
+def test_explore_page_negative():
+    response = get_client().get("/explore?page=-3")
+    assert response.status_code == 200
+
+
+def test_explore_all_bad_params_combination():
+    """A combination of every malformed value must never produce a 500."""
+    response = get_client().get("/explore?page=-2&per_page=0&search=&level=")
+    assert response.status_code == 200
+
+
+def test_explore_render_is_bounded_by_per_page():
+    """The rendered page must not contain more cards than the requested per_page."""
+    response = get_client().get("/explore?per_page=5")
+    assert response.status_code == 200
+    card_count = response.data.count(b'class="project-card"')
+    assert 0 < card_count <= 5


### PR DESCRIPTION
## Problem

`/explore` reads `page` and `per_page` straight from the query string and divides by `per_page` before any validation:

```python
page = request.args.get("page", 1, type=int)
per_page = request.args.get("per_page", 12, type=int)
...
total_pages = math.ceil(total_items / per_page) if total_items > 0 else 1
```

Because the DB is always auto-seeded (34 projects), `total_items > 0` always, so:

- `GET /explore?per_page=0` → `ZeroDivisionError` → **HTTP 500**.
- `GET /explore?per_page=-5` → nonsense negative `total_pages` and broken slicing.
- No upper bound on `per_page` (e.g. `per_page=100000` accepted).

The existing bounds check runs *after* the division, so it can't protect the divide-by-zero path.

## Fix

- Added `src/utils/pagination.py` with a shared `parse_pagination(page, per_page)` helper that clamps `page >= 1` and `per_page` into `[1, MAX_PER_PAGE]` (100) **before** any arithmetic. Missing values fall back to `(1, 12)`.
- `/explore` now uses the helper (moved validation to the top of the handler, before the division).
- `/admin` dashboard uses the same helper so every paginated route behaves identically (per the issue's suggestion).

## Files changed

- `src/utils/pagination.py` — new shared pagination parsing/clamping helper.
- `src/routes/main_routes.py` — `/explore` uses `parse_pagination`.
- `src/routes/admin_routes.py` — `/admin` dashboard uses `parse_pagination`.
- `tests/test_pagination.py` — new unit tests for the helper (`per_page=0`, `per_page=-1`, huge `per_page`, `page=0`) plus integration tests proving `/explore` returns 200 for every malformed combination.

## Testing

```
py -m pytest tests/test_pagination.py -q
14 passed
```

Full suite: 535 passed; only the pre-existing failures (identical on `main`).

Closes #1812
