### PR TITLE
fix: require authentication for skill-progression and code-review APIs (#1832)

### DIFF
--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -36,6 +36,11 @@ from models import db, ProjectProgress, UserGameProgress
 _skill_validator = SkillProgressionValidator()
 _code_review_manager = CodeReviewManager()
 
+
+def _authenticated_user_id():
+    """Return the logged-in user id, or None for anonymous requests."""
+    return session.get("user_id")
+
 # Interest categories that currently have no project recommendations available
 NO_PROJECT_INTERESTS = {
     "machine learning/ai",
@@ -551,18 +556,21 @@ def search_projects():
 @main.route("/api/skill-progression/validate", methods=["POST"])
 def validate_skill():
     """Validate if user can learn a skill at target difficulty level."""
+    user_id = _authenticated_user_id()
+    if not user_id:
+        return jsonify({"error": "Unauthorized"}), 401
+
     payload = request.get_json(silent=True)
 
     if not payload:
         return jsonify({"error": "Request body must be valid JSON."}), 400
 
-    user_id = (payload.get("user_id") or "").strip()
     skill_name = (payload.get("skill") or "").strip()
     target_difficulty = (payload.get("difficulty") or "").strip()
 
-    if not user_id or not skill_name or not target_difficulty:
+    if not skill_name or not target_difficulty:
         return jsonify({
-            "error": "user_id, skill, and difficulty are required"
+            "error": "skill and difficulty are required"
         }), 400
 
     result = validate_skill_progression(
@@ -578,19 +586,22 @@ def validate_skill():
 @main.route("/api/skill-progression/record", methods=["POST"])
 def record_skill_completion():
     """Record user completion of a skill at given difficulty level."""
+    user_id = _authenticated_user_id()
+    if not user_id:
+        return jsonify({"error": "Unauthorized"}), 401
+
     payload = request.get_json(silent=True)
 
     if not payload:
         return jsonify({"error": "Request body must be valid JSON."}), 400
 
-    user_id = (payload.get("user_id") or "").strip()
     skill_name = (payload.get("skill") or "").strip()
     difficulty = (payload.get("difficulty") or "").strip()
     assessment_score = payload.get("assessment_score")
 
-    if not user_id or not skill_name or not difficulty:
+    if not skill_name or not difficulty:
         return jsonify({
-            "error": "user_id, skill, and difficulty are required"
+            "error": "skill and difficulty are required"
         }), 400
 
     try:
@@ -629,10 +640,17 @@ def record_skill_completion():
 @main.route("/api/skill-progression/user/<user_id>")
 def get_user_progression(user_id):
     """Get skill progression data for a user."""
+    authenticated_user_id = _authenticated_user_id()
+    if not authenticated_user_id:
+        return jsonify({"error": "Unauthorized"}), 401
+
     user_id = user_id.strip()
 
     if not user_id:
         return jsonify({"error": "user_id is required"}), 400
+
+    if str(authenticated_user_id) != user_id:
+        return jsonify({"error": "Forbidden"}), 403
 
     skills = _skill_validator.get_user_skills(user_id)
     proficiency = _skill_validator.calculate_overall_proficiency(user_id)
@@ -647,11 +665,18 @@ def get_user_progression(user_id):
 @main.route("/api/skill-progression/next/<user_id>/<skill>")
 def get_next_skill(user_id, skill):
     """Get recommended next skill level for user to pursue."""
+    authenticated_user_id = _authenticated_user_id()
+    if not authenticated_user_id:
+        return jsonify({"error": "Unauthorized"}), 401
+
     user_id = user_id.strip()
     skill = skill.strip()
 
     if not user_id or not skill:
         return jsonify({"error": "user_id and skill are required"}), 400
+
+    if str(authenticated_user_id) != user_id:
+        return jsonify({"error": "Forbidden"}), 403
 
     next_skill = _skill_validator.get_recommended_next_skill(user_id, skill)
 
@@ -676,21 +701,28 @@ def get_next_skill(user_id, skill):
 @main.route("/api/code-review/submit", methods=["POST"])
 def submit_code_for_review():
     """Submit code for expert review."""
+    user_id = _authenticated_user_id()
+    if not user_id:
+        return jsonify({"error": "Unauthorized"}), 401
+
     payload = request.get_json(silent=True)
 
     if not payload:
         return jsonify({"error": "Request body must be valid JSON."}), 400
 
+    requested_user_id = (payload.get("user_id") or "").strip()
+    if requested_user_id and str(user_id) != requested_user_id:
+        return jsonify({"error": "Forbidden"}), 403
+
     submission_id = (payload.get("submission_id") or "").strip()
-    user_id = (payload.get("user_id") or "").strip()
     project_id = payload.get("project_id")
     code = (payload.get("code") or "").strip()
     language = (payload.get("language") or "").strip()
     description = (payload.get("description") or "").strip()
 
-    if not all([submission_id, user_id, project_id, code, language]):
+    if not all([submission_id, project_id, code, language]):
         return jsonify({
-            "error": "submission_id, user_id, project_id, code, and language are required"
+            "error": "submission_id, project_id, code, and language are required"
         }), 400
 
     try:
@@ -713,6 +745,9 @@ def submit_code_for_review():
 @main.route("/api/code-review/submission/<submission_id>")
 def get_submission(submission_id):
     """Get submission details."""
+    if not _authenticated_user_id():
+        return jsonify({"error": "Unauthorized"}), 401
+
     submission_id = submission_id.strip()
 
     submission = _code_review_manager.get_submission(submission_id)
@@ -728,7 +763,14 @@ def get_submission(submission_id):
 @main.route("/api/code-review/user/<user_id>/submissions")
 def get_user_code_submissions(user_id):
     """Get all code submissions from a user."""
+    authenticated_user_id = _authenticated_user_id()
+    if not authenticated_user_id:
+        return jsonify({"error": "Unauthorized"}), 401
+
     user_id = user_id.strip()
+
+    if str(authenticated_user_id) != user_id:
+        return jsonify({"error": "Forbidden"}), 403
 
     submissions = _code_review_manager.get_user_submissions(user_id)
     return jsonify({
@@ -741,6 +783,9 @@ def get_user_code_submissions(user_id):
 @main.route("/api/code-review/project/<int:project_id>/submissions")
 def get_project_code_submissions(project_id):
     """Get all code submissions for a project."""
+    if not _authenticated_user_id():
+        return jsonify({"error": "Unauthorized"}), 401
+
     submissions = _code_review_manager.get_project_submissions(project_id)
     return jsonify({
         "project_id": project_id,
@@ -752,6 +797,9 @@ def get_project_code_submissions(project_id):
 @main.route("/api/code-review/start", methods=["POST"])
 def start_code_review():
     """Start a code review session."""
+    if not _authenticated_user_id():
+        return jsonify({"error": "Unauthorized"}), 401
+
     payload = request.get_json(silent=True)
 
     if not payload:
@@ -781,6 +829,9 @@ def start_code_review():
 @main.route("/api/code-review/<review_id>/comment", methods=["POST"])
 def add_review_comment(review_id):
     """Add feedback comment to a review."""
+    if not _authenticated_user_id():
+        return jsonify({"error": "Unauthorized"}), 401
+
     payload = request.get_json(silent=True)
 
     if not payload:
@@ -815,6 +866,9 @@ def add_review_comment(review_id):
 @main.route("/api/code-review/<review_id>/score", methods=["POST"])
 def score_review_category(review_id):
     """Score a code quality category in a review."""
+    if not _authenticated_user_id():
+        return jsonify({"error": "Unauthorized"}), 401
+
     payload = request.get_json(silent=True)
 
     if not payload:
@@ -848,6 +902,9 @@ def score_review_category(review_id):
 @main.route("/api/code-review/<review_id>/complete", methods=["POST"])
 def complete_code_review(review_id):
     """Complete a code review."""
+    if not _authenticated_user_id():
+        return jsonify({"error": "Unauthorized"}), 401
+
     payload = request.get_json(silent=True)
 
     if not payload:
@@ -876,6 +933,9 @@ def complete_code_review(review_id):
 @main.route("/api/code-review/<review_id>/comments")
 def get_review_feedback(review_id):
     """Get all feedback comments for a review."""
+    if not _authenticated_user_id():
+        return jsonify({"error": "Unauthorized"}), 401
+
     review_id = review_id.strip()
 
     comments = _code_review_manager.get_review_comments(review_id)
@@ -889,6 +949,9 @@ def get_review_feedback(review_id):
 @main.route("/api/code-review/submission/<submission_id>/quality")
 def get_code_quality_score(submission_id):
     """Get code quality score for a submission."""
+    if not _authenticated_user_id():
+        return jsonify({"error": "Unauthorized"}), 401
+
     submission_id = submission_id.strip()
 
     score_data = _code_review_manager.get_code_quality_score(submission_id)
@@ -898,6 +961,9 @@ def get_code_quality_score(submission_id):
 @main.route("/api/code-review/submission/<submission_id>/recommendations")
 def get_code_recommendations(submission_id):
     """Get improvement recommendations for a submission."""
+    if not _authenticated_user_id():
+        return jsonify({"error": "Unauthorized"}), 401
+
     submission_id = submission_id.strip()
 
     recommendations = _code_review_manager.get_improvement_recommendations(

--- a/tests/test_api_auth_required.py
+++ b/tests/test_api_auth_required.py
@@ -1,0 +1,95 @@
+# tests/test_api_auth_required.py
+# Tests for issue #1832: skill-progression and code-review APIs must require
+# authentication, and user-scoped endpoints must not leak other users' data.
+
+import pytest
+
+
+@pytest.fixture
+def client():
+    from app import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def _login(client, user_id="u1832"):
+    with client.session_transaction() as sess:
+        sess["user_id"] = user_id
+
+
+SKILL_ENDPOINTS = [
+    ("POST", "/api/skill-progression/validate"),
+    ("POST", "/api/skill-progression/record"),
+    ("GET", "/api/skill-progression/user/someuser"),
+    ("GET", "/api/skill-progression/next/someuser/Python"),
+]
+
+CODE_REVIEW_ENDPOINTS = [
+    ("POST", "/api/code-review/submit"),
+    ("GET", "/api/code-review/submission/somesub"),
+    ("GET", "/api/code-review/user/someuser/submissions"),
+    ("GET", "/api/code-review/project/1/submissions"),
+    ("POST", "/api/code-review/start"),
+    ("POST", "/api/code-review/somerev/comment"),
+    ("POST", "/api/code-review/somerev/score"),
+    ("POST", "/api/code-review/somerev/complete"),
+    ("GET", "/api/code-review/somerev/comments"),
+    ("GET", "/api/code-review/submission/somesub/quality"),
+    ("GET", "/api/code-review/submission/somesub/recommendations"),
+]
+
+
+@pytest.mark.parametrize("method,path", SKILL_ENDPOINTS + CODE_REVIEW_ENDPOINTS)
+def test_endpoint_requires_auth(client, method, path):
+    """Anonymous requests must be rejected with 401."""
+    resp = getattr(client, method.lower())(path)
+    assert resp.status_code == 401
+    assert resp.get_json()["error"] == "Unauthorized"
+
+
+def test_validate_skill_works_when_authenticated(client):
+    _login(client)
+    resp = client.post("/api/skill-progression/validate", json={
+        "skill": "Python",
+        "difficulty": "beginner",
+    })
+    assert resp.status_code == 200
+    assert resp.get_json()["allowed"] is True
+
+
+def test_record_skill_passes_auth_when_authenticated(client):
+    """The endpoint must accept an authenticated user (it still 500s on a
+    pre-existing SkillDifficulty JSON-serialization bug, unrelated to #1832)."""
+    _login(client)
+    resp = client.post("/api/skill-progression/record", json={
+        "skill": "Python",
+        "difficulty": "beginner",
+    })
+    assert resp.status_code != 401
+
+
+def test_user_progression_rejects_other_users(client):
+    _login(client)
+    resp = client.get("/api/skill-progression/user/otheruser")
+    assert resp.status_code == 403
+
+
+def test_user_progression_passes_auth_for_own_user(client):
+    """Own-user access passes the auth gate (still hits the pre-existing
+    SkillDifficulty serialization bug, unrelated to #1832)."""
+    _login(client)
+    resp = client.get("/api/skill-progression/user/u1832")
+    assert resp.status_code != 401
+
+
+def test_code_submit_rejects_other_users(client):
+    _login(client)
+    resp = client.post("/api/code-review/submit", json={
+        "submission_id": "sub1",
+        "user_id": "otheruser",
+        "project_id": 1,
+        "code": "print('hi')",
+        "language": "python",
+    })
+    assert resp.status_code == 403


### PR DESCRIPTION
## Problem

All skill-progression and code-review API endpoints accepted a `user_id` from the client (JSON body or URL) with **no authentication check**. Any anonymous caller could read or write any user's skill progression and code-review data, and could impersonate another user by supplying their `user_id`.

## Fix

Every `/api/skill-progression/*` and `/api/code-review/*` endpoint now:
- Requires an authenticated session (`session.get("user_id")`), returning `401 {"error": "Unauthorized"}` otherwise.
- For user-scoped endpoints, the acting user must match the requested `user_id` (from JSON body or URL), returning `403 {"error": "Forbidden"}` on mismatch — closing cross-user data access.

`validate_skill` and `record_skill_completion` now derive the user from the session instead of trusting a client-supplied `user_id`.

## Files changed

- `src/routes/main_routes.py`
- `tests/test_api_auth_required.py` (new tests)

## Testing

```
python -m pytest tests/test_api_auth_required.py -q
```

- 20 tests pass: every skill-progression and code-review endpoint returns 401 for anonymous requests, user-scoped endpoints reject other users with 403, and authenticated requests pass the auth gate.
- Full suite (excluding pre-existing unrelated failures in the URL/starter-code validators and `test_basic.py`): 381 passed.

Note: `record_skill_completion` and `get_user_progression` still 500 on a pre-existing `SkillDifficulty` JSON-serialization bug after auth passes — that bug is unrelated to #1832 and is not touched here.

Closes #1832
