### PR TITLE
fix: point explore navbar/footer anchors at homepage sections (issue #1876)

### DIFF
--- a/src/templates/explore.html
+++ b/src/templates/explore.html
@@ -411,10 +411,10 @@
         <input type="search" id="topic-search-mobile" autocomplete="off" aria-label="Search projects"
           placeholder="Search projects…" />
       </form>
-      <a href="#home" class="nav-mobile-link" role="menuitem">Home</a>
-      <a href="#how-it-works" class="nav-mobile-link" role="menuitem">How It Works</a>
-      <a href="#features" class="nav-mobile-link" role="menuitem">Features</a>
-      <a href="#find-project" class="nav-mobile-link" role="menuitem">Find Project</a>
+      <a href="/#home" class="nav-mobile-link" role="menuitem">Home</a>
+      <a href="/#how-it-works" class="nav-mobile-link" role="menuitem">How It Works</a>
+      <a href="/#features" class="nav-mobile-link" role="menuitem">Features</a>
+      <a href="/#find-project" class="nav-mobile-link" role="menuitem">Find Project</a>
       <a href="/explore" class="nav-mobile-link" role="menuitem">Explore All</a>
       <a href="/compare" class="nav-mobile-link" role="menuitem">Compare</a>
       <a href="/contact" class="nav-mobile-link" role="menuitem">Contact</a>
@@ -604,12 +604,11 @@
       <div class="footer-col">
         <h4 class="footer-col-title">Quick Links</h4>
         <ul class="footer-links-list">
-          <li><a href="#home">Home</a></li>
-          <li><a href="#how-it-works">How It Works</a></li>
-          <li><a href="#features">Features</a></li>
+          <li><a href="/#home">Home</a></li>
+          <li><a href="/#how-it-works">How It Works</a></li>
+          <li><a href="/#features">Features</a></li>
           <li><a href="/explore">Explore All</a></li>
-          <li><a href="#the-project">Find Project</a></li>
-          <li><a href="#find-project">Find Project</a></li>
+          <li><a href="/#find-project">Find Project</a></li>
           <li><a href="/contact">Contact Us</a></li>
         </ul>
       </div>
@@ -627,7 +626,7 @@
       <div class="footer-col">
         <h4 class="footer-col-title">About Us</h4>
         <ul class="footer-links-list">
-          <li><a href="#our-story">Our Story</a></li>
+          <li><a href="/#our-story">Our Story</a></li>
           <li><a href="https://github.com/komalharshita/DevPath" target="_blank" rel="noopener noreferrer">Open Source</a></li>
           <li><a href="https://github.com/komalharshita/DevPath/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">License</a></li>
         </ul>
@@ -637,7 +636,7 @@
     <div class="footer-bottom">
       <p>DevPath is open source. Licensed under the MIT License.</p>
       <div class="footer-bottom-links">
-        <a href="#our-story">About Us</a>
+        <a href="/#our-story">About Us</a>
         <a href="https://github.com/komalharshita/DevPath/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">Project License</a>
       </div>
     </div>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1269,7 +1269,7 @@
           <li><a href="#how-it-works">How It Works</a></li>
           <li><a href="#features">Features</a></li>
           <li><a href="/explore">Explore All</a></li>
-          <li><a href="#the-project">Find Project</a></li>
+          <li><a href="#find-project">Find Project</a></li>
           <li><a href="/contact">Contact Us</a></li>
         </ul>
       </div>

--- a/tests/test_html_anchor_integrity.py
+++ b/tests/test_html_anchor_integrity.py
@@ -1,0 +1,60 @@
+# tests/test_html_anchor_integrity.py
+# Regression test for issue #1876: every same-page anchor (<a href="#id">) in an
+# HTML template must target an element ID that actually exists in that file.
+#
+# Cross-page fragment links (e.g. href="/#home") intentionally point at sections
+# of the homepage and are exempt; only bare "#fragment" targets are checked.
+
+import os
+import re
+
+import pytest
+
+TEMPLATES_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "src",
+    "templates",
+)
+
+_HREF_RE = re.compile(r'href="#([^"]+)"')
+_ID_RE = re.compile(r'\bid="([^"]+)"')
+
+TEMPLATE_FILES = [
+    os.path.relpath(p, TEMPLATES_DIR)
+    for p in (
+        os.path.join(TEMPLATES_DIR, "explore.html"),
+        os.path.join(TEMPLATES_DIR, "index.html"),
+        os.path.join(TEMPLATES_DIR, "project.html"),
+        os.path.join(TEMPLATES_DIR, "profile.html"),
+        os.path.join(TEMPLATES_DIR, "contact.html"),
+        os.path.join(TEMPLATES_DIR, "compare.html"),
+    )
+]
+
+
+def _parse_template(path):
+    with open(os.path.join(TEMPLATES_DIR, path), encoding="utf-8") as f:
+        content = f.read()
+    ids = set(_ID_RE.findall(content))
+    return content, ids
+
+
+@pytest.mark.parametrize("template", TEMPLATE_FILES)
+def test_in_page_anchors_have_matching_ids(template):
+    """Bare #fragment anchors must resolve to an element ID in the same file."""
+    content, ids = _parse_template(template)
+    targets = _HREF_RE.findall(content)
+    missing = sorted({t for t in targets if t not in ids})
+    assert not missing, (
+        f"{template} has in-page anchors with no matching element ID: {missing}"
+    )
+
+
+def test_explore_has_no_dead_section_anchors():
+    """explore.html must not reference homepage-only sections as bare anchors."""
+    content, ids = _parse_template("explore.html")
+    targets = _HREF_RE.findall(content)
+    assert targets == [], (
+        "explore.html still contains dead in-page anchors (issue #1876): "
+        f"{sorted(set(targets))}"
+    )


### PR DESCRIPTION
## Problem

Every anchor in the explore page's navbar, mobile menu, and footer pointed at section anchors (`#home`, `#how-it-works`, `#features`, `#find-project`, `#the-project`, `#our-story`) that do not exist anywhere in `explore.html` — these are copied-over homepage anchors. Clicking any of them scrolled nowhere, so all primary navigation on `/explore` was dead.

## Fix

- Repointed the dead anchors at the homepage sections they are meant to reach (`/#home`, `/#how-it-works`, `/#features`, `/#find-project`, `/#our-story`) in both the explore mobile menu and the explore footer.
- Removed the duplicate "Find Project" footer link that targeted the nonexistent `#the-project` section.
- Also fixed the same `#the-project` → `#find-project` dead anchor in `index.html`'s footer (same bug class; would otherwise trip the new CI check).
- Added `tests/test_html_anchor_integrity.py` — a pure-file CI check that every same-page `<a href="#id">` in the HTML templates resolves to a matching element ID in the same file, with an explicit regression test that `explore.html` contains no bare homepage-section anchors.

## Files changed

- `src/templates/explore.html` — mobile menu + footer links now point at homepage sections.
- `src/templates/index.html` — `#the-project` footer link corrected to `#find-project`.
- `tests/test_html_anchor_integrity.py` — new anchor-integrity CI check (parametrized across the main templates + explore-specific regression test).

## Testing

- `tests/test_html_anchor_integrity.py` — 7 passed (run with `--noconftest` since the app can't boot locally due to the pre-existing #1810).

Closes #1876
