### PR TITLE
fix: declare buildProjectCard detail link before it is appended (#1830)

### DIFF
--- a/src/static/script.js
+++ b/src/static/script.js
@@ -809,6 +809,17 @@ async function updatePortfolioAnalysis() {
     var footer = document.createElement("div");
     footer.className = "project-card-footer";
 
+    var link = document.createElement("a");
+    link.className = "btn-details";
+    link.textContent = "View Full Project";
+    link.href = "/project/" + project.id;
+
+    link.addEventListener("click", function() {
+      if (typeof RecentlyViewed !== "undefined") {
+        RecentlyViewed.trackView(project);
+      }
+    });
+
     if (typeof DevPathBookmarks !== "undefined") {
       var saveBtn = document.createElement("button");
       saveBtn.type = "button";
@@ -834,19 +845,8 @@ async function updatePortfolioAnalysis() {
 
       // Also keep recently-viewed tracking code
       footer.appendChild(saveBtn);
-      footer.appendChild(link);
     }
 
-    var link = document.createElement("a");
-    link.className = "btn-details";
-    link.textContent = "View Full Project";
-    link.href = "/project/" + project.id;
-    
-    link.addEventListener("click", function() {
-      if (typeof RecentlyViewed !== "undefined") {
-        RecentlyViewed.trackView(project);
-      }
-    });
     footer.appendChild(link);
 
     card.appendChild(title);


### PR DESCRIPTION
## Problem

In `buildProjectCard` (`src/static/script.js`), the project card footer appended `link` to the footer **before** `var link` was declared:

```js
if (typeof DevPathBookmarks !== "undefined") {
  footer.appendChild(saveBtn);
  footer.appendChild(link);   // link is undefined here
}

var link = document.createElement("a");
```

Because `var` declarations are hoisted, `link` is `undefined` at the point of `appendChild`, so whenever the bookmarks module is loaded the card fails with a `TypeError` and the project card is never rendered on the explore/search page.

## Fix

Declared and wired up the `link` element **before** the bookmarks block, and append it exactly once (the bookmarks block only appends the save button now).

## Files changed

- `src/static/script.js`

## Testing

- `buildProjectCard` now constructs a valid `<a class="btn-details">` link before it is referenced.
- No JS test harness exists in the repo; change is a pure reordering of element creation so the existing bookmark + recently-viewed behavior is unchanged.
- Ran the Python test suite (unrelated to this JS change).

Closes #1830
