### PR TITLE
feat(learning-path): persist learning paths in the database instead of a process-local dict (#1813)

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -1,6 +1,13 @@
+from datetime import datetime, timezone
+
 from flask_sqlalchemy import SQLAlchemy
 
 db = SQLAlchemy()
+
+
+def _utcnow():
+    """Return the current UTC time as a naive datetime for DB storage."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 class Project(db.Model):
     __tablename__ = 'projects'
@@ -80,3 +87,16 @@ class UserGameProgress(db.Model):
     data = db.Column(db.JSON, nullable=False, default=dict)
 
     user = db.relationship('User', backref=db.backref('game_progress', uselist=False, cascade="all, delete-orphan"))
+
+
+class LearningPath(db.Model):
+    __tablename__ = 'learning_paths'
+
+    # The client-supplied opaque path id (typically a UUID chosen in the browser).
+    path_id = db.Column(db.String(128), primary_key=True)
+    # Only a salted SHA-256 hash of the owner token is ever stored; the raw
+    # token is never persisted so a leaked DB does not expose bearer secrets.
+    token_hash = db.Column(db.String(128), nullable=False)
+    data = db.Column(db.JSON, nullable=False, default=dict)
+    created_at = db.Column(db.DateTime, nullable=False, default=_utcnow)
+    updated_at = db.Column(db.DateTime, nullable=False, default=_utcnow, onupdate=_utcnow)

--- a/src/utils/learning_path.py
+++ b/src/utils/learning_path.py
@@ -8,16 +8,18 @@
 # must present the same token; requests with a missing or wrong token are
 # rejected with a 403 status before any data is returned or modified.
 #
-# Storage is intentionally in-memory so the module has no external
-# dependencies beyond the Python standard library.  Data does not survive
-# an application restart, which is acceptable for this project's scope and
-# is clearly documented in the API contract.
+# Storage is backed by the database (the ``LearningPath`` SQLAlchemy model)
+# so paths survive application restarts, cold starts, and serverless function
+# recycling, and are consistent across concurrent instances.  Only a salted
+# SHA-256 hash of the owner token is persisted - the raw token is never
+# stored, so a leaked database does not expose bearer secrets.
 #
 # Public surface:
 #   create_learning_path(path_id, token, data)  -> None   (raises on conflict)
 #   get_learning_path(path_id, token)           -> dict   (raises on auth fail)
 #   update_learning_path(path_id, token, data)  -> None   (raises on auth fail)
 #   path_exists(path_id)                        -> bool
+#   cleanup_expired_paths([max_age_seconds])    -> int    (deleted row count)
 #   _clear_all()                                -> None   (test helper only)
 #
 # Error types:
@@ -25,21 +27,27 @@
 #   PathAlreadyExistsError – path_id is already registered (on create)
 #   AuthorizationError   – token does not match the stored token
 
+import hashlib
 import re
 import secrets
+from datetime import datetime, timedelta, timezone
+
+from models import db, LearningPath
 
 # ---------------------------------------------------------------------------
-# Module-level storage
+# Constants
 # ---------------------------------------------------------------------------
-
-# Map of path_id -> {"token": str, "data": dict}
-_store: dict = {}
 
 # Maximum byte length accepted for a path_id to prevent abuse
 _MAX_PATH_ID_LEN = 128
 
 # Regex that path_id values must satisfy (alphanumeric + hyphens/underscores)
 _PATH_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+
+# Abandoned paths are purged after this many seconds without activity.  Paths
+# that are actively updated never expire; this only cleans up paths whose
+# owners stopped using them.
+_PATH_TTL_SECONDS = 30 * 24 * 60 * 60  # 30 days
 
 
 # ---------------------------------------------------------------------------
@@ -87,9 +95,32 @@ def _validate_data(data: dict) -> None:
         raise ValueError("data must be a JSON object (dict).")
 
 
-def _tokens_equal(a: str, b: str) -> bool:
-    """Compare two token strings in constant time to prevent timing attacks."""
-    return secrets.compare_digest(a, b)
+# ---------------------------------------------------------------------------
+# Token hashing helpers
+# ---------------------------------------------------------------------------
+
+def _hash_token(token: str) -> str:
+    """Return a salted SHA-256 hash of ``token``.
+
+    The raw token is never stored; only ``"<salt>$<hex-digest>"`` is kept.
+    """
+    salt = secrets.token_hex(16)
+    digest = hashlib.sha256((salt + token).encode("utf-8")).hexdigest()
+    return f"{salt}${digest}"
+
+
+def _verify_token(stored_hash: str, token: str) -> bool:
+    """Verify ``token`` against a stored ``"<salt>$<digest>"`` hash.
+
+    Comparison uses ``secrets.compare_digest`` (constant time) on the two
+    equal-length hex digests.
+    """
+    try:
+        salt, digest = stored_hash.split("$", 1)
+    except (ValueError, AttributeError):
+        return False
+    candidate = hashlib.sha256((salt + token).encode("utf-8")).hexdigest()
+    return secrets.compare_digest(candidate, digest)
 
 
 # ---------------------------------------------------------------------------
@@ -99,10 +130,10 @@ def _tokens_equal(a: str, b: str) -> bool:
 def create_learning_path(path_id: str, token: str, data: dict) -> None:
     """Register a new learning path.
 
-    Associates ``path_id`` with ``token`` and stores the initial ``data``
-    payload.  The caller is responsible for generating a cryptographically
-    random token (e.g. ``secrets.token_urlsafe(32)``) before calling this
-    function.
+    Associates ``path_id`` with a hash of ``token`` and stores the initial
+    ``data`` payload.  The caller is responsible for generating a
+    cryptographically random token (e.g. ``secrets.token_urlsafe(32)``)
+    before calling this function.
 
     Raises:
         ValueError             – if any argument fails basic validation.
@@ -112,12 +143,21 @@ def create_learning_path(path_id: str, token: str, data: dict) -> None:
     _validate_token(token)
     _validate_data(data)
 
-    if path_id in _store:
+    if db.session.get(LearningPath, path_id) is not None:
         raise PathAlreadyExistsError(
             f"A learning path with id '{path_id}' already exists."
         )
 
-    _store[path_id] = {"token": token, "data": dict(data)}
+    path = LearningPath(
+        path_id=path_id,
+        token_hash=_hash_token(token),
+        data=dict(data),
+    )
+    db.session.add(path)
+    db.session.commit()
+
+    # Opportunistically purge abandoned paths on write activity.
+    cleanup_expired_paths()
 
 
 def get_learning_path(path_id: str, token: str) -> dict:
@@ -131,19 +171,19 @@ def get_learning_path(path_id: str, token: str) -> dict:
     _validate_path_id(path_id)
     _validate_token(token)
 
-    if path_id not in _store:
+    path = db.session.get(LearningPath, path_id)
+    if path is None:
         raise PathNotFoundError(
             f"No learning path found with id '{path_id}'."
         )
 
-    stored = _store[path_id]
-    if not _tokens_equal(stored["token"], token):
+    if not _verify_token(path.token_hash, token):
         raise AuthorizationError(
             "The provided token does not match the owner token for this path."
         )
 
     # Return a copy so callers cannot mutate the stored state directly
-    return dict(stored["data"])
+    return dict(path.data or {})
 
 
 def update_learning_path(path_id: str, token: str, data: dict) -> None:
@@ -160,18 +200,19 @@ def update_learning_path(path_id: str, token: str, data: dict) -> None:
     _validate_token(token)
     _validate_data(data)
 
-    if path_id not in _store:
+    path = db.session.get(LearningPath, path_id)
+    if path is None:
         raise PathNotFoundError(
             f"No learning path found with id '{path_id}'."
         )
 
-    stored = _store[path_id]
-    if not _tokens_equal(stored["token"], token):
+    if not _verify_token(path.token_hash, token):
         raise AuthorizationError(
             "The provided token does not match the owner token for this path."
         )
 
-    stored["data"] = dict(data)
+    path.data = dict(data)
+    db.session.commit()
 
 
 def path_exists(path_id: str) -> bool:
@@ -182,7 +223,23 @@ def path_exists(path_id: str) -> bool:
     """
     if not isinstance(path_id, str):
         return False
-    return path_id in _store
+    return db.session.get(LearningPath, path_id) is not None
+
+
+def cleanup_expired_paths(max_age_seconds: int = _PATH_TTL_SECONDS) -> int:
+    """Delete learning paths that have not been touched in ``max_age_seconds``.
+
+    Returns the number of rows deleted.  Safe to call periodically (e.g. on
+    write activity or from a cron/interval job); active paths are unaffected
+    because their ``updated_at`` timestamp is refreshed on every update.
+    """
+    cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(
+        seconds=max_age_seconds
+    )
+    deleted = LearningPath.query.filter(LearningPath.updated_at < cutoff).delete()
+    if deleted:
+        db.session.commit()
+    return deleted
 
 
 def _clear_all() -> None:
@@ -191,4 +248,5 @@ def _clear_all() -> None:
     This function exists solely for test isolation.  It must not be called
     from application code.
     """
-    _store.clear()
+    LearningPath.query.delete()
+    db.session.commit()

--- a/tests/test_learning_path.py
+++ b/tests/test_learning_path.py
@@ -26,6 +26,7 @@ from utils.learning_path import (
     update_learning_path,
     path_exists,
     _clear_all,
+    cleanup_expired_paths,
     PathNotFoundError,
     PathAlreadyExistsError,
     AuthorizationError,
@@ -576,6 +577,98 @@ class TestUpdatePathRoute:
         )
 
         assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# 3. Persistence tests — data survives fresh contexts / other "instances"
+# ---------------------------------------------------------------------------
+
+class TestPersistenceAcrossContexts:
+
+    def setup_method(self):
+        _clear_all()
+
+    def test_path_survives_fresh_app_context(self):
+        """A path written inside one app context must be readable from a fresh one."""
+        token = make_token()
+        with app.app_context():
+            create_learning_path("persist-1", token, {"plan": "learn flask"})
+
+        # Simulate a new request/instance: a brand-new context, no reference
+        # to anything held by the creating context.
+        with app.app_context():
+            assert get_learning_path("persist-1", token) == {"plan": "learn flask"}
+
+    def test_path_readable_from_second_instance(self):
+        """A path created by one 'instance' must be visible to a second one."""
+        token = make_token()
+        with app.app_context():
+            create_learning_path("persist-2", token, {"step": 1})
+
+        # Second "instance": fresh context, fresh client, fresh session.
+        with app.app_context():
+            client = get_client()
+            response = client.get(
+                "/api/learning-path/persist-2",
+                headers={TOKEN_HEADER: token},
+            )
+            assert response.status_code == 200
+            assert response.get_json()["data"] == {"step": 1}
+
+    def test_update_visible_after_context_switch(self):
+        """An update from a new context must be reflected in the stored row."""
+        token = make_token()
+        with app.app_context():
+            create_learning_path("persist-3", token, {"v": 1})
+        with app.app_context():
+            update_learning_path("persist-3", token, {"v": 2})
+        with app.app_context():
+            assert get_learning_path("persist-3", token) == {"v": 2}
+
+    def test_raw_token_not_stored_anywhere(self):
+        """The DB must contain a hash, never the raw token."""
+        from models import LearningPath
+
+        token = make_token()
+        with app.app_context():
+            create_learning_path("hash-1", token, {})
+            row = LearningPath.query.filter_by(path_id="hash-1").first()
+            assert row is not None
+            assert row.token_hash != token
+            assert token not in row.token_hash
+            assert "$" in row.token_hash  # "<salt>$<digest>" format
+            assert len(row.token_hash.split("$", 1)[1]) == 64  # sha256 hex
+
+
+class TestCleanupExpiredPaths:
+
+    def setup_method(self):
+        _clear_all()
+
+    def test_active_path_survives_cleanup(self):
+        """Paths that are actively used must never be purged by TTL cleanup."""
+        token = make_token()
+        with app.app_context():
+            create_learning_path("active-1", token, {})
+            assert cleanup_expired_paths() == 0
+            assert path_exists("active-1") is True
+
+    def test_expired_path_is_removed(self):
+        """A path older than the TTL cutoff must be deleted."""
+        import datetime
+        from models import LearningPath, db
+
+        token = make_token()
+        with app.app_context():
+            create_learning_path("stale-1", token, {})
+            stale = datetime.datetime.now() - datetime.timedelta(days=90)
+            LearningPath.query.filter_by(path_id="stale-1").update(
+                {"updated_at": stale}
+            )
+            db.session.commit()
+
+            assert cleanup_expired_paths() == 1
+            assert path_exists("stale-1") is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

All learning paths are stored in a single process-local module dict in `src/utils/learning_path.py`:

```python
_store: dict = {}
```

The public API routes `POST/GET/PUT /api/learning-path/<path_id>` (`src/routes/main_routes.py` lines 935–1049) and the analytics endpoint (lines 1151–1222) all read/write this dict. The module docstring explicitly acknowledged "Data does not survive an application restart."

The deployed app runs on **Vercel serverless**, where function instances are recycled constantly and multiple instances run concurrently. Consequences:

- Every cold start / instance recycle destroys all saved learning paths — users get `404 Learning path not found` for paths they created minutes earlier.
- A path created on instance A is a 404 when the next request lands on instance B.
- The raw bearer token is stored next to each path with no expiry and no cleanup.

## Fix

- Added a `LearningPath` SQLAlchemy model in `src/models.py` (`path_id` PK, `token_hash`, `data` JSON, `created_at`/`updated_at` timestamps).
- Rewrote `src/utils/learning_path.py` to be database-backed while keeping the **exact same public API and exception types**, so the routes are unchanged:
  - `create_learning_path` / `get_learning_path` / `update_learning_path` / `path_exists` now use `db.session` + the `LearningPath` model.
  - Tokens are stored **only as a salted SHA-256 hash** (`"<salt>$<digest>"`); the raw token is never persisted, and verification uses `secrets.compare_digest` on the equal-length hex digests (constant time).
  - Added `cleanup_expired_paths(max_age_seconds=30 days)` TTL cleanup, invoked opportunistically on write activity. `updated_at` is refreshed on every update, so actively used paths never expire.
  - `_clear_all()` remains test-only.
- Paths now persist across restarts/cold starts and are consistent across concurrent instances (shared database).

## Files changed

- `src/models.py` — new `LearningPath` model (+ naive-UTC timestamp helper).
- `src/utils/learning_path.py` — DB-backed storage with token hashing and TTL cleanup.
- `tests/test_learning_path.py` — new persistence tests.

## Testing

```
py -m pytest tests/test_learning_path.py -q
54 passed
```

New tests prove:
- a path survives a fresh `app` context,
- a path created by one "instance" is readable from a second "instance",
- an update from a new context is reflected in the stored row,
- the raw token never appears in the DB (only a `"<salt>$<digest>"` SHA-256 hash),
- TTL cleanup removes abandoned paths but never active ones.

Full suite: 527 passed; only the pre-existing failures (identical on `main`).

Closes #1813
