### PR TITLE
fix(oauth): consolidate the two incompatible GitHub OAuth flows (#1814)

### DIFF
--- a/src/routes/github_routes.py
+++ b/src/routes/github_routes.py
@@ -1,62 +1,63 @@
-import os
 import requests
-from flask import Blueprint, redirect, request, session, jsonify, url_for
+from flask import Blueprint, redirect, session, jsonify, url_for
 
 github_bp = Blueprint("github", __name__)
 
-GITHUB_CLIENT_ID = os.getenv("GITHUB_CLIENT_ID")
-GITHUB_CLIENT_SECRET = os.getenv("GITHUB_CLIENT_SECRET")
+# This blueprint previously ran a second, manual OAuth flow
+# (/api/github/login + /api/github/callback) that was incompatible with the
+# Authlib flow in routes/auth_routes.py:
+#
+#   - it stored a bare access-token *string* in session['github_token'],
+#     while the Authlib flow stores the full token dict
+#     {"access_token": ..., "token_type": ..., "expires_in": ...}, and
+#     export_github expects the dict shape -> TypeError.
+#   - it never created a User row nor set session['user_id'], so the user
+#     remained unauthenticated for /profile and progress APIs.
+#   - it read credentials from os.getenv at import time instead of Config.
+#
+# Both OAuth entry points now delegate to the single Authlib flow, so every
+# login produces one consistent session payload.  Only /api/github/repos
+# remains here (used by the frontend to list the user's repositories).
 
-# You can configure your local callback URL in GitHub, e.g., http://localhost:5000/api/github/callback
-# In production, it will be your domain.
+
+def _session_access_token():
+    """Return the GitHub access token from the session, if present.
+
+    The Authlib flow stores the full token dict.  A bare string may still
+    exist in older sessions, so both shapes are handled defensively.
+    """
+    token = session.get("github_token")
+    if isinstance(token, dict):
+        return token.get("access_token")
+    if isinstance(token, str) and token:
+        return token
+    return None
+
 
 @github_bp.route("/api/github/login")
 def login():
-    """Redirect user to GitHub OAuth login."""
-    if not GITHUB_CLIENT_ID:
-        return jsonify({"error": "GitHub OAuth is not configured on the server."}), 500
-        
-    redirect_uri = request.host_url.rstrip('/') + url_for("github.callback")
-    auth_url = (
-        f"https://github.com/login/oauth/authorize"
-        f"?client_id={GITHUB_CLIENT_ID}"
-        f"&redirect_uri={redirect_uri}"
-        f"&scope=public_repo"
-    )
-    return redirect(auth_url)
+    """Alias of the canonical Authlib login flow.
+
+    Kept so existing frontend links (and bookmarks) keep working while the
+    app consolidates on a single OAuth implementation.
+    """
+    return redirect(url_for("auth.login"))
+
 
 @github_bp.route("/api/github/callback")
 def callback():
-    """Handle GitHub OAuth callback and exchange code for access token."""
-    code = request.args.get("code")
-    if not code:
-        return redirect("/?github_auth=error")
+    """Backward-compatible alias of the canonical Authlib callback.
 
-    redirect_uri = request.host_url.rstrip('/') + url_for("github.callback")
-    
-    token_url = "https://github.com/login/oauth/access_token"
-    payload = {
-        "client_id": GITHUB_CLIENT_ID,
-        "client_secret": GITHUB_CLIENT_SECRET,
-        "code": code,
-        "redirect_uri": redirect_uri
-    }
-    headers = {"Accept": "application/json"}
+    Old GitHub OAuth app redirect URIs may still point here; forward the
+    user into the canonical flow rather than returning a 404.
+    """
+    return redirect(url_for("auth.login"))
 
-    response = requests.post(token_url, json=payload, headers=headers)
-    data = response.json()
-
-    access_token = data.get("access_token")
-    if access_token:
-        session["github_token"] = access_token
-        return redirect("/?github_auth=success")
-    else:
-        return redirect("/?github_auth=error")
 
 @github_bp.route("/api/github/repos")
 def repos():
     """Fetch user's repositories using the stored access token."""
-    access_token = session.get("github_token")
+    access_token = _session_access_token()
     if not access_token:
         return jsonify({"error": "Not authenticated with GitHub"}), 401
 
@@ -66,7 +67,7 @@ def repos():
     }
 
     response = requests.get("https://api.github.com/user/repos?sort=updated&per_page=100", headers=headers)
-    
+
     if response.status_code != 200:
         return jsonify({"error": "Failed to fetch repositories from GitHub"}), response.status_code
 

--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -386,7 +386,12 @@ def download_code(project_id):
 def export_github(project_id):
     """Create a new GitHub repository for the user and push starter code."""
     token = session.get('github_token')
-    if not token or 'access_token' not in token:
+    access_token = None
+    if isinstance(token, dict):
+        access_token = token.get('access_token')
+    elif isinstance(token, str):
+        access_token = token
+    if not access_token:
         flash("You must be logged in with GitHub to export projects.", "error")
         return redirect(url_for('auth.login'))
 
@@ -416,7 +421,7 @@ def export_github(project_id):
     repo_name = f"DevPath-Starter-{safe_title}"
 
     headers = {
-        "Authorization": f"Bearer {token['access_token']}",
+        "Authorization": f"Bearer {access_token}",
         "Accept": "application/vnd.github.v3+json"
     }
 

--- a/tests/test_github_oauth.py
+++ b/tests/test_github_oauth.py
@@ -1,0 +1,145 @@
+# tests/test_github_oauth.py
+# Tests for the consolidated GitHub OAuth flow (issue #1814).
+#
+# Previously there were two incompatible OAuth implementations:
+#   - Authlib flow (/auth/login, /auth/authorize) stores a token *dict* in
+#     session['github_token'] and creates a User + sets session['user_id'].
+#   - Manual flow (/api/github/login, /api/github/callback) stored a bare
+#     token *string* and never created a User.
+#
+# The manual routes now alias the Authlib flow, and export_github handles
+# both token shapes defensively so legacy sessions cannot crash it.
+
+import sys
+import os
+
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from app import app
+
+
+def get_client():
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    return app.test_client()
+
+
+# ============================================================
+# Consolidated OAuth entry points
+# ============================================================
+
+def test_api_github_login_redirects_to_authlib_flow():
+    """/api/github/login must forward into the canonical Authlib flow."""
+    client = get_client()
+    response = client.get("/api/github/login")
+    assert response.status_code == 302
+    assert "/auth/login" in response.headers["Location"]
+
+
+def test_api_github_callback_redirects_to_authlib_flow():
+    """Legacy /api/github/callback must not 404 and must forward to Authlib."""
+    client = get_client()
+    response = client.get("/api/github/callback?code=legacy-code")
+    assert response.status_code == 302
+    assert "/auth/login" in response.headers["Location"]
+
+
+def test_auth_login_still_redirects_to_github_authorize():
+    """The canonical /auth/login must still start a GitHub OAuth round trip."""
+    client = get_client()
+    response = client.get("/auth/login")
+    assert response.status_code == 302
+    assert "github.com/login/oauth/authorize" in response.headers["Location"]
+
+
+# ============================================================
+# /api/github/repos
+# ============================================================
+
+def test_github_repos_requires_auth():
+    client = get_client()
+    response = client.get("/api/github/repos")
+    assert response.status_code == 401
+
+
+@patch("routes.github_routes.requests.get")
+def test_github_repos_with_dict_token(mock_get):
+    """Repos endpoint must work with the Authlib dict token shape."""
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = [{"name": "devpath"}]
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["github_token"] = {"access_token": "abc", "token_type": "bearer"}
+        response = client.get("/api/github/repos")
+    assert response.status_code == 200
+    assert response.get_json() == [{"name": "devpath"}]
+
+
+# ============================================================
+# export_github with both token shapes
+# ============================================================
+
+def _seed_project_with_starter_code():
+    """Ensure a project with a starter_code file exists for export tests."""
+    with app.app_context():
+        from models import db, Project
+        p = db.session.get(Project, 1000)
+        if not p:
+            p = Project(
+                id=1000,
+                title="Valid Code",
+                level="Beg",
+                interest="Web",
+                time="Low",
+                description="Desc",
+                starter_code="expense_tracker.py",
+            )
+            db.session.add(p)
+            db.session.commit()
+
+
+@patch("routes.main_routes.requests.put")
+@patch("routes.main_routes.requests.post")
+@patch("routes.main_routes.requests.get")
+def test_export_github_with_dict_token_succeeds(mock_get, mock_post, mock_put):
+    """The Authlib dict token shape must flow through export_github."""
+    _seed_project_with_starter_code()
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {"login": "testuser"}
+    mock_post.return_value.status_code = 201
+    mock_put.return_value.status_code = 201
+
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["github_token"] = {
+                "access_token": "abc",
+                "token_type": "bearer",
+                "expires_in": 3600,
+            }
+        response = client.post("/project/1000/export_github")
+
+    assert response.status_code == 302
+    assert "github.com/testuser/DevPath-Starter-valid-code" in response.headers["Location"]
+
+
+@patch("routes.main_routes.requests.put")
+@patch("routes.main_routes.requests.post")
+@patch("routes.main_routes.requests.get")
+def test_export_github_with_legacy_string_token_does_not_crash(mock_get, mock_post, mock_put):
+    """A legacy bare-string token must NOT raise TypeError (issue #1814)."""
+    _seed_project_with_starter_code()
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {"login": "testuser"}
+    mock_post.return_value.status_code = 201
+    mock_put.return_value.status_code = 201
+
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["github_token"] = "legacy-string-token"
+        response = client.post("/project/1000/export_github")
+
+    assert response.status_code == 302
+    assert "github.com/testuser/DevPath-Starter-valid-code" in response.headers["Location"]


### PR DESCRIPTION
## Problem

The project had **two independent, mutually incompatible GitHub OAuth implementations**, both registered in `src/app.py`:

1. **Authlib flow** — `src/routes/auth_routes.py` (`/auth/login`, `/auth/authorize`): stores the whole token **dict** in `session['github_token']`, creates/updates a `User` row and sets `session['user_id']`.
2. **Manual `requests` flow** — `src/routes/github_routes.py` (`/api/github/login`, `/api/github/callback`, `/api/github/repos`): stores a bare access-token **string**, never creates a `User`, never sets `session['user_id']`, and reads `GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET` from `os.getenv()` at import time.

`export_github` in `src/routes/main_routes.py` assumes the dict shape:

```python
token = session.get('github_token')
if not token or 'access_token' not in token:   # substring check on a string!
headers = {"Authorization": f"Bearer {token['access_token']}"}  # TypeError
```

After `/api/github/login`, `token['access_token']` raises `TypeError: string indices must be integers`. Users of that flow also have no `user_id`, so `/profile`, progress APIs, and anything gated on the session reject them.

## Fix

Consolidated both entry points on the canonical **Authlib** flow so there is one OAuth implementation and one consistent session payload:

- `/api/github/login` and `/api/github/callback` now **alias** the Authlib flow (`redirect(url_for('auth.login'))`) — kept so existing frontend links/bookmarks/GitHub redirect URIs don't 404. Every login now creates the `User` row and sets `session['user_id']`.
- Credential lookup now comes only from `app.config` (via `Config`) — the module-level `os.getenv` manual flow is gone.
- `/api/github/repos` reads the token defensively (dict, or legacy string).
- `export_github` defensively extracts `access_token` from either shape, so legacy string sessions can no longer crash it.

## Files changed

- `src/routes/github_routes.py` — manual flow removed; `/api/github/login` + `/api/github/callback` alias Authlib; `/api/github/repos` handles both token shapes.
- `src/routes/main_routes.py` — `export_github` reads `access_token` from dict or string.
- `tests/test_github_oauth.py` — new tests.

## Testing

```
py -m pytest tests/test_github_oauth.py -q
7 passed
```

Covers: login via both entry points redirect into the Authlib flow, `/auth/login` still starts a GitHub authorization, `/api/github/repos` works with the dict token (401 unauthenticated), and `export_github` succeeds with **both** the dict token and a legacy string token.

Existing auth/export tests in `tests/test_basic.py` still pass (11 passed). Full suite: 528 passed; only the pre-existing failures (identical on `main`).

Closes #1814
