### PR TITLE
Guard OAuth callbacks against non-JSON GitHub responses

### DIFF
--- a/src/routes/auth_routes.py
+++ b/src/routes/auth_routes.py
@@ -26,7 +26,12 @@ def authorize():
     session['github_token'] = token
     
     resp = github.get('user', token=token)
-    profile = resp.json()
+    if not resp.ok:
+        return redirect(url_for('main.index'))
+    try:
+        profile = resp.json()
+    except ValueError:
+        return redirect(url_for('main.index'))
     
     github_id = str(profile.get('id'))
     username = profile.get('login')

--- a/src/routes/github_routes.py
+++ b/src/routes/github_routes.py
@@ -44,7 +44,12 @@ def callback():
     headers = {"Accept": "application/json"}
 
     response = requests.post(token_url, json=payload, headers=headers)
-    data = response.json()
+    if response.status_code != 200:
+        return redirect("/?github_auth=error")
+    try:
+        data = response.json()
+    except ValueError:
+        return redirect("/?github_auth=error")
 
     access_token = data.get("access_token")
     if access_token:

--- a/tests/test_oauth_json_guard.py
+++ b/tests/test_oauth_json_guard.py
@@ -1,0 +1,99 @@
+# tests/test_oauth_json_guard.py
+# Regression tests for issue #1863: OAuth callbacks must not 500 when
+# GitHub returns a non-JSON / non-200 response. They should redirect to
+# the auth-error path instead of raising on .json().
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import pytest
+
+from app import app, github
+
+
+class FakeTokenResponse:
+    def __init__(self, status_code, content_type, text):
+        self.status_code = status_code
+        self.headers = {"Content-Type": content_type}
+        self._text = text
+
+    def json(self):
+        import json
+        return json.loads(self._text)
+
+
+class FakeAuthlibUserResponse:
+    ok = False
+    status_code = 502
+
+    def json(self):
+        raise ValueError("response is not JSON")
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def test_github_callback_html_error_page_redirects(client, monkeypatch):
+    def fake_post(url, json=None, headers=None):
+        return FakeTokenResponse(502, "text/html", "<html><body>Bad Gateway</body></html>")
+
+    monkeypatch.setattr("requests.post", fake_post)
+    response = client.get("/api/github/callback?code=bad", follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/?github_auth=error"
+
+
+def test_github_callback_empty_body_redirects(client, monkeypatch):
+    def fake_post(url, json=None, headers=None):
+        return FakeTokenResponse(200, "application/json", "")
+
+    monkeypatch.setattr("requests.post", fake_post)
+    response = client.get("/api/github/callback?code=bad", follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/?github_auth=error"
+
+
+def test_github_callback_rate_limited_redirects(client, monkeypatch):
+    def fake_post(url, json=None, headers=None):
+        return FakeTokenResponse(429, "text/plain", "API rate limit exceeded")
+
+    monkeypatch.setattr("requests.post", fake_post)
+    response = client.get("/api/github/callback?code=bad", follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/?github_auth=error"
+
+
+def test_authorize_non_ok_user_response_redirects(client, monkeypatch):
+    monkeypatch.setattr(github, "authorize_access_token", lambda: {"access_token": "t", "token_type": "bearer"})
+    monkeypatch.setattr(github, "get", lambda url, token=None: FakeAuthlibUserResponse())
+
+    response = client.get("/auth/authorize?code=bad", follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/"
+
+
+def test_authorize_valid_user_response_redirects_to_profile(client, monkeypatch):
+    class GoodResponse:
+        ok = True
+        status_code = 200
+
+        def json(self):
+            return {"id": "github-1863-user", "login": "tester", "avatar_url": "http://a"}
+
+    monkeypatch.setattr(github, "authorize_access_token", lambda: {"access_token": "t", "token_type": "bearer"})
+    monkeypatch.setattr(github, "get", lambda url, token=None: GoodResponse())
+
+    with app.app_context():
+        from models import db
+        response = client.get("/auth/authorize?code=good", follow_redirects=False)
+        assert response.status_code == 302
+        assert response.headers["Location"].endswith("/profile")
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
﻿## Problem

Both GitHub OAuth callbacks call .json() without checking HTTP status or content type. When GitHub returns an HTML error page, a 502, or an empty body, the token/authorize responses cannot be parsed as JSON and the unhandled ValueError/JSONDecodeError produces an HTTP 500 instead of the intended graceful auth-error redirect.

## Fix

src/routes/github_routes.py (token exchange in callback):

- Return 302 to /?github_auth=error when the token response is not 200 or cannot be parsed as JSON.

src/routes/auth_routes.py (Authlib authorize flow):

- Return the existing failure redirect when github.get('user') is not ok or the profile cannot be parsed as JSON.

## Files changed

- src/routes/github_routes.py
- src/routes/auth_routes.py
- tests/test_oauth_json_guard.py (new)

## Testing

- New tests test_oauth_json_guard.py (5 tests): HTML error page, empty body, and 429 text responses all redirect to /?github_auth=error instead of 500; authorize flow redirects to / on a non-ok user response and to /profile on a valid one.
- Full suite: 522 passed, 19 pre-existing unrelated failures, 3 skipped.

Closes #1863
