### PR TITLE
fix: remove never-populating Saved Skills and Bookmarked Projects sections from profile (#1826)

### DIFF
--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -331,7 +331,6 @@ def project_detail(project_id):
 def profile():
     from flask import session
     from models import db, User
-    from utils.data_loader import find_project_by_id
     
     user_id = session.get('user_id')
     if not user_id:
@@ -342,14 +341,7 @@ def profile():
         session.pop('user_id', None)
         return redirect(url_for('auth.login'))
         
-    # Hydrate bookmarked projects
-    bookmarked_projects = []
-    for pid in user.bookmarked_projects:
-        p = find_project_by_id(pid)
-        if p:
-            bookmarked_projects.append(p)
-            
-    return render_template("profile.html", user=user, bookmarked_projects=bookmarked_projects)
+    return render_template("profile.html", user=user)
 
 @main.route("/project/<int:project_id>/code")
 def view_code(project_id):

--- a/src/templates/profile.html
+++ b/src/templates/profile.html
@@ -161,39 +161,6 @@
        Main Content
   ============================================================= -->
   <main class="profile-content container">
-    <h2 class="section-title">Saved Skills</h2>
-    {% if user.saved_skills %}
-    <div class="skills-list">
-      {% for skill in user.saved_skills %}
-      <span class="project-tag project-tag--skill">{{ skill }}</span>
-      {% endfor %}
-    </div>
-    {% else %}
-    <p style="color: var(--text-muted); margin-bottom: 3rem;">You haven't saved any skills yet. Your search history will automatically populate this section over time.</p>
-    {% endif %}
-
-    <h2 class="section-title">Bookmarked Projects</h2>
-    {% if bookmarked_projects %}
-    <div class="results-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.5rem;">
-      {% for project in bookmarked_projects %}
-      <div class="project-card">
-        <h3 class="project-card-title">{{ project.title }}</h3>
-        <p class="project-card-desc"><span class="project-card-desc-text">{{ project.description | truncate(120) }}</span></p>
-        <div class="project-card-tags">
-          <span class="project-tag project-tag--{{ project.level | lower | replace(' ', '-') }}">{{ project.level }}</span>
-          <span class="project-tag project-tag--time">Time: {{ project.time }}</span>
-        </div>
-        <div class="project-card-footer">
-          <a href="/project/{{ project.id }}" class="btn-view-project" style="flex: 1; text-align: center;">View Project &rarr;</a>
-        </div>
-      </div>
-      {% endfor %}
-    </div>
-    {% else %}
-    <p style="color: var(--text-muted);">You haven't bookmarked any projects yet. Go explore the catalog to find your next challenge!</p>
-    <a href="/explore" class="btn-primary" style="display: inline-block; margin-top: 1rem;">Explore Projects</a>
-    {% endif %}
-
     <div style="margin-top: 4rem; border-top: 1px solid var(--border); padding-top: 2rem;">
       <h3 style="font-size: 1.25rem; font-weight: 700; margin-bottom: 1rem; color: var(--text-main);">Account Management</h3>
       <p style="color: var(--text-muted); font-size: 0.95rem;">You are currently authenticated via GitHub OAuth.</p>

--- a/tests/test_profile_sections.py
+++ b/tests/test_profile_sections.py
@@ -1,0 +1,60 @@
+# tests/test_profile_sections.py
+# Tests for issue #1826: the /profile "Saved Skills" and "Bookmarked Projects"
+# sections could never populate (their DB columns were never written), so they
+# and their misleading empty-state copy are removed.
+
+import pytest
+
+
+@pytest.fixture
+def client():
+    from app import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def _login(client):
+    from models import db, User
+    user = User(github_id="test-1826", username="tester")
+    db.session.add(user)
+    db.session.commit()
+    with client.session_transaction() as sess:
+        sess["user_id"] = user.id
+    return user
+
+
+def test_profile_renders_for_logged_in_user(client):
+    """The profile page must still render for an authenticated user."""
+    _login(client)
+    response = client.get("/profile")
+    assert response.status_code == 200
+    assert b"tester" in response.data
+
+
+def test_profile_redirects_when_logged_out(client):
+    """Unauthenticated users must be redirected to the login page."""
+    response = client.get("/profile")
+    assert response.status_code == 302
+
+
+def test_profile_has_no_saved_skills_section(client):
+    """The dead 'Saved Skills' section and its copy must be gone."""
+    _login(client)
+    response = client.get("/profile")
+    assert b"Saved Skills" not in response.data
+    assert b"Your search history will automatically populate" not in response.data
+
+
+def test_profile_has_no_bookmarked_projects_section(client):
+    """The dead 'Bookmarked Projects' section must be gone."""
+    _login(client)
+    response = client.get("/profile")
+    assert b"Bookmarked Projects" not in response.data
+
+
+def test_profile_keeps_account_management(client):
+    """The Account Management section must remain."""
+    _login(client)
+    response = client.get("/profile")
+    assert b"Account Management" in response.data


### PR DESCRIPTION
## Problem

The `/profile` page rendered a "Saved Skills" section and a "Bookmarked Projects" section that could never contain data: the `User.saved_skills` and `User.bookmarked_projects` columns are never written by any code. The empty-state copy ("Your search history will automatically populate this section over time") was never true, and projects bookmarked client-side never appeared.

## Fix

Removed the permanently-empty "Saved Skills" and "Bookmarked Projects" sections and their misleading copy from `profile.html`. Also removed the now-unused bookmarked-projects hydration loop from the `/profile` route. The Account Management section is kept.

## Files changed

- `src/templates/profile.html`
- `src/routes/main_routes.py`
- `tests/test_profile_sections.py` (new tests)

## Testing

```
python -m pytest tests/test_profile_sections.py -q
```

Tests confirm the profile still renders for logged-in users, still redirects when logged out, no longer contains either dead section, and keeps the Account Management section.

Closes #1826
