### PR TITLE
feat: rank leaderboard from real UserGameProgress data instead of hardcoded entries (#1834)

### DIFF
--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -1114,6 +1114,28 @@ def save_user_game_progress():
     db.session.commit()
     return jsonify({"message": "Progress saved successfully"}), 200
 
+
+@main.route("/api/leaderboard", methods=["GET"])
+def leaderboard():
+    """Return the top users ranked by gamified progress points."""
+    if not session.get("user_id"):
+        return jsonify({"error": "Unauthorized"}), 401
+
+    entries = []
+    for record in UserGameProgress.query.all():
+        points = record.data.get("points", 0) if isinstance(record.data, dict) else 0
+        try:
+            points = int(points)
+        except (TypeError, ValueError):
+            points = 0
+        name = record.user.username if record.user else f"user-{record.user_id}"
+        entries.append({"name": name, "points": points})
+
+    entries.sort(key=lambda e: e["points"], reverse=True)
+
+    return jsonify({"leaderboard": entries[:10]}), 200
+
+
 @main.route("/api/portfolio-analysis", methods=["POST"])
 def portfolio_analysis():
     """

--- a/src/static/script.js
+++ b/src/static/script.js
@@ -339,6 +339,16 @@ function projectIsCompleted(projectId) {
   });
 }
 
+function renderLeaderboardList(listEl, entries) {
+  if (!entries.length) {
+    listEl.innerHTML = '<li class="leaderboard-empty">Complete projects to see rankings</li>';
+    return;
+  }
+  listEl.innerHTML = entries.map(function (entry, index) {
+    return "<li><span>" + (index + 1) + ". " + entry.name + "</span><strong>" + entry.points + " pts</strong></li>";
+  }).join("");
+}
+
 function updateProfileWidgets() {
   var pointsEl = document.getElementById("progress-points");
   var statsEl = document.getElementById("progress-stats");
@@ -387,15 +397,17 @@ function updateProfileWidgets() {
       : "<li class=\"achievement-empty\">No achievements yet. Use DevPath and unlock the first badge.</li>";
   }
   if (leaderboardList) {
-    var entries = [
-      { name: "Ava", points: 245 },
-      { name: "Kai", points: 192 },
-      { name: "Sam", points: 176 },
-      { name: "You", points: progress.points }
-    ].sort(function (a, b) { return b.points - a.points; });
-    leaderboardList.innerHTML = entries.map(function (entry, index) {
-      return "<li><span>" + (index + 1) + ". " + entry.name + "</span><strong>" + entry.points + " pts</strong></li>";
-    }).join("");
+    fetch("/api/leaderboard")
+      .then(function (r) {
+        if (!r.ok) throw new Error("Leaderboard unavailable");
+        return r.json();
+      })
+      .then(function (data) {
+        renderLeaderboardList(leaderboardList, data.leaderboard || []);
+      })
+      .catch(function () {
+        renderLeaderboardList(leaderboardList, [{ name: "You", points: progress.points }]);
+      });
   }
   if (historyList) {
     historyList.innerHTML = progress.completedProjects.length

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -1,0 +1,74 @@
+# tests/test_leaderboard.py
+# Tests for issue #1834: the leaderboard is ranked from real UserGameProgress
+# data instead of hardcoded placeholder entries.
+
+import pytest
+
+
+@pytest.fixture
+def client():
+    from app import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def _add_user(username, github_id, points):
+    from models import db, User, UserGameProgress
+    user = User(github_id=github_id, username=username)
+    db.session.add(user)
+    db.session.flush()
+    progress = UserGameProgress(user_id=user.id, data={"points": points})
+    db.session.add(progress)
+    db.session.commit()
+    return user
+
+
+def test_leaderboard_requires_auth(client):
+    resp = client.get("/api/leaderboard")
+    assert resp.status_code == 401
+
+
+def test_leaderboard_returns_top_users_by_points(client):
+    _add_user("Alice", "gh-alice", 300)
+    _add_user("Bob", "gh-bob", 150)
+    _add_user("Carol", "gh-carol", 450)
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = 1
+
+    resp = client.get("/api/leaderboard")
+    assert resp.status_code == 200
+    entries = resp.get_json()["leaderboard"]
+    assert [entry["name"] for entry in entries] == ["Carol", "Alice", "Bob"]
+    assert entries[0]["points"] == 450
+
+
+def test_leaderboard_limits_to_top_ten(client):
+    for i in range(12):
+        _add_user(f"User{i}", f"gh-user{i}", i * 10)
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = 1
+
+    resp = client.get("/api/leaderboard")
+    entries = resp.get_json()["leaderboard"]
+    assert len(entries) == 10
+    assert entries[0]["name"] == "User11"
+
+
+def test_leaderboard_handles_missing_points(client):
+    from models import db, User, UserGameProgress
+    user = User(github_id="gh-novalue", username="NoValue")
+    db.session.add(user)
+    db.session.flush()
+    progress = UserGameProgress(user_id=user.id, data={})
+    db.session.add(progress)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = user.id
+
+    resp = client.get("/api/leaderboard")
+    assert resp.status_code == 200
+    assert resp.get_json()["leaderboard"] == [{"name": "NoValue", "points": 0}]


### PR DESCRIPTION
## Problem

The profile/achievements leaderboard widget was populated with hardcoded placeholder entries:

```js
{ name: "Ava", points: 245 },
{ name: "Kai", points: 192 },
{ name: "Sam", points: 176 },
{ name: "You", points: progress.points }
```

Meanwhile the app already persists real gamified progress per user in `UserGameProgress.data` (via `POST /api/user-progress`), which was never used for the leaderboard.

## Fix

- Added `GET /api/leaderboard`, which ranks all users by the `points` stored in their `UserGameProgress.data` (joined with the `User` for the display name), returns the top 10, and requires authentication (401 otherwise).
- `updateProfileWidgets()` in `script.js` now fetches `/api/leaderboard` and renders the real rankings. If the fetch fails, it falls back to a single "You" entry with the local `progress.points`, preserving the old widget behavior offline.

## Files changed

- `src/routes/main_routes.py`
- `src/static/script.js`
- `tests/test_leaderboard.py` (new tests)

## Testing

```
python -m pytest tests/test_leaderboard.py -q
```

Tests cover: 401 for anonymous requests, correct descending order by points, top-10 limit, and users whose stored data has no `points` (treated as 0). Full suite (excluding pre-existing unrelated failures): 365 passed.

Closes #1834
