### PR TITLE
Fix profile.html stylesheet link and add theme partial

### DIFF
--- a/src/templates/profile.html
+++ b/src/templates/profile.html
@@ -13,9 +13,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <!-- Import Inter font -->
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+  {% include 'partials/theme_head.html' %}
 
   <!-- Link to central stylesheet -->
-  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
   
   <style>
     .profile-header {


### PR DESCRIPTION
﻿## Problem

profile.html links a stylesheet named styles.css, but src/static only contains style.css. The profile page (the page users land on after GitHub login) loads with no application CSS and renders unstyled. It also omits the theme_head.html partial that every other page includes, so theme initialization is missing.

## Fix

- Change the stylesheet link from styles.css to style.css.
- Add {% include 'partials/theme_head.html' %} in the head so profile.html gets the same theme initialization (data-theme attribute + dark-theme body class) as the rest of the site.

## Files changed

- src/templates/profile.html

## Testing

- profile.html now references style.css (exists at src/static/style.css); no styles.css reference remains.
- theme_head.html partial renders (initThemeInline script present in head).
- Full suite: 522 passed, 19 pre-existing unrelated failures, 3 skipped.

Closes #1860
