### PR TITLE
fix: harden session cookie with Secure, HttpOnly, SameSite and lifetime (#1852)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -5,6 +5,7 @@
 # between environments (development, production, forks).
 
 import os
+from datetime import timedelta
 
 class Config:
     """Base configuration class with sensible defaults."""
@@ -17,6 +18,16 @@ class Config:
     BASE_URL = os.getenv("BASE_URL", "https://mydevpath-github.vercel.app")
     # Security and Session
     SECRET_KEY = os.getenv("SECRET_KEY", "dev_secret_key_change_in_production")
+
+    # Session cookie hardening. The session carries the GitHub OAuth token,
+    # so the cookie must be Secure, HttpOnly and SameSite. SESSION_COOKIE_SECURE
+    # can be disabled via env for local http:// development.
+    SESSION_COOKIE_SECURE = os.getenv(
+        "SESSION_COOKIE_SECURE", "true"
+    ).lower() in ("true", "1")
+    SESSION_COOKIE_SAMESITE = "Lax"
+    SESSION_COOKIE_HTTPONLY = True
+    PERMANENT_SESSION_LIFETIME = timedelta(days=7)
     
     # GitHub OAuth Settings
     GITHUB_CLIENT_ID = os.getenv("GITHUB_CLIENT_ID", "dummy_client_id")

--- a/src/routes/auth_routes.py
+++ b/src/routes/auth_routes.py
@@ -24,6 +24,7 @@ def authorize():
         return redirect(url_for('main.index'))
         
     session['github_token'] = token
+    session.permanent = True
     
     resp = github.get('user', token=token)
     profile = resp.json()

--- a/src/routes/github_routes.py
+++ b/src/routes/github_routes.py
@@ -49,6 +49,7 @@ def callback():
     access_token = data.get("access_token")
     if access_token:
         session["github_token"] = access_token
+        session.permanent = True
         return redirect("/?github_auth=success")
     else:
         return redirect("/?github_auth=error")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,8 @@ from utils.rate_limiter import reset_rate_limits
 # Disable CSRF globally for testing
 app.config['WTF_CSRF_ENABLED'] = False
 app.config['TESTING'] = True
+# Tests run over plain HTTP; the app's production default is a Secure cookie.
+app.config['SESSION_COOKIE_SECURE'] = False
 
 @pytest.fixture(autouse=True)
 def app_context():

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -896,6 +896,30 @@ def test_logout_redirect():
     assert response.status_code == 302
     assert response.headers["Location"] == "/"
 
+def test_session_cookie_security_config_defaults():
+    """Session cookie hardening flags should be configured by default."""
+    from config import Config
+    assert Config.SESSION_COOKIE_SECURE is True
+    assert Config.SESSION_COOKIE_SAMESITE == "Lax"
+    assert Config.SESSION_COOKIE_HTTPONLY is True
+    assert Config.PERMANENT_SESSION_LIFETIME.days == 7
+
+def test_session_cookie_security_flags():
+    """Session cookie should be marked Secure, HttpOnly and SameSite=Lax."""
+    previous = app.config.get("SESSION_COOKIE_SECURE")
+    app.config["SESSION_COOKIE_SECURE"] = True
+    try:
+        client = get_client()
+        with client.session_transaction() as sess:
+            sess["user_id"] = 1
+        response = client.get("/auth/logout", base_url="https://localhost")
+        set_cookie = response.headers.get("Set-Cookie", "")
+        assert "Secure" in set_cookie
+        assert "HttpOnly" in set_cookie
+        assert "SameSite=Lax" in set_cookie
+    finally:
+        app.config["SESSION_COOKIE_SECURE"] = previous
+
 def test_profile_unauthenticated_redirects_to_login():
     """Profile route should redirect to login if unauthenticated."""
     client = get_client()


### PR DESCRIPTION
## Problem
The session cookie carries `user_id` and the live GitHub OAuth token (`session['github_token']`), but no cookie hardening flags are set. Flask's default `SESSION_COOKIE_SECURE=False` sends the cookie (and the OAuth token inside it) over plain HTTP, and there is no `SameSite`, `HttpOnly`, or session lifetime configured.

## Fix
- `src/config.py`: add `SESSION_COOKIE_SECURE` (env-configurable, defaults to `true`), `SESSION_COOKIE_SAMESITE="Lax"`, `SESSION_COOKIE_HTTPONLY=True`, and `PERMANENT_SESSION_LIFETIME=timedelta(days=7)`.
- `src/routes/auth_routes.py` and `src/routes/github_routes.py`: mark the session permanent after a successful GitHub login so `PERMANENT_SESSION_LIFETIME` applies.
- `tests/conftest.py`: disable `SESSION_COOKIE_SECURE` for the plain-HTTP test client so existing tests keep working.
- `tests/test_basic.py`: add tests asserting the cookie is `Secure`, `HttpOnly` and `SameSite=Lax`, plus tests for the config defaults.

## Files changed
- `src/config.py`
- `src/routes/auth_routes.py`
- `src/routes/github_routes.py`
- `tests/conftest.py`
- `tests/test_basic.py`

## Testing
- `py -m pytest tests/ -q` → 523 passed, 19 pre-existing unrelated failures (identical to baseline), 3 skipped.
- New `test_session_cookie_security_flags` verifies the `Set-Cookie` header contains `Secure`, `HttpOnly` and `SameSite=Lax`.

Closes #1852
