### PR TITLE
fix: add csrf_token to admin forms so admin CRUD is not rejected (#1829)

### DIFF
--- a/src/templates/admin/dashboard.html
+++ b/src/templates/admin/dashboard.html
@@ -62,6 +62,7 @@
             <a href="/project/{{ project.id }}" target="_blank" class="btn btn-secondary">View</a>
             <a href="/admin/projects/{{ project.id }}/edit" class="btn btn-primary" style="background-color: #4f46e5;">Edit</a>
             <form action="/admin/projects/{{ project.id }}/delete" method="POST" onsubmit="return confirm('Are you sure you want to delete this project?');">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
               <button type="submit" class="btn btn-danger">Delete</button>
             </form>
           </td>

--- a/src/templates/admin/form.html
+++ b/src/templates/admin/form.html
@@ -32,6 +32,7 @@
     </div>
 
     <form method="POST">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="form-group">
         <label for="title">Project Title</label>
         <input type="text" id="title" name="title" required value="{{ project.title if project else '' }}" placeholder="e.g. Build a Web Scraper">

--- a/tests/test_admin_csrf.py
+++ b/tests/test_admin_csrf.py
@@ -1,0 +1,77 @@
+# tests/test_admin_csrf.py
+# Tests for issue #1829: admin forms must include a CSRF token so the
+# admin CRUD actions are not rejected by CSRFProtect.
+
+import pytest
+
+
+@pytest.fixture
+def client():
+    from app import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def _login_admin(client):
+    from models import db, User
+    admin = User(github_id="admin-1829", username="admin", is_admin=True)
+    db.session.add(admin)
+    db.session.commit()
+    with client.session_transaction() as sess:
+        sess["user_id"] = admin.id
+
+
+def test_admin_new_project_form_has_csrf_token(client):
+    """The create/edit form must render a csrf_token hidden input."""
+    _login_admin(client)
+    response = client.get("/admin/projects/new")
+    assert response.status_code == 200
+    assert b'name="csrf_token"' in response.data
+
+
+def test_admin_dashboard_delete_form_has_csrf_token(client):
+    """The delete form must render a csrf_token hidden input."""
+    _login_admin(client)
+    response = client.get("/admin/")
+    assert response.status_code == 200
+    assert b'name="csrf_token"' in response.data
+
+
+def test_admin_create_rejected_without_csrf_when_enabled(client):
+    """With CSRF enabled, a POST without a token must be rejected."""
+    from app import app
+    app.config["WTF_CSRF_ENABLED"] = True
+    _login_admin(client)
+    response = client.post("/admin/projects/new", data={
+        "title": "Test Project",
+        "level": "Beginner",
+        "interest": "Web",
+        "time": "Low",
+        "description": "desc",
+    })
+    assert response.status_code == 400
+
+
+def test_admin_create_succeeds_with_csrf_when_enabled(client):
+    """With CSRF enabled, a POST including the form's token must succeed."""
+    import re
+    from app import app
+    app.config["WTF_CSRF_ENABLED"] = True
+    _login_admin(client)
+
+    # Fetch the create form to obtain a valid CSRF token from the session.
+    form = client.get("/admin/projects/new")
+    match = re.search(rb'name="csrf_token" value="([^"]+)"', form.data)
+    assert match is not None
+    token = match.group(1).decode()
+
+    response = client.post("/admin/projects/new", data={
+        "title": "Test Project",
+        "level": "Beginner",
+        "interest": "Web",
+        "time": "Low",
+        "description": "desc",
+        "csrf_token": token,
+    })
+    assert response.status_code == 302


### PR DESCRIPTION
## Problem

The admin panel was non-functional: every mutating action (create, edit, delete project) was rejected with HTTP 400 "The CSRF token is missing." `CSRFProtect(app)` protects all state-changing requests by default, but none of the admin forms included a `csrf_token` hidden input.

## Fix

Added `{{ csrf_token() }}` hidden inputs to:
- the create/edit project form in `admin/form.html`
- the delete-project form in `admin/dashboard.html`

Admin create, edit, and delete now work with CSRF protection enabled.

## Files changed

- `src/templates/admin/form.html`
- `src/templates/admin/dashboard.html`
- `tests/test_admin_csrf.py` (new tests)

## Testing

```
python -m pytest tests/test_admin_csrf.py -q
```

Tests verify the forms render a CSRF token, that a POST without a token is rejected (400) when CSRF is enabled, and that a POST with the form's token succeeds.

Closes #1829
