### PR TITLE
fix: clamp per_page/page values in explore to prevent ZeroDivisionError (#1836)

### DIFF
--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -75,6 +75,11 @@ def explore():
     """Render the explore page with server-side pagination, filtering, and sorting."""
     page = request.args.get("page", 1, type=int)
     per_page = request.args.get("per_page", 12, type=int)
+    # Clamp per_page to a safe range so invalid values (0, negative, or
+    # oversized) can never crash pagination or load the entire catalog.
+    per_page = min(max(per_page, 1), 100)
+    if page < 1:
+        page = 1
     search_query = request.args.get("search", "").strip().lower()
     level_filter = request.args.get("level", "").strip().lower()
     interest_filter = request.args.get("interest", "").strip().lower()

--- a/tests/test_explore_pagination.py
+++ b/tests/test_explore_pagination.py
@@ -1,0 +1,56 @@
+# tests/test_explore_pagination.py
+# Tests for explore pagination edge cases (issue #1836).
+#
+# Validates that invalid `per_page` / `page` values cannot crash the
+# /explore endpoint or produce unbounded result sizes.
+
+import pytest
+
+
+@pytest.fixture
+def client():
+    from app import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_explore_default_returns_200(client):
+    """The explore page must render normally with no query params."""
+    response = client.get("/explore")
+    assert response.status_code == 200
+
+
+def test_explore_per_page_zero_no_crash(client):
+    """per_page=0 previously raised ZeroDivisionError -> 500."""
+    response = client.get("/explore?per_page=0")
+    assert response.status_code == 200
+    assert b"Showing" in response.data
+
+
+def test_explore_per_page_negative_no_crash(client):
+    """Negative per_page values must be clamped and not break pagination."""
+    response = client.get("/explore?per_page=-1")
+    assert response.status_code == 200
+    assert b"Showing" in response.data
+
+
+def test_explore_per_page_oversized_is_capped(client):
+    """Oversized per_page values must be capped (no full-catalog dump)."""
+    response = client.get("/explore?per_page=100000")
+    assert response.status_code == 200
+    assert b"Showing" in response.data
+
+
+def test_explore_page_negative_clamped(client):
+    """Negative page values must be clamped to page 1."""
+    response = client.get("/explore?page=-5")
+    assert response.status_code == 200
+    assert b"Showing" in response.data
+
+
+def test_explore_page_beyond_last_is_clamped(client):
+    """page beyond total_pages must be clamped to the last page."""
+    response = client.get("/explore?page=999999")
+    assert response.status_code == 200
+    assert b"Showing" in response.data


### PR DESCRIPTION
## Problem

`GET /explore?per_page=0` raises an unhandled `ZeroDivisionError` and returns HTTP 500 (`math.ceil(total_items / per_page)` divides by zero). Negative or oversized `per_page` values also break pagination or let a single request load the entire catalog.

## Fix

Clamp `per_page` into the safe range `1..100` immediately after parsing, and clamp `page` to be at least 1. Invalid values (0, negative, or oversized) are now normalized instead of crashing or dumping the full catalog.

## Files changed

- `src/routes/main_routes.py`
- `tests/test_explore_pagination.py` (new tests for `per_page=0`, negative, oversized, and invalid page values)

## Testing

Added regression tests covering `per_page=0`, negative `per_page`, oversized `per_page`, and negative/out-of-range `page` values.

```
python -m pytest tests/test_explore_pagination.py -q
```

Closes #1836
