### PR TITLE
fix: enforce prerequisites and prevent difficulty downgrades on skill progression record

### DIFF
--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -598,6 +598,18 @@ def record_skill_completion():
     except KeyError:
         return jsonify({"error": f"Invalid difficulty: {difficulty}"}), 400
 
+    # Enforce the prerequisite graph before recording: a user must not claim
+    # a level without completing its required baseline skills first.
+    allowed, error_msg = _skill_validator.can_learn_skill(
+        user_id,
+        skill_name,
+        diff_enum,
+    )
+    if not allowed:
+        return jsonify({
+            "error": error_msg or "Skill prerequisites not met"
+        }), 400
+
     if assessment_score is not None:
         try:
             assessment_score = float(assessment_score)
@@ -617,12 +629,20 @@ def record_skill_completion():
         assessment_score
     )
 
+    # The difficulty is stored internally as a SkillDifficulty enum (so
+    # prerequisite comparisons stay meaningful); expose it by name so the
+    # response is JSON-serializable and reflects any preserved higher level.
+    response_skill_data = dict(skill_data)
+    stored_difficulty = skill_data.get("difficulty")
+    if isinstance(stored_difficulty, SkillDifficulty):
+        response_skill_data["difficulty"] = stored_difficulty.name
+
     return jsonify({
         "success": True,
         "user_id": user_id,
         "skill": skill_name,
         "difficulty": difficulty,
-        "skill_data": skill_data
+        "skill_data": response_skill_data
     }), 201
 
 

--- a/src/utils/skill_progression.py
+++ b/src/utils/skill_progression.py
@@ -193,6 +193,13 @@ class SkillProgressionValidator:
             }
 
         skill_data = self.user_skills[user_id][skill_name]
+
+        # Preserve the higher existing difficulty: a lower re-record must not
+        # silently destroy previously earned progress.
+        existing_difficulty = skill_data.get("difficulty")
+        if existing_difficulty is not None and existing_difficulty > difficulty:
+            difficulty = existing_difficulty
+
         skill_data["difficulty"] = difficulty
         skill_data["completed_at"] = datetime.now(timezone.utc).isoformat()
         skill_data["assessment_score"] = assessment_score

--- a/tests/test_skill_progression.py
+++ b/tests/test_skill_progression.py
@@ -120,6 +120,27 @@ class TestSkillProgressionValidator:
         assert skill_data["completed_at"] is not None
         assert len(skill_data["progression_history"]) == 1
 
+    def test_record_skill_completion_does_not_downgrade(self, validator):
+        """Re-recording at a lower difficulty must preserve the higher level."""
+        user_id = "user123"
+
+        validator.record_skill_completion(
+            user_id,
+            "Python",
+            SkillDifficulty.EXPERT,
+            assessment_score=90
+        )
+
+        skill_data = validator.record_skill_completion(
+            user_id,
+            "Python",
+            SkillDifficulty.BEGINNER,
+            assessment_score=60
+        )
+
+        assert skill_data["difficulty"] == SkillDifficulty.EXPERT
+        assert skill_data["assessment_score"] == 60
+
     def test_get_user_skills(self, validator):
         """Test retrieving user's completed skills."""
         user_id = "user123"

--- a/tests/test_skill_progression_routes.py
+++ b/tests/test_skill_progression_routes.py
@@ -1,0 +1,65 @@
+"""
+Route-level tests for the skill progression API.
+
+Run with:   python -m pytest tests/test_skill_progression_routes.py
+Or:         python tests/test_skill_progression_routes.py
+
+These tests exercise /api/skill-progression/record end-to-end, verifying
+that prerequisites are enforced and that difficulty never regresses.
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from app import app
+
+
+def get_client():
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    return app.test_client()
+
+
+def test_record_rejects_unmet_prerequisites():
+    """Claiming a level without its baseline prerequisites returns 400."""
+    client = get_client()
+    response = client.post("/api/skill-progression/record", json={
+        "user_id": "user-1869-prereq",
+        "skill": "React",
+        "difficulty": "ADVANCED",
+    })
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data["error"]
+
+
+def test_record_preserves_higher_difficulty_on_downgrade():
+    """Re-recording at a lower difficulty must not wipe earned progress."""
+    client = get_client()
+    user_id = "user-1869-downgrade"
+
+    for level in ("BEGINNER", "INTERMEDIATE", "ADVANCED", "EXPERT"):
+        response = client.post("/api/skill-progression/record", json={
+            "user_id": user_id,
+            "skill": "Python",
+            "difficulty": level,
+            "assessment_score": 90,
+        })
+        assert response.status_code == 201
+
+    downgrade = client.post("/api/skill-progression/record", json={
+        "user_id": user_id,
+        "skill": "Python",
+        "difficulty": "BEGINNER",
+        "assessment_score": 60,
+    })
+    assert downgrade.status_code == 201
+    assert downgrade.get_json()["skill_data"]["difficulty"] == "EXPERT"
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v", "--no-header"]))


### PR DESCRIPTION
## Problem

`POST /api/skill-progression/record` never validates prerequisites and never enforces difficulty monotonicity. A client can claim `Advanced` for `React` without any `JavaScript` baseline in a single request, or silently downgrade an existing `Expert` skill back to `Beginner`. The validation endpoint (`/validate`) exists but `record` never calls it, so #814 remains unfixed in practice.

## Fix

- Route the record request through `can_learn_skill(user_id, skill_name, difficulty)` before storing; when prerequisites are unmet, return `400` with the missing/incomplete prerequisite message.
- Preserve the higher existing difficulty when a lower one is re-submitted (`record_skill_completion` no longer unconditionally overwrites `skill_data["difficulty"]`), so progress can't be wiped or downgraded.
- The record response now exposes the stored difficulty by name, so a preserved higher level is visible to the client.
- Added route-level tests for prerequisite violation and for downgrade preservation (plus a unit test for the monotonic guard).

## Files changed

- `src/utils/skill_progression.py`
- `src/routes/main_routes.py`
- `tests/test_skill_progression.py`
- `tests/test_skill_progression_routes.py`

## Testing

- `pytest tests/test_skill_progression.py` — 19 passed (incl. new `test_record_skill_completion_does_not_downgrade`).
- Route behavior verified with a standalone Flask harness: claiming `React ADVANCED` without a JS baseline returns 400 with the prerequisite message; climbing the Python chain BEGINNER→EXPERT then re-recording BEGINNER returns 201 while keeping `difficulty = "EXPERT"`; invalid difficulty returns 400.
- Note: the route-level test file follows the repo's existing `client` test conventions; it runs once the app boots in CI (the app currently fails to import locally because of the unrelated pre-existing `portfolio_analyzer.py` `NameError: name 're'` tracked in #1810).

Closes #1869
