### PR TITLE
fix: store SkillDifficulty as serializable name in skill progression records

### DIFF
--- a/src/utils/skill_progression.py
+++ b/src/utils/skill_progression.py
@@ -38,6 +38,22 @@ class SkillDifficulty(Enum):
         return self.value >= other.value
 
 
+def _to_skill_difficulty(value) -> Optional[SkillDifficulty]:
+    """Coerce a stored difficulty (name string or enum) back to an enum.
+
+    Stored difficulty values are kept as ``difficulty.name`` strings so the
+    records are JSON-serializable; comparisons still need the enum.
+    """
+    if value is None:
+        return None
+    if isinstance(value, SkillDifficulty):
+        return value
+    try:
+        return SkillDifficulty[value]
+    except (KeyError, TypeError):
+        return None
+
+
 SKILL_PREREQUISITES = {
     "JavaScript": {
         SkillDifficulty.BEGINNER: [],
@@ -147,7 +163,9 @@ class SkillProgressionValidator:
                     f"Missing prerequisite: {prereq_skill} at {prereq_difficulty.name} level",
                 )
 
-            user_level = user_skills[prereq_skill].get("difficulty")
+            user_level = _to_skill_difficulty(
+                user_skills[prereq_skill].get("difficulty")
+            )
             if user_level is None or user_level < prereq_difficulty:
                 return (
                     False,
@@ -193,7 +211,7 @@ class SkillProgressionValidator:
             }
 
         skill_data = self.user_skills[user_id][skill_name]
-        skill_data["difficulty"] = difficulty
+        skill_data["difficulty"] = difficulty.name
         skill_data["completed_at"] = datetime.now(timezone.utc).isoformat()
         skill_data["assessment_score"] = assessment_score
         skill_data["progression_history"].append(
@@ -226,7 +244,9 @@ class SkillProgressionValidator:
         if skill_name not in user_skills:
             return None
 
-        current_difficulty = user_skills[skill_name].get("difficulty")
+        current_difficulty = _to_skill_difficulty(
+            user_skills[skill_name].get("difficulty")
+        )
         if current_difficulty is None:
             return None
 
@@ -267,7 +287,7 @@ class SkillProgressionValidator:
 
         levels_distribution = {}
         for skill, data in user_skills.items():
-            difficulty = data.get("difficulty")
+            difficulty = _to_skill_difficulty(data.get("difficulty"))
             if difficulty:
                 level_name = difficulty.name
                 levels_distribution[level_name] = (

--- a/tests/test_skill_progression.py
+++ b/tests/test_skill_progression.py
@@ -115,10 +115,26 @@ class TestSkillProgressionValidator:
             assessment_score=88.5
         )
 
-        assert skill_data["difficulty"] == SkillDifficulty.BEGINNER
+        assert skill_data["difficulty"] == SkillDifficulty.BEGINNER.name
         assert skill_data["assessment_score"] == 88.5
         assert skill_data["completed_at"] is not None
         assert len(skill_data["progression_history"]) == 1
+
+    def test_record_skill_completion_json_serializable(self, validator):
+        """Recorded skill data must be JSON-serializable (no raw enums)."""
+        import json
+
+        user_id = "user123"
+
+        skill_data = validator.record_skill_completion(
+            user_id,
+            "Python",
+            SkillDifficulty.BEGINNER,
+            assessment_score=88.5
+        )
+
+        encoded = json.dumps(skill_data)
+        assert '"difficulty": "BEGINNER"' in encoded
 
     def test_get_user_skills(self, validator):
         """Test retrieving user's completed skills."""


### PR DESCRIPTION
## Problem

`POST /api/skill-progression/record` and `GET /api/skill-progression/user/<user_id>` 500 with `TypeError: Object of type SkillDifficulty is not JSON serializable`. `record_skill_completion` stores the raw `SkillDifficulty` enum member in `skill_data["difficulty"]`, and the routes hand that dict to `jsonify` / `json.dumps`, which cannot serialize a plain `Enum`.

## Fix

- Store `difficulty.name` (a string) in the skill record, matching what `progression_history` already stores, so the whole record is JSON-serializable.
- Coerce stored values back to the `SkillDifficulty` enum (via a new `_to_skill_difficulty` helper) in the internal logic that needs enum comparison/property access: `can_learn_skill`, `get_recommended_next_skill`, and `calculate_overall_proficiency`.
- Updated the test that asserted the old enum-storage behavior and added a regression test asserting `json.dumps(skill_data)` succeeds after `record_skill_completion`.

## Files changed

- `src/utils/skill_progression.py`
- `tests/test_skill_progression.py`

## Testing

- `pytest tests/test_skill_progression.py` — 19 passed.
- Manually verified `json.dumps` on a recorded skill record and that prerequisite checks, next-skill recommendation, and proficiency calculation still work.

Closes #1868
