### PR TITLE
fix: stop leaking raw exception messages from code-review API (issue #1880)

### DIFF
--- a/src/routes/main_routes.py
+++ b/src/routes/main_routes.py
@@ -3,7 +3,7 @@
 # Each route is kept thin: it validates input, calls a utility function,
 # and returns a response. No business logic lives here.
 
-from flask import Blueprint, render_template, request, jsonify, send_from_directory, abort, make_response, redirect, url_for, session, flash
+from flask import Blueprint, render_template, request, jsonify, send_from_directory, abort, make_response, redirect, url_for, session, flash, current_app
 
 from utils.recommender import get_recommendations, validate_recommendation_inputs, diagnose_empty_state
 from utils.data_loader import find_project_by_id, load_all_projects, get_available_levels, get_project_stats, get_available_interests
@@ -707,7 +707,8 @@ def submit_code_for_review():
             "submission": submission
         }), 201
     except Exception as e:
-        return jsonify({"error": str(e)}), 400
+        current_app.logger.exception("code review submit error: %s", e)
+        return jsonify({"error": "An internal error occurred."}), 400
 
 
 @main.route("/api/code-review/submission/<submission_id>")
@@ -775,7 +776,8 @@ def start_code_review():
             "review": review
         }), 201
     except ValueError as e:
-        return jsonify({"error": str(e)}), 404
+        current_app.logger.exception("code review start error: %s", e)
+        return jsonify({"error": "An internal error occurred."}), 404
 
 
 @main.route("/api/code-review/<review_id>/comment", methods=["POST"])
@@ -809,7 +811,8 @@ def add_review_comment(review_id):
             "comment": comment
         }), 201
     except ValueError as e:
-        return jsonify({"error": str(e)}), 404
+        current_app.logger.exception("code review comment error: %s", e)
+        return jsonify({"error": "An internal error occurred."}), 404
 
 
 @main.route("/api/code-review/<review_id>/score", methods=["POST"])
@@ -842,7 +845,8 @@ def score_review_category(review_id):
             "category_score": category_score
         }), 201
     except ValueError as e:
-        return jsonify({"error": str(e)}), 400
+        current_app.logger.exception("code review score error: %s", e)
+        return jsonify({"error": "An internal error occurred."}), 400
 
 
 @main.route("/api/code-review/<review_id>/complete", methods=["POST"])
@@ -870,7 +874,8 @@ def complete_code_review(review_id):
             "review": completed
         }), 200
     except ValueError as e:
-        return jsonify({"error": str(e)}), 404
+        current_app.logger.exception("code review complete error: %s", e)
+        return jsonify({"error": "An internal error occurred."}), 404
 
 
 @main.route("/api/code-review/<review_id>/comments")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1098,6 +1098,35 @@ def test_sitemap_includes_compare():
     assert b"/compare" in response.data
 
 
+def test_code_review_errors_do_not_leak_exception_details():
+    """Code-review API errors must return a generic message, not raw str(e)."""
+    client = get_client()
+    generic = "An internal error occurred."
+
+    response = client.post("/api/code-review/submit", json={
+        "submission_id": "s1", "user_id": "u1", "project_id": "not-an-int",
+        "code": "x = 1", "language": "python",
+    })
+    assert response.status_code == 400
+    assert response.get_json()["error"] == generic
+
+    for status, path, payload in (
+        (404, "/api/code-review/start",
+         {"submission_id": "no-such-submission", "reviewer_id": "r1"}),
+        (404, "/api/code-review/no-such-review/comment",
+         {"line_number": 1, "code_snippet": "x", "feedback": "f"}),
+        (400, "/api/code-review/no-such-review/score",
+         {"category": "functionality", "score": 80}),
+        (404, "/api/code-review/no-such-review/complete",
+         {"summary": "done"}),
+    ):
+        response = client.post(path, json=payload)
+        assert response.status_code == status, path
+        error = response.get_json()["error"]
+        assert error == generic, f"{path} leaked: {error}"
+        assert "no-such" not in error, f"{path} leaked exception internals"
+
+
 
 # ============================================================
 # Run tests directly (no pytest required)


### PR DESCRIPTION
## Problem

Five code-review API routes serialized `str(e)` directly into JSON error responses, leaking raw exception strings (exception messages, IDs, internal values) to any caller. This is an information-disclosure vector: an unforeseen runtime error's internals — or a `ValueError` message containing IDs/state — went out verbatim.

## Fix

- In all five routes (`submit_code_for_review`, `start_code_review`, `add_review_comment`, `score_review_category`, `complete_code_review`), the error body is now the generic `"An internal error occurred."` while the real exception is logged server-side via `current_app.logger.exception(...)` (added `current_app` to the Flask imports).
- Status codes are unchanged and remain meaningful (400/404).
- Added `tests/test_basic.py::test_code_review_errors_do_not_leak_exception_details`, asserting all five endpoints return the generic message and never echo the triggering ID/value.

## Files changed

- `src/routes/main_routes.py` — replaced five `jsonify({"error": str(e)})` responses with generic bodies + server-side logging.
- `tests/test_basic.py` — new regression test covering all five routes.

## Testing

- Verified against the real routes (stubbed `portfolio_analyzer` + in-memory SQLite): submit → 400 generic, start/comment/complete → 404 generic, score → 400 generic; exception details appear only in the server log. Full suite runs in CI (local app boot is blocked by the pre-existing #1810).

Closes #1880
