### PR TITLE
fix: honor MAX_RESULTS default cap in recommendations (issue #1881)

### DIFF
--- a/src/utils/recommender.py
+++ b/src/utils/recommender.py
@@ -725,7 +725,7 @@ def get_recommendations(
     scored_projects.sort(key=lambda item: (-item["score"], int(item["project"].get("id", 0))))
     
     selected_projects = (
-      scored_projects
+      scored_projects[:MAX_RESULTS]
       if max_results is None
       else scored_projects[:max_results])
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -304,6 +304,21 @@ def test_get_recommendations_max_three():
     assert len(results.get("recommendations", [])) <= 3, f"Expected at most 3 results, got {len(results.get('recommendations', []))}"
 
 
+def test_get_recommendations_default_cap_applies():
+    """MAX_RESULTS must be honored as the default cap when max_results is None."""
+    capped = get_recommendations("python", "Beginner", "Web", "Low")
+    assert len(capped.get("recommendations", [])) <= 3, (
+        f"Expected default cap of 3, got {len(capped.get('recommendations', []))}"
+    )
+
+    uncapped = get_recommendations(
+        "python", "Beginner", "Web", "Low", max_results=100
+    )
+    assert len(uncapped.get("recommendations", [])) > 3, (
+        "Explicit max_results should override the default cap"
+    )
+
+
 def test_get_recommendations_result_format():
     """Each returned project must be a dict with at least a title and id."""
     results = get_recommendations("Python", "Beginner", "Data", "Low")


### PR DESCRIPTION
## Problem

`MAX_RESULTS = 3` in `recommender.py` was dead code. `get_recommendations` only capped results when `max_results` was non-`None`, and the route always passed `max_results=None`, so the recommendation API returned every relevant project (28–30 on a broad "python" query) — an unbounded payload far beyond what the UI uses.

## Fix

- `src/utils/recommender.py`: `get_recommendations` now honors `MAX_RESULTS` as the default cap — `scored_projects[:MAX_RESULTS]` when `max_results is None`, with explicit `max_results` still able to override.
- `tests/test_basic.py`: added `test_get_recommendations_default_cap_applies`, asserting a broad query returns ≤ 3 by default while an explicit `max_results=100` returns more.

## Files changed

- `src/utils/recommender.py` — the default result cap now takes effect.
- `tests/test_basic.py` — new regression test for the default cap.

## Testing

- Measured against the real engine with a seeded DB: broad "python" queries return 28–30 uncapped and exactly 3 with the default; the existing `test_get_recommendations_max_three` and all other recommender tests (`test_tiebreaker`, `test_case_sensitivity`, determinism/format checks) remain satisfied. Full suite runs in CI (local app boot is blocked by the pre-existing #1810).

Closes #1881
