### PR TITLE
fix: apply technology stack filter in recommendations (issue #1870)

### DIFF
--- a/src/utils/recommender.py
+++ b/src/utils/recommender.py
@@ -662,6 +662,8 @@ def get_recommendations(
         for entry in skill_entries
     }
     all_projects = load_all_projects()
+    if tech_stack and tech_stack.lower() != "all":
+        all_projects = [p for p in all_projects if project_matches_tech(p, tech_stack)]
     # Load NLP model to determine if we should use semantic search
     model = get_nlp_model()
     

--- a/tests/test_recommender_tech_stack.py
+++ b/tests/test_recommender_tech_stack.py
@@ -1,0 +1,44 @@
+# tests/test_recommender_tech_stack.py
+# Regression test for issue #1870:
+# The technology stack filter must actually narrow the recommendations returned
+# by get_recommendations (project_matches_tech was defined but never called).
+
+from utils.recommender import get_recommendations, project_matches_tech
+
+
+def test_all_returns_everything():
+    """With tech_stack='all' the filter must not exclude any project."""
+    results = get_recommendations("Python", "Beginner", "Data", "Low", tech_stack="all")
+    assert len(results["recommendations"]) > 0
+
+
+def test_tech_stack_filter_changes_results():
+    """A non-'all' tech stack must produce a different recommendation set."""
+    base = get_recommendations("Python", "Beginner", "Data", "Low", tech_stack="all")
+    filtered = get_recommendations("Python", "Beginner", "Data", "Low", tech_stack="java")
+    base_ids = [p["id"] for p in base["recommendations"]]
+    filtered_ids = [p["id"] for p in filtered["recommendations"]]
+    assert filtered_ids != base_ids, (
+        "tech_stack filter had no effect (issue #1870)"
+    )
+
+
+def test_filtered_projects_actually_match_tech():
+    """Every project returned for a given tech_stack must match it."""
+    filtered = get_recommendations("Python", "Beginner", "Data", "Low", tech_stack="java")
+    assert filtered["recommendations"], "Expected at least one java project to match"
+    for project in filtered["recommendations"]:
+        assert project_matches_tech(project, "java"), (
+            f"Project {project.get('id')} does not match tech_stack='java' (issue #1870)"
+        )
+
+
+def test_filtered_results_are_subset_of_all():
+    """Filtered results must never include projects the 'all' query excludes."""
+    base = get_recommendations("Python", "Beginner", "Data", "Low", tech_stack="all")
+    filtered = get_recommendations("Python", "Beginner", "Data", "Low", tech_stack="flask")
+    base_ids = {p["id"] for p in base["recommendations"]}
+    for project in filtered["recommendations"]:
+        assert project["id"] in base_ids, (
+            f"Project {project.get('id')} returned by filter but absent from unfiltered query"
+        )


### PR DESCRIPTION
## Problem

The Technology Stack dropdown on the recommendation page has no effect: the same recommendations are returned regardless of the selected stack. `project_matches_tech` is defined in `src/utils/recommender.py` but is never called, so the filter added in #936 and previously working via #1285 was silently dropped when the recommender engine was restored.

## Fix

Apply `project_matches_tech` inside `get_recommendations`: when a non-`all` `tech_stack` is selected, filter the loaded projects before scoring, mirroring the original #936 implementation. Projects that do not match the selected stack are excluded from scoring, relevance, and final recommendations.

## Files changed

- `src/utils/recommender.py` — filter `all_projects` with `project_matches_tech` when `tech_stack` is not "all".
- `tests/test_recommender_tech_stack.py` — new regression tests asserting the filter changes the result set, all returned projects match the selected stack, and filtered results are a subset of the unfiltered query.

## Testing

- Isolated test run (seeded SQLite DB, app context): `tests/test_recommender_tech_stack.py` — 4 passed.
- Manual experiment against the real `projects.json` dataset confirmed the filter now narrows results correctly (e.g. `java` → 3 projects all matching, `flask` → 4 all matching, previously 30 unfiltered for every value).

Closes #1870
