### PR TITLE
Remove debug JS error overlay from index and explore

### DIFF
--- a/src/templates/explore.html
+++ b/src/templates/explore.html
@@ -7,35 +7,6 @@
   <meta name="description"
     content="DevPath recommends real coding projects based on your skills, level, and interests — with full roadmaps and starter code." />
   <title>DevPath — Find Projects Based On Your Skills</title>
-  
-  <script>
-    window.addEventListener('error', function(e) {
-      var errDiv = document.createElement('div');
-      errDiv.style.position = 'fixed';
-      errDiv.style.top = '0';
-      errDiv.style.left = '0';
-      errDiv.style.width = '100%';
-      errDiv.style.background = 'red';
-      errDiv.style.color = 'white';
-      errDiv.style.zIndex = '999999';
-      errDiv.style.padding = '20px';
-      errDiv.textContent = 'JS ERROR: ' + e.message + ' at ' + e.filename + ':' + e.lineno;
-      document.body.appendChild(errDiv);
-    });
-    window.addEventListener('unhandledrejection', function(e) {
-      var errDiv = document.createElement('div');
-      errDiv.style.position = 'fixed';
-      errDiv.style.top = '50px';
-      errDiv.style.left = '0';
-      errDiv.style.width = '100%';
-      errDiv.style.background = 'orange';
-      errDiv.style.color = 'white';
-      errDiv.style.zIndex = '999999';
-      errDiv.style.padding = '20px';
-      errDiv.textContent = 'PROMISE REJECTION: ' + (e.reason ? e.reason.message : e.reason);
-      document.body.appendChild(errDiv);
-    });
-  </script>
 
   <!-- Open Graph meta tags for social media sharing -->
   <meta property="og:title" content="DevPath — Find Projects Based On Your Skills" />

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -7,35 +7,6 @@
   <meta name="description"
     content="DevPath recommends real coding projects based on your skills, level, and interests — with full roadmaps and starter code." />
   <title>DevPath — Find Projects Based On Your Skills</title>
-  
-  <script>
-    window.addEventListener('error', function(e) {
-      var errDiv = document.createElement('div');
-      errDiv.style.position = 'fixed';
-      errDiv.style.top = '0';
-      errDiv.style.left = '0';
-      errDiv.style.width = '100%';
-      errDiv.style.background = 'red';
-      errDiv.style.color = 'white';
-      errDiv.style.zIndex = '999999';
-      errDiv.style.padding = '20px';
-      errDiv.textContent = 'JS ERROR: ' + e.message + ' at ' + e.filename + ':' + e.lineno;
-      document.body.appendChild(errDiv);
-    });
-    window.addEventListener('unhandledrejection', function(e) {
-      var errDiv = document.createElement('div');
-      errDiv.style.position = 'fixed';
-      errDiv.style.top = '50px';
-      errDiv.style.left = '0';
-      errDiv.style.width = '100%';
-      errDiv.style.background = 'orange';
-      errDiv.style.color = 'white';
-      errDiv.style.zIndex = '999999';
-      errDiv.style.padding = '20px';
-      errDiv.textContent = 'PROMISE REJECTION: ' + (e.reason ? e.reason.message : e.reason);
-      document.body.appendChild(errDiv);
-    });
-  </script>
 
   <!-- Open Graph meta tags for social media sharing -->
   <meta property="og:title" content="DevPath — Find Projects Based On Your Skills" />


### PR DESCRIPTION
﻿## Problem

index.html ships a debug JS error overlay in production: global 'error' and 'unhandledrejection' listeners paint a fixed red/orange banner with the raw JS message, filename, and line number for every visitor. Any transient client-side error permanently obscures the page and leaks internal script paths. The identical overlay also exists in explore.html.

## Fix

Remove the debug overlay <script> block from the <head> of both src/templates/index.html and src/templates/explore.html. No replacement is needed — errors are already visible in the browser console.

## Files changed

- src/templates/index.html
- src/templates/explore.html

## Testing

- GET / and GET /explore return 200; rendered HTML no longer contains the error/unhandledrejection overlay script.
- Full suite: 522 passed, 19 pre-existing unrelated failures, 3 skipped.

Closes #1862
