### PR TITLE
Emit data-project-interest on project detail page

### DIFF
--- a/src/templates/project.html
+++ b/src/templates/project.html
@@ -25,7 +25,7 @@
     rel="stylesheet" />
 </head>
 
-<body class="detail-page">
+<body class="detail-page" data-project-interest="{{ project.interest }}">
 
   <nav class="navbar" aria-label="Main navigation">
     <div class="nav-inner">


### PR DESCRIPTION
﻿## Problem

The "Recently Viewed" panel always shows a meaningless "General" chip because script.js looks for the data-project-interest attribute to record a project's interest, but project.html never emits it. The attribute query falls back to the hardcoded string "General".

## Fix

Add data-project-interest="{{ project.interest }}" to the <body> tag of src/templates/project.html. script.js reads document.querySelector("[data-project-interest]"), so the body element (the earliest node in the page) now provides the real interest from the project metadata.

## Files changed

- src/templates/project.html

## Testing

- GET /project/1 renders data-project-interest="Data" on the body tag (matching the dataset interest).
- Recently-viewed tracking in script.js now records the actual interest instead of "General".
- Full suite: 522 passed, 19 pre-existing unrelated failures, 3 skipped.

Closes #1859
