### PR TITLE
fix: reject duplicate code-review submission ids with 409 (issue #1871)

### DIFF
--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -23,7 +23,7 @@ from utils.skill_progression import (
     SkillDifficulty,
     validate_skill_progression,
 )
-from utils.code_review import CodeReviewManager
+from utils.code_review import CodeReviewManager, SubmissionAlreadyExistsError
 from config import Config
 from utils.portfolio_analyzer import analyze_portfolio
 import math
@@ -706,6 +706,8 @@ def submit_code_for_review():
             "success": True,
             "submission": submission
         }), 201
+    except SubmissionAlreadyExistsError as e:
+        return jsonify({"error": str(e)}), 409
     except Exception as e:
         return jsonify({"error": str(e)}), 400
 

--- a/src/utils/code_review.py
+++ b/src/utils/code_review.py
@@ -10,6 +10,10 @@ from enum import Enum
 from datetime import datetime, timezone
 
 
+class SubmissionAlreadyExistsError(Exception):
+    """Raised when a code submission re-uses an existing submission_id."""
+
+
 class ReviewStatus(Enum):
     """Status of a code review."""
     PENDING = "pending"
@@ -105,6 +109,11 @@ class CodeReviewManager:
             "review_count": 0,
             "metrics": {},
         }
+
+        if submission_id in self.submissions:
+            raise SubmissionAlreadyExistsError(
+                f"Submission {submission_id} already exists"
+            )
 
         self.submissions[submission_id] = submission
         return submission

--- a/tests/test_code_review.py
+++ b/tests/test_code_review.py
@@ -8,6 +8,7 @@ from src.utils.code_review import (
     ReviewStatus,
     CodeQualityCategory,
     FEEDBACK_TEMPLATES,
+    SubmissionAlreadyExistsError,
 )
 
 
@@ -36,6 +37,66 @@ class TestCodeReviewManager:
         assert submission["project_id"] == 1
         assert submission["review_status"] == ReviewStatus.PENDING.value
         assert submission["submitted_at"] is not None
+
+    def test_submit_code_rejects_duplicate_id(self, review_manager):
+        """Re-submitting an existing submission_id must be rejected (issue #1871)."""
+        review_manager.submit_code(
+            submission_id="sub_001",
+            user_id="user_123",
+            project_id=1,
+            code="print('hello')",
+            language="python",
+        )
+
+        with pytest.raises(SubmissionAlreadyExistsError):
+            review_manager.submit_code(
+                submission_id="sub_001",
+                user_id="user_456",
+                project_id=2,
+                code="print('overwrite')",
+                language="python",
+            )
+
+    def test_resubmission_does_not_clobber_review_progress(self, review_manager):
+        """A rejected re-submit must leave review_count and metrics intact (issue #1871)."""
+        review_manager.submit_code(
+            submission_id="sub_001",
+            user_id="user_123",
+            project_id=1,
+            code="print('hello')",
+            language="python",
+        )
+        review = review_manager.start_review(
+            submission_id="sub_001",
+            reviewer_id="reviewer_001",
+        )
+        review_manager.score_category(
+            review_id=review["review_id"],
+            category="functionality",
+            score=90,
+        )
+        review_manager.complete_review(
+            review_id=review["review_id"],
+            summary="Good work",
+        )
+
+        before = review_manager.get_submission("sub_001")
+        assert before["review_count"] == 1
+        assert before["metrics"]["overall_score"] == 90.0
+
+        with pytest.raises(SubmissionAlreadyExistsError):
+            review_manager.submit_code(
+                submission_id="sub_001",
+                user_id="user_123",
+                project_id=1,
+                code="print('overwrite')",
+                language="python",
+            )
+
+        after = review_manager.get_submission("sub_001")
+        assert after["review_count"] == before["review_count"]
+        assert after["metrics"] == before["metrics"]
+        assert after["code"] == "print('hello')"
 
     def test_get_submission(self, review_manager):
         """Test retrieving a submission."""


### PR DESCRIPTION
## Problem

`POST /api/code-review/submit` silently overwrites an existing submission when the caller re-uses a `submission_id`. `submit_code` does an unconditional `self.submissions[submission_id] = submission`, destroying any existing submission — including its `review_count` and `metrics` — while reviews already started against the old submission keep pointing at the stale ID. There was no error path, so clients could not detect the collision.

## Fix

- Added `SubmissionAlreadyExistsError` in `src/utils/code_review.py`.
- `submit_code` now raises `SubmissionAlreadyExistsError` when `submission_id` already exists, instead of clobbering the record.
- The route catches the new exception and returns HTTP 409 Conflict with a clear message, keeping the existing record (review progress, metrics) intact.

## Files changed

- `src/utils/code_review.py` — new `SubmissionAlreadyExistsError`; existence check in `submit_code`.
- `src/routes/main_routes.py` — catch `SubmissionAlreadyExistsError` and return 409.
- `tests/test_code_review.py` — regression tests: duplicate `submission_id` is rejected; rejected re-submit leaves `review_count`/`metrics`/`code` untouched.

## Testing

- Isolated test run of `tests/test_code_review.py` — 21 passed (19 existing + 2 new).
- Route simulation confirmed first submit returns 201, duplicate submit returns 409 with `{"error": "Submission s1 already exists"}`.

Closes #1871
