### PR TITLE
fix: generate /explore interest dropdown from dataset (#1840)

### DIFF
--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -132,6 +132,7 @@ def explore():
 
     # Also pass filter dropdown options to UI
     available_levels = get_available_levels()
+    available_interests = get_available_interests()
     stats = get_project_stats()
     
     return render_template(
@@ -146,6 +147,7 @@ def explore():
         time=time_filter,
         sort=sort_by,
         available_levels=available_levels,
+        available_interests=available_interests,
         stats=stats,
         config=Config
     )

--- a/src/templates/explore.html
+++ b/src/templates/explore.html
@@ -490,20 +490,9 @@
               <div class="select-wrap" style="width: 100%;">
                 <select id="interest" name="interest">
                   <option value="">Any Interest</option>
-                  <!-- We can hardcode standard interests or pass them -->
-                  <option value="web" {% if interest == "web" %}selected{% endif %}>Web Development</option>
-                  <option value="data" {% if interest == "data" %}selected{% endif %}>Data and Analytics</option>
-                  <option value="education" {% if interest == "education" %}selected{% endif %}>Education Tools</option>
-                  <option value="automation" {% if interest == "automation" %}selected{% endif %}>Automation</option>
-                  <option value="games" {% if interest == "games" %}selected{% endif %}>Games</option>
-                  <option value="cybersecurity" {% if interest == "cybersecurity" %}selected{% endif %}>CyberSecurity/Ethical Hacking</option>
-                  <option value="devops" {% if interest == "devops" %}selected{% endif %}>DevOps / Cloud Computing</option>
-                  <option value="backend" {% if interest == "backend" %}selected{% endif %}>Backend APIs</option>
-                  <option value="tools" {% if interest == "tools" %}selected{% endif %}>Developer Tools</option>
-                  <option value="productivity" {% if interest == "productivity" %}selected{% endif %}>Productivity</option>
-                  <option value="business logic" {% if interest == "business logic" %}selected{% endif %}>Business Logic</option>
-                  <option value="mobile" {% if interest == "mobile" %}selected{% endif %}>Mobile Development</option>
-                  <option value="machine learning/ai" {% if interest == "machine learning/ai" %}selected{% endif %}>Machine Learning/AI</option>
+                  {% for i in available_interests %}
+                  <option value="{{ i | lower }}" {% if interest == i | lower %}selected{% endif %}>{{ i }}</option>
+                  {% endfor %}
                 </select>
               </div>
             </div>

--- a/tests/test_explore_interests.py
+++ b/tests/test_explore_interests.py
@@ -1,0 +1,32 @@
+# tests/test_explore_interests.py
+# Tests for issue #1840: the /explore interest dropdown must be generated
+# from the real dataset instead of a hardcoded list that includes interests
+# with no matching projects.
+
+import pytest
+
+
+@pytest.fixture
+def client():
+    from app import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_explore_dropdown_includes_real_interests(client):
+    """The dropdown must offer interests that exist in the dataset."""
+    response = client.get("/explore")
+    assert response.status_code == 200
+    assert b"Automation" in response.data
+    assert b"DevOps" in response.data
+    assert b"Mobile" in response.data
+    assert b"Backend" in response.data
+
+
+def test_explore_dropdown_omits_interests_without_projects(client):
+    """Options like 'Business Logic' with no matching projects must be gone."""
+    response = client.get("/explore")
+    assert response.status_code == 200
+    assert b"Business Logic" not in response.data
+    assert b"Machine Learning/AI" not in response.data


### PR DESCRIPTION
## Problem

The `/explore` interest filter dropdown was hardcoded with 13 options, while the dataset only contains 10 distinct interests. Several options (e.g. "Business Logic", "Machine Learning/AI", "Developer Tools") have no matching projects and always produce an empty page — inconsistent with the homepage dropdown, which is generated from the data via `get_available_interests()`.

## Fix

- The `/explore` route now computes `available_interests = get_available_interests()` and passes it to the template (same pattern the homepage already uses).
- `explore.html` renders the dropdown from `available_interests`, so both pages offer exactly the same, real set of interests — every option now has results.

## Files changed

- `src/routes/main_routes.py`
- `src/templates/explore.html`
- `tests/test_explore_interests.py` (new tests)

## Testing

```
python -m pytest tests/test_explore_interests.py -q
```

Tests confirm the dropdown includes real interests (DevOps, Mobile, Backend, Automation) and omits interests with no matching projects ("Business Logic", "Machine Learning/AI").

Closes #1840
