### PR TITLE
fix: stop blocking DevOps and Mobile recommendations (#1835)

### DIFF
--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -39,8 +39,6 @@ _code_review_manager = CodeReviewManager()
 # Interest categories that currently have no project recommendations available
 NO_PROJECT_INTERESTS = {
     "machine learning/ai",
-    "devops",
-    "mobile",
     "artificial intelligence",
     "cloud computing",
     "mobile app development",

--- a/tests/test_recommend_interests.py
+++ b/tests/test_recommend_interests.py
@@ -1,0 +1,43 @@
+# tests/test_recommend_interests.py
+# Tests for issue #1835: the hardcoded NO_PROJECT_INTERESTS bypass must not
+# block DevOps and Mobile recommendations even though matching projects exist.
+
+import pytest
+
+
+@pytest.fixture
+def client():
+    from app import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_devops_interest_returns_projects(client):
+    """Selecting DevOps must return the matching CI/CD project."""
+    response = client.post("/api/recommend", json={
+        "skills": "Docker",
+        "level": "Advanced",
+        "interest": "DevOps",
+        "time": "High"
+    })
+    assert response.status_code == 200
+    data = response.get_json()
+    assert "projects" in data
+    assert len(data["projects"]) > 0
+    assert any(p.get("interest") == "DevOps" for p in data["projects"])
+
+
+def test_mobile_interest_returns_projects(client):
+    """Selecting Mobile must return the matching Android/Kotlin projects."""
+    response = client.post("/api/recommend", json={
+        "skills": "Kotlin",
+        "level": "Beginner",
+        "interest": "Mobile",
+        "time": "Low"
+    })
+    assert response.status_code == 200
+    data = response.get_json()
+    assert "projects" in data
+    assert len(data["projects"]) > 0
+    assert any(p.get("interest") == "Mobile" for p in data["projects"])


### PR DESCRIPTION
## Problem

The hardcoded `NO_PROJECT_INTERESTS` bypass in `/api/recommend` still short-circuits the recommender for **DevOps** and **Mobile** — even though `data/projects.json` contains projects with those interests. Users selecting DevOps or Mobile always saw "No projects are currently available..." (regression of #652).

## Fix

Removed `"devops"` and `"mobile"` from `NO_PROJECT_INTERESTS`. The remaining entries (`machine learning/ai`, `artificial intelligence`, `cloud computing`, `mobile app development`) still have no matching projects in the dataset, so the data-driven empty-state handling covers them.

## Files changed

- `src/routes/main_routes.py`
- `tests/test_recommend_interests.py` (new tests asserting DevOps/Mobile return matching projects)

## Testing

```
python -m pytest tests/test_recommend_interests.py -q
```

Both new tests pass: selecting DevOps returns the CI/CD project, and selecting Mobile returns the Android/Kotlin projects.

Closes #1835
