### PR TITLE
fix: cascade ProjectProgress deletion when a project is deleted and enforce SQLite FKs

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -1,6 +1,22 @@
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+import sqlite3
 
 db = SQLAlchemy()
+
+
+@event.listens_for(Engine, "connect")
+def _set_sqlite_foreign_keys(dbapi_connection, connection_record):
+    """Enable SQLite foreign-key enforcement so deletes cascade correctly.
+
+    SQLite does not enforce foreign keys by default. Without this PRAGMA,
+    deleting a Project would leave orphaned ProjectProgress rows behind.
+    """
+    if isinstance(dbapi_connection, sqlite3.Connection):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
 
 class Project(db.Model):
     __tablename__ = 'projects'
@@ -19,6 +35,8 @@ class Project(db.Model):
     roadmap = db.Column(db.JSON, nullable=False, default=list)
     resources = db.Column(db.JSON, nullable=True, default=list)
     starter_code = db.Column(db.String(500), nullable=True)
+
+    progress = db.relationship('ProjectProgress', cascade="all, delete-orphan", back_populates='project')
 
     def to_dict(self):
         """Convert the model to a dictionary matching projects.json format."""
@@ -70,7 +88,7 @@ class ProjectProgress(db.Model):
     completed_steps = db.Column(db.JSON, nullable=False, default=list)
 
     user = db.relationship('User', backref=db.backref('progress', lazy=True, cascade="all, delete-orphan"))
-    project = db.relationship('Project')
+    project = db.relationship('Project', back_populates='progress')
 
 class UserGameProgress(db.Model):
     __tablename__ = 'user_game_progress'

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -632,6 +632,26 @@ def test_project_progress_unauthenticated_post():
     assert response.status_code == 401
     assert b"Unauthorized" in response.data
 
+def test_delete_project_cascades_progress():
+    """Deleting a project must remove its ProjectProgress rows."""
+    with app.app_context():
+        from models import db, User, ProjectProgress
+        if not db.session.get(User, 2):
+            db.session.add(User(id=2, github_id="456", username="adminuser", is_admin=True))
+        if not db.session.get(User, 1):
+            db.session.add(User(id=1, github_id="123", username="testuser"))
+        db.session.add(ProjectProgress(user_id=1, project_id=1, completed_steps=[True, True]))
+        db.session.commit()
+    client = get_client()
+    with client.session_transaction() as sess:
+        sess["user_id"] = 2
+    response = client.post("/admin/projects/1/delete")
+    assert response.status_code == 302
+    with app.app_context():
+        from models import Project, ProjectProgress
+        assert db.session.get(Project, 1) is None
+        assert ProjectProgress.query.filter_by(project_id=1).count() == 0
+
 
 def test_view_code_nested_path():
     """A project with a nested starter_code path should still return 200."""


### PR DESCRIPTION
## Problem
Deleting a project via the admin panel (`POST /admin/projects/<id>/delete`) deletes only the `Project` row. `ProjectProgress` rows referencing that project are orphaned because (a) the `ProjectProgress.project` relationship has no cascade and (b) SQLite, the default database, does not enforce foreign keys unless `PRAGMA foreign_keys=ON` is set. If a future project reuses the same numeric `id`, stale progress rows silently attach to the new project.

## Fix
- `src/models.py`: add `cascade="all, delete-orphan"` on the `Project.progress` relationship so deleting a project removes its `ProjectProgress` rows.
- `src/models.py`: add a `@event.listens_for(Engine, "connect")` listener that runs `PRAGMA foreign_keys=ON` for SQLite connections, so FK constraints are actually enforced.
- `tests/test_basic.py`: add `test_delete_project_cascades_progress` verifying the admin delete removes the project and all of its progress rows.

## Files changed
- `src/models.py`
- `tests/test_basic.py`

## Testing
- `py -m pytest tests/ -q` → 522 passed, 19 pre-existing unrelated failures (identical to baseline), 3 skipped.
- New cascade test confirms `ProjectProgress` rows are gone after deleting their project.

Closes #1855
