### PR TITLE
fix: clear github_token on logout and require POST for /auth/logout (#1850)

### DIFF
--- a/src/routes/auth_routes.py
+++ b/src/routes/auth_routes.py
@@ -52,7 +52,9 @@ def authorize():
     session['user_id'] = user.id
     return redirect(url_for('main.profile'))
 
-@auth_bp.route('/logout')
+@auth_bp.route('/logout', methods=['POST'])
 def logout():
-    session.pop('user_id', None)
+    # Clear the entire session so the GitHub OAuth access token
+    # (session['github_token']) is not left behind for the next browser user.
+    session.clear()
     return redirect(url_for('main.index'))

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -422,7 +422,10 @@
         <a href="/admin" class="nav-link" style="font-weight: 600; color: #4f46e5; text-decoration: none;">Admin</a>
         {% endif %}
         <a href="/profile" class="nav-link" style="font-weight: 600; color: var(--text-main); text-decoration: none;">Profile</a>
-        <a href="/auth/logout" class="nav-link" style="color: var(--text-muted); text-decoration: none;">Logout</a>
+        <form method="POST" action="/auth/logout" style="display: inline; margin: 0;">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          <button type="submit" class="nav-link" style="color: var(--text-muted); text-decoration: none; background: none; border: none; cursor: pointer;">Logout</button>
+        </form>
         {% else %}
         <a href="/auth/login" class="nav-link" style="font-weight: 600; color: var(--text-main); text-decoration: none;">Login with GitHub</a>
         {% endif %}
@@ -462,7 +465,10 @@
       <a href="/admin" class="nav-mobile-link" role="menuitem" style="color: #4f46e5;">Admin</a>
       {% endif %}
       <a href="/profile" class="nav-mobile-link" role="menuitem">Profile</a>
-      <a href="/auth/logout" class="nav-mobile-link" role="menuitem">Logout</a>
+      <form method="POST" action="/auth/logout" style="display: block; margin: 0;">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <button type="submit" class="nav-mobile-link" role="menuitem" style="width: 100%; text-align: left; background: none; border: none; color: inherit; cursor: pointer;">Logout</button>
+      </form>
       {% else %}
       <a href="/auth/login" class="nav-mobile-link" role="menuitem">Login with GitHub</a>
       {% endif %}

--- a/src/templates/profile.html
+++ b/src/templates/profile.html
@@ -116,7 +116,10 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path>
           </svg>
         </button>
-        <a href="/auth/logout" class="btn-primary" style="padding: 0.5rem 1rem;">Logout</a>
+        <form method="POST" action="/auth/logout" style="display: inline; margin: 0;">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          <button type="submit" class="btn-primary" style="padding: 0.5rem 1rem; border: none; cursor: pointer;">Logout</button>
+        </form>
       </div>
 
       <!-- Mobile hamburger toggle -->
@@ -131,7 +134,10 @@
     <div class="nav-mobile-menu" id="nav-mobile-menu" role="menu">
       <a href="/" class="nav-mobile-link" role="menuitem">Home</a>
       <a href="/explore" class="nav-mobile-link" role="menuitem">Explore All</a>
-      <a href="/auth/logout" class="nav-mobile-link" role="menuitem">Logout</a>
+      <form method="POST" action="/auth/logout" style="display: block; margin: 0;">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <button type="submit" class="nav-mobile-link" role="menuitem" style="width: 100%; text-align: left; background: none; border: none; color: inherit; cursor: pointer;">Logout</button>
+      </form>
       <button class="nav-mobile-link theme-toggle" id="theme-toggle-mobile" role="menuitem" style="text-align: left; width: 100%; display: flex; align-items: center; justify-content: space-between;">
         <span>Toggle Theme</span>
         <svg class="sun-icon" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"></path></svg>
@@ -197,7 +203,10 @@
     <div style="margin-top: 4rem; border-top: 1px solid var(--border); padding-top: 2rem;">
       <h3 style="font-size: 1.25rem; font-weight: 700; margin-bottom: 1rem; color: var(--text-main);">Account Management</h3>
       <p style="color: var(--text-muted); font-size: 0.95rem;">You are currently authenticated via GitHub OAuth.</p>
-      <a href="/auth/logout" class="btn-danger">Sign Out</a>
+      <form method="POST" action="/auth/logout" style="display: inline-block; margin-top: 1rem;">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <button type="submit" class="btn-danger" style="border: none; cursor: pointer;">Sign Out</button>
+      </form>
     </div>
   </main>
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -890,11 +890,23 @@ def test_login_redirect():
     assert "github.com/login/oauth/authorize" in response.headers["Location"]
 
 def test_logout_redirect():
-    """Logout route should redirect to homepage."""
+    """Logout route should redirect to homepage and clear the session."""
     client = get_client()
-    response = client.get("/auth/logout")
+    with client.session_transaction() as sess:
+        sess["user_id"] = 1
+        sess["github_token"] = "test-token"
+    response = client.post("/auth/logout")
     assert response.status_code == 302
     assert response.headers["Location"] == "/"
+    with client.session_transaction() as sess:
+        assert "user_id" not in sess
+        assert "github_token" not in sess
+
+def test_logout_rejects_get():
+    """Logout must not be triggerable via a plain GET (logout CSRF)."""
+    client = get_client()
+    response = client.get("/auth/logout")
+    assert response.status_code == 405
 
 def test_profile_unauthenticated_redirects_to_login():
     """Profile route should redirect to login if unauthenticated."""


### PR DESCRIPTION
## Problem
`/auth/logout` is a GET route that only pops `user_id` from the session, leaving the live GitHub OAuth token (`session['github_token']`) behind after logout. The token (full API access with `public_repo` scope) persists until session expiry. A GET request to a state-changing route is also trivially CSRF-able (e.g. an `<img>` tag logs the user out).

## Fix
- `src/routes/auth_routes.py`: logout is now `POST`-only and calls `session.clear()` so `github_token` is removed along with the session.
- `src/templates/index.html` and `src/templates/profile.html`: the four logout anchors are converted to CSRF-protected POST forms.
- `tests/test_basic.py`: logout test updated to assert the session is fully cleared, plus a new test that `GET /auth/logout` is rejected.

## Files changed
- `src/routes/auth_routes.py`
- `src/templates/index.html`
- `src/templates/profile.html`
- `tests/test_basic.py`

## Testing
- `GET /auth/logout` → 405 (Method Not Allowed).
- `POST /auth/logout` → 302 and the session is empty (`github_token` and `user_id` both gone).
- Full suite: no new failures vs baseline.

Closes #1850
