### PR TITLE
fix: make seed_db idempotent and require explicit --reset to drop tables (#1856)

### DIFF
--- a/src/seed_db.py
+++ b/src/seed_db.py
@@ -1,48 +1,69 @@
 import json
 import os
+import sys
 from app import app
 from models import db, Project
+from utils.data_loader import validate_projects
 
-def seed_database():
+def seed_database(reset=False):
+    """Seed the project catalog from data/projects.json.
+
+    Idempotent by default: it upserts projects by id (matching the app.py
+    auto-seed behavior) and never drops tables, so existing user data,
+    progress and admin flags are preserved. Pass ``reset=True`` to drop all
+    tables first — this is destructive.
+    """
     with app.app_context():
-        # Create all tables
-        db.drop_all()
         db.create_all()
 
         # Path to projects.json
         data_file = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data", "projects.json")
-        
+
         if not os.path.exists(data_file):
             print(f"Error: Could not find {data_file}")
             return
-            
+
         print(f"Loading data from {data_file}...")
-        
+
         with open(data_file, "r", encoding="utf-8") as f:
             projects_data = json.load(f)
-            
-        print(f"Found {len(projects_data)} projects. Inserting into database...")
-        
+
+        validate_projects(projects_data)
+
+        if reset:
+            db.drop_all()
+            db.create_all()
+
+        print(f"Found {len(projects_data)} projects. Upserting into database...")
+
         for p_data in projects_data:
-            # We enforce JSON arrays for features, skills, etc
-            project = Project(
-                id=p_data.get("id"),
-                title=p_data.get("title", ""),
-                level=p_data.get("level", "Beginner"),
-                interest=p_data.get("interest", ""),
-                time=p_data.get("time", "Low"),
-                description=p_data.get("description", ""),
-                skills=p_data.get("skills", []),
-                features=p_data.get("features", []),
-                tech_stack=p_data.get("tech_stack", []),
-                roadmap=p_data.get("roadmap", []),
-                resources=p_data.get("resources", []),
-                starter_code=p_data.get("starter_code")
-            )
-            db.session.add(project)
-            
+            project = db.session.get(Project, p_data.get("id"))
+            if project is None:
+                project = Project(id=p_data.get("id"))
+                db.session.add(project)
+            project.title = p_data.get("title", "")
+            project.level = p_data.get("level", "Beginner")
+            project.interest = p_data.get("interest", "")
+            project.time = p_data.get("time", "Low")
+            project.description = p_data.get("description", "")
+            project.skills = p_data.get("skills", [])
+            project.features = p_data.get("features", [])
+            project.tech_stack = p_data.get("tech_stack", [])
+            project.roadmap = p_data.get("roadmap", [])
+            project.resources = p_data.get("resources", [])
+            project.starter_code = p_data.get("starter_code")
+
         db.session.commit()
         print("Successfully seeded the database!")
 
 if __name__ == "__main__":
-    seed_database()
+    reset = "--reset" in sys.argv[1:]
+    if reset:
+        confirm = input(
+            "WARNING: --reset will DROP ALL TABLES and destroy all user data. "
+            "Type 'yes' to continue: "
+        )
+        if confirm.strip().lower() != "yes":
+            print("Aborted.")
+            sys.exit(0)
+    seed_database(reset=reset)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -116,6 +116,28 @@ def test_projects_json_loads():
     assert len(projects) > 0
 
 
+def test_seed_database_is_idempotent_and_preserves_users():
+    """Seeding must upsert projects without dropping user data."""
+    with app.app_context():
+        from models import db, User
+        db.session.add(User(id=99, github_id="seed-test-user", username="seeduser"))
+        db.session.commit()
+    from seed_db import seed_database
+    seed_database()
+    with app.app_context():
+        from models import db, Project, User
+        assert db.session.get(User, 99) is not None
+        data_file = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "data",
+            "projects.json",
+        )
+        with open(data_file, "r", encoding="utf-8") as f:
+            import json
+            expected_count = len(json.load(f))
+        assert Project.query.count() == expected_count
+
+
 def test_find_project_by_id():
     project = find_project_by_id(1)
     assert project is not None


### PR DESCRIPTION
## Problem
`src/seed_db.py` starts with an unconditional `db.drop_all()`, wiping every table — users, saved progress, game progress and admin flags — every time the documented seeding script is run on an existing database. It also inserts without the project validation that the data loader relies on.

## Fix
- `src/seed_db.py`: replace `db.drop_all()` with an idempotent upsert — `db.create_all()` then update-or-insert each project by id (matching the app.py auto-seed behavior) — so running the seed script no longer destroys user data.
- The destructive path is now guarded behind an explicit `--reset` flag with a confirmation prompt.
- The dataset is validated with `validate_projects()` before any writes, and the whole upsert is committed in one transaction.
- `tests/test_basic.py`: add `test_seed_database_is_idempotent_and_preserves_users` verifying a user survives re-seeding and the project count stays correct.

## Files changed
- `src/seed_db.py`
- `tests/test_basic.py`

## Testing
- `py -m pytest tests/ -q` → 522 passed, 19 pre-existing unrelated failures (identical to baseline), 3 skipped.
- New test confirms seeding preserves existing user rows.

Closes #1856
