### PR TITLE
fix(security): single SECRET_KEY definition and fail fast on known defaults (#1815)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,22 @@ pip install -r requirements.txt
 python src/app.py
 ```
 
+## Environment Variables
+
+| Variable | Required in production | Default | Description |
+| --- | --- | --- | --- |
+| `SECRET_KEY` | **Yes** | dev-only fallback | Signs session cookies and CSRF tokens. The app **refuses to start** in non-debug environments when this is missing or still a known default. Generate one with `python -c "import secrets; print(secrets.token_hex(32))"`. |
+| `GITHUB_CLIENT_ID` | Yes (for GitHub login) | `dummy_client_id` | GitHub OAuth app client id. |
+| `GITHUB_CLIENT_SECRET` | Yes (for GitHub login) | `dummy_client_secret` | GitHub OAuth app client secret. |
+| `DATABASE_URL` | No | local SQLite file | Production database URL (e.g. a managed Postgres). |
+| `BASE_URL` | No | `https://mydevpath-github.vercel.app` | Used for OG tags and canonical URLs. |
+
+Copy `.env.example` to `.env` and fill in real values before deploying:
+
+```bash
+cp .env.example .env
+```
+
 ## Verify Everything Works
 
 Run the test suite:

--- a/src/app.py
+++ b/src/app.py
@@ -25,16 +25,39 @@ from flask import Flask, session
 from flask_wtf.csrf import CSRFProtect
 from routes.main_routes import main
 from routes.github_routes import github_bp
-from config import Config
+from config import Config, secret_key_is_safe
 from errors.handlers import register_error_handlers
 from models import db
 from authlib.integrations.flask_client import OAuth
 
 app = Flask(__name__)
-app.secret_key = os.getenv("SECRET_KEY", "default-dev-secret-key-replace-in-production")
 
 # Load config settings into Flask's internal config manager properly
 app.config.from_object(Config)
+
+
+def _is_debug_mode():
+    return os.environ.get("FLASK_DEBUG", "False").lower() in ("true", "1")
+
+
+def _validate_secret_key():
+    """Raise RuntimeError if SECRET_KEY is unusable outside debug mode.
+
+    SECRET_KEY signs session cookies and CSRF tokens.  A missing or
+    publicly-known key lets an attacker forge sessions, so refuse to boot
+    rather than silently continuing (issue #1815).
+    """
+    if not _is_debug_mode() and not secret_key_is_safe(app.config.get("SECRET_KEY")):
+        raise RuntimeError(
+            "SECRET_KEY is missing or set to a known default value. In "
+            "production you must set the SECRET_KEY environment variable to "
+            "a secure random string (see README 'Environment Variables'). "
+            "Refusing to start because a publicly-known key would allow "
+            "forging session cookies and CSRF tokens."
+        )
+
+
+_validate_secret_key()
 
 # Initialize SQLAlchemy
 db.init_app(app)

--- a/src/config.py
+++ b/src/config.py
@@ -6,17 +6,36 @@
 
 import os
 
+# Publicly-known SECRET_KEY values committed to the repository.  The app
+# must never sign sessions or CSRF tokens with these outside debug mode.
+KNOWN_DEFAULT_SECRET_KEYS = {
+    "dev_secret_key_change_in_production",
+    "change-this-secret-in-production",
+    "default-dev-secret-key-replace-in-production",
+}
+
+
+def secret_key_is_safe(value):
+    """Return True only when ``value`` is usable for signing data.
+
+    A safe key is non-empty and not equal to any publicly-known default.
+    """
+    return bool(value) and value not in KNOWN_DEFAULT_SECRET_KEYS
+
+
 class Config:
     """Base configuration class with sensible defaults."""
     
-    # Secret key for session signing and CSRF protection
-    SECRET_KEY = os.getenv("SECRET_KEY", "change-this-secret-in-production")
+    # Secret key for session signing and CSRF protection.
+    # Must be overridden with a secure random value in production (the
+    # application refuses to boot with this dev-only fallback unless
+    # FLASK_DEBUG is set).  Generate one with:
+    #     python -c "import secrets; print(secrets.token_hex(32))"
+    SECRET_KEY = os.getenv("SECRET_KEY", "dev_secret_key_change_in_production")
     
     # Base URL for the application - used for OG tags and canonical URLs
     # Can be overridden via environment variable for different deployments
     BASE_URL = os.getenv("BASE_URL", "https://mydevpath-github.vercel.app")
-    # Security and Session
-    SECRET_KEY = os.getenv("SECRET_KEY", "dev_secret_key_change_in_production")
     
     # GitHub OAuth Settings
     GITHUB_CLIENT_ID = os.getenv("GITHUB_CLIENT_ID", "dummy_client_id")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,12 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 import pytest
+
+# app.py refuses to boot with a missing/known-default SECRET_KEY in non-debug
+# environments (issue #1815).  Provide a distinct test key before importing
+# the app so the test suite exercises the real production code path.
+os.environ.setdefault("SECRET_KEY", "test-secret-key-not-a-production-default")
+
 from app import app
 from utils.rate_limiter import reset_rate_limits
 

--- a/tests/test_secret_key.py
+++ b/tests/test_secret_key.py
@@ -1,0 +1,111 @@
+# tests/test_secret_key.py
+# Tests for the SECRET_KEY handling (issue #1815).
+#
+# Previously SECRET_KEY was defined twice in config.py with two different
+# public defaults, app.py set a third fallback that was immediately
+# overwritten, and the app booted in production with a publicly-known signing
+# key.  Now there is one definition and the app refuses to start (outside
+# debug mode) with a missing or known-default key.
+
+import sys
+import os
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from config import secret_key_is_safe, KNOWN_DEFAULT_SECRET_KEYS
+
+from app import app
+import app as app_module
+
+
+# ============================================================
+# secret_key_is_safe unit tests
+# ============================================================
+
+def test_known_defaults_are_rejected():
+    for default in KNOWN_DEFAULT_SECRET_KEYS:
+        assert secret_key_is_safe(default) is False
+
+
+def test_missing_and_empty_keys_are_rejected():
+    assert secret_key_is_safe(None) is False
+    assert secret_key_is_safe("") is False
+
+
+def test_secure_random_key_is_accepted():
+    assert secret_key_is_safe("a-secure-random-64-char-secret-0123456789abcdef") is True
+
+
+# ============================================================
+# Effective configuration tests
+# ============================================================
+
+def test_effective_secret_key_is_not_a_default():
+    """The key the app actually signs with must not be a known default."""
+    value = app.config.get("SECRET_KEY")
+    assert value, "SECRET_KEY must be configured"
+    assert value not in KNOWN_DEFAULT_SECRET_KEYS
+
+
+def test_only_one_secret_key_definition_in_config():
+    """config.py must define SECRET_KEY exactly once (no dead duplicate)."""
+    import inspect
+    import config
+
+    source = inspect.getsource(config)
+    occurrences = source.count("SECRET_KEY = os.getenv(\"SECRET_KEY\"")
+    assert occurrences == 1, f"Expected 1 SECRET_KEY definition, found {occurrences}"
+
+
+# ============================================================
+# Startup guard tests
+# ============================================================
+
+def test_guard_raises_for_known_default_key(monkeypatch):
+    """In non-debug mode a known-default key must make startup refuse to run."""
+    monkeypatch.setenv("FLASK_DEBUG", "0")
+    original = app.config.get("SECRET_KEY")
+    app.config["SECRET_KEY"] = "dev_secret_key_change_in_production"
+    try:
+        with pytest.raises(RuntimeError, match="SECRET_KEY"):
+            app_module._validate_secret_key()
+    finally:
+        app.config["SECRET_KEY"] = original
+
+
+def test_guard_raises_for_missing_key(monkeypatch):
+    monkeypatch.setenv("FLASK_DEBUG", "0")
+    original = app.config.get("SECRET_KEY")
+    app.config["SECRET_KEY"] = ""
+    try:
+        with pytest.raises(RuntimeError, match="SECRET_KEY"):
+            app_module._validate_secret_key()
+    finally:
+        app.config["SECRET_KEY"] = original
+
+
+def test_guard_passes_for_secure_key(monkeypatch):
+    """A strong key must allow startup even in non-debug mode."""
+    monkeypatch.setenv("FLASK_DEBUG", "0")
+    original = app.config.get("SECRET_KEY")
+    app.config["SECRET_KEY"] = "a-secure-random-secret-key"
+    try:
+        # Must not raise.
+        app_module._validate_secret_key()
+    finally:
+        app.config["SECRET_KEY"] = original
+
+
+def test_guard_allows_default_key_in_debug_mode(monkeypatch):
+    """Development (FLASK_DEBUG) may still use the default key."""
+    monkeypatch.setenv("FLASK_DEBUG", "1")
+    original = app.config.get("SECRET_KEY")
+    app.config["SECRET_KEY"] = "dev_secret_key_change_in_production"
+    try:
+        # Must not raise.
+        app_module._validate_secret_key()
+    finally:
+        app.config["SECRET_KEY"] = original


### PR DESCRIPTION
## Problem

`SECRET_KEY` is defined **twice** in `src/config.py` with two different publicly-known fallbacks:

```python
SECRET_KEY = os.getenv("SECRET_KEY", "change-this-secret-in-production")     # line 13 (dead)
...
SECRET_KEY = os.getenv("SECRET_KEY", "dev_secret_key_change_in_production")  # line 19 (wins)
```

`src/app.py` line 34 also set `app.secret_key` from env with a third fallback, but it was immediately overwritten by `app.config.from_object(Config)`.

With `SECRET_KEY` unset, the effective key is `dev_secret_key_change_in_production` — a string committed in the repository. Every deployment that forgets `SECRET_KEY` silently signs session cookies and CSRF tokens with a key an attacker can read, enabling forged sessions. The app boots happily instead of failing fast.

## Fix

- **Exactly one `SECRET_KEY` definition** in `src/config.py`; added `KNOWN_DEFAULT_SECRET_KEYS` and a `secret_key_is_safe()` helper.
- **Removed the dead `app.secret_key` fallback** in `src/app.py`.
- **Fail fast**: `_validate_secret_key()` runs at startup (after `app.config.from_object(Config)`) and raises `RuntimeError` when the key is missing or equals any known default — unless `FLASK_DEBUG` is set (development only).
- **Documented** `SECRET_KEY` as a required production variable in a new README "Environment Variables" section.
- `tests/conftest.py` sets a distinct test `SECRET_KEY` before importing the app so the test suite exercises the real production code path.

## Files changed

- `src/config.py` — single `SECRET_KEY`; `KNOWN_DEFAULT_SECRET_KEYS` + `secret_key_is_safe()`.
- `src/app.py` — removed dead fallback; `_validate_secret_key()` startup guard.
- `README.md` — new Environment Variables table.
- `tests/conftest.py` — sets test `SECRET_KEY` before app import.
- `tests/test_secret_key.py` — new tests.

## Testing

```
py -m pytest tests/test_secret_key.py -q
9 passed
```

Covers: all known defaults rejected / secure keys accepted by `secret_key_is_safe`, the effective key is never a default, `config.py` defines `SECRET_KEY` exactly once, and the guard raises for missing/known-default keys in non-debug but passes for a secure key — and still allows the dev key under `FLASK_DEBUG`.

Verified end-to-end: with `SECRET_KEY` unset the app refuses to boot (`RuntimeError: SECRET_KEY is missing...`); with `FLASK_DEBUG=1` it boots with the dev key.

Full suite: 530 passed; only the pre-existing failures (identical on `main`).

Closes #1815
