### PR TITLE
fix: add and validate state param in GitHub OAuth flow to prevent login CSRF (#1828)

### DIFF
--- a/src/routes/github_routes.py
+++ b/src/routes/github_routes.py
@@ -1,4 +1,5 @@
 import os
+import secrets
 import requests
 from flask import Blueprint, redirect, request, session, jsonify, url_for
 
@@ -6,6 +7,9 @@ github_bp = Blueprint("github", __name__)
 
 GITHUB_CLIENT_ID = os.getenv("GITHUB_CLIENT_ID")
 GITHUB_CLIENT_SECRET = os.getenv("GITHUB_CLIENT_SECRET")
+
+# Session key used to store the OAuth state between login and callback.
+_OAUTH_STATE_KEY = "github_oauth_state"
 
 # You can configure your local callback URL in GitHub, e.g., http://localhost:5000/api/github/callback
 # In production, it will be your domain.
@@ -15,13 +19,18 @@ def login():
     """Redirect user to GitHub OAuth login."""
     if not GITHUB_CLIENT_ID:
         return jsonify({"error": "GitHub OAuth is not configured on the server."}), 500
-        
+
+    # Generate and persist a state parameter to protect against login CSRF.
+    state = secrets.token_urlsafe(32)
+    session[_OAUTH_STATE_KEY] = state
+
     redirect_uri = request.host_url.rstrip('/') + url_for("github.callback")
     auth_url = (
         f"https://github.com/login/oauth/authorize"
         f"?client_id={GITHUB_CLIENT_ID}"
         f"&redirect_uri={redirect_uri}"
         f"&scope=public_repo"
+        f"&state={state}"
     )
     return redirect(auth_url)
 
@@ -30,6 +39,12 @@ def callback():
     """Handle GitHub OAuth callback and exchange code for access token."""
     code = request.args.get("code")
     if not code:
+        return redirect("/?github_auth=error")
+
+    # Validate the state parameter to prevent login CSRF.
+    expected_state = session.pop(_OAUTH_STATE_KEY, None)
+    returned_state = request.args.get("state")
+    if not expected_state or not returned_state or not secrets.compare_digest(expected_state, returned_state):
         return redirect("/?github_auth=error")
 
     redirect_uri = request.host_url.rstrip('/') + url_for("github.callback")

--- a/tests/test_github_oauth_state.py
+++ b/tests/test_github_oauth_state.py
@@ -1,0 +1,43 @@
+# tests/test_github_oauth_state.py
+# Tests for issue #1828: GitHub OAuth login must generate and persist a
+# `state` parameter and the callback must reject missing/mismatched states.
+
+import pytest
+
+
+@pytest.fixture
+def client(monkeypatch):
+    from routes import github_routes
+    monkeypatch.setattr(github_routes, "GITHUB_CLIENT_ID", "test-client-id")
+    monkeypatch.setattr(github_routes, "GITHUB_CLIENT_SECRET", "test-client-secret")
+    from app import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_login_redirects_with_state(client):
+    response = client.get("/api/github/login")
+    assert response.status_code == 302
+    location = response.headers["Location"]
+    assert "state=" in location
+
+
+def test_login_persists_state_in_session(client):
+    client.get("/api/github/login")
+    with client.session_transaction() as sess:
+        state = sess.get("github_oauth_state")
+    assert state
+
+
+def test_callback_rejects_missing_state(client):
+    response = client.get("/api/github/callback?code=abc123")
+    assert response.status_code == 302
+    assert "/?github_auth=error" in response.headers["Location"]
+
+
+def test_callback_rejects_wrong_state(client):
+    client.get("/api/github/login")
+    response = client.get("/api/github/callback?code=abc123&state=not-the-right-state")
+    assert response.status_code == 302
+    assert "/?github_auth=error" in response.headers["Location"]


### PR DESCRIPTION
## Problem

The GitHub OAuth flow was vulnerable to login CSRF / state-forgery: `login()` built the authorize URL without a `state` parameter and `callback()` performed no validation of any state that GitHub echoed back.

## Fix

- `login()` now generates a random `state` (`secrets.token_urlsafe(32)`), stores it in the session, and appends `&state=...` to the authorize URL.
- `callback()` now pops the stored state and compares it against the returned value using a constant-time comparison (`secrets.compare_digest`). If the state is missing or mismatched, the request is rejected with a redirect to `/?github_auth=error` before any token exchange happens.

## Files changed

- `src/routes/github_routes.py`
- `tests/test_github_oauth_state.py` (new tests)

## Testing

```
python -m pytest tests/test_github_oauth_state.py -q
```

Tests verify the login redirect includes a state param, that the state is persisted in the session, and that the callback rejects both a missing state and a mismatched state.

Closes #1828
