### PR TITLE
fix: remove duplicate CSRFProtect(app) registration in app.py (#1837)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -94,8 +94,6 @@ from routes.admin_routes import admin_bp
 
 app.register_blueprint(auth_bp, url_prefix='/auth')
 app.register_blueprint(admin_bp, url_prefix='/admin')
-# Enable CSRF protection for all state-changing requests
-csrf = CSRFProtect(app)
 
 # Register all routes defined in the main Blueprint (This handles your '/' route!)
 app.register_blueprint(main)


### PR DESCRIPTION
## Problem

`CSRFProtect(app)` is registered twice in `src/app.py` (previously lines 75 and 98). The duplicate registration is redundant and confusing, making it look like CSRF was deliberately enabled at two separate points during startup.

## Fix

Removed the duplicate `csrf = CSRFProtect(app)` statement. The single registration (right after `db.init_app` / seeding) is kept, so CSRF protection remains active for all state-changing requests. No behavioral change.

## Files changed

- `src/app.py`

## Testing

Verified the app still boots correctly and CSRF remains enabled for the application.

```
python -m pytest -q
```

Closes #1837
