### PR TITLE
fix: remove unused import random inside get_recommendations (#1839)

### DIFF
--- a/src/utils/recommender.py
+++ b/src/utils/recommender.py
@@ -755,8 +755,6 @@ def get_recommendations(
 
       match_details = item.get("match_details", {})
 
-      import random
-
       matched_skills_list = match_details.get("matched_skills", [])
       skills_str = ""
 


### PR DESCRIPTION
## Problem

`import random` is executed inside the hot path of `get_recommendations()` in `src/utils/recommender.py` (line 758) but is never used. The explanation-template index is derived deterministically from the project ID, not from `random`. Importing inside the function (rather than at module top) is also a style issue.

## Fix

Deleted the `import random` statement inside `get_recommendations()`. Verified via search that `random` is not used anywhere else in the module.

## Files changed

- `src/utils/recommender.py`

## Testing

Verified the module imports cleanly and the recommendation logic is unaffected (the template index remains deterministic).

```
python -m pytest -q
```

Closes #1839
