### PR TITLE
test: expand DevPath Sentinel validator test coverage

### DIFF
--- a/tests/test_sentinel_dataset_validator.py
+++ b/tests/test_sentinel_dataset_validator.py
@@ -258,3 +258,271 @@ def test_missing_dataset_file(tmp_path):
         in error
         for error in result.errors
     )
+
+
+def test_multiple_duplicate_project_ids(tmp_path):
+    """Multiple duplicate IDs should all be reported."""
+
+    create_starter_file(
+        tmp_path,
+        "expense_tracker.py",
+    )
+
+    dataset = write_dataset(
+        tmp_path,
+        [
+            create_project(
+                id=1,
+                title="Expense Tracker",
+            ),
+            create_project(
+                id=1,
+                title="Calculator",
+            ),
+            create_project(
+                id=2,
+                title="Weather App",
+            ),
+            create_project(
+                id=2,
+                title="Todo App",
+            ),
+        ],
+    )
+
+    result = run(dataset)
+
+    assert result.passed is False
+
+    assert result.errors == [
+        "Duplicate project ID: 1",
+        "Duplicate project ID: 2",
+    ]
+
+
+def test_multiple_duplicate_project_titles(tmp_path):
+    """Multiple duplicate titles should all be reported."""
+
+    create_starter_file(
+        tmp_path,
+        "expense_tracker.py",
+    )
+
+    dataset = write_dataset(
+        tmp_path,
+        [
+            create_project(
+                id=1,
+                title="Calculator",
+            ),
+            create_project(
+                id=2,
+                title="Calculator",
+            ),
+            create_project(
+                id=3,
+                title="Todo App",
+            ),
+            create_project(
+                id=4,
+                title="Todo App",
+            ),
+        ],
+    )
+
+    result = run(dataset)
+
+    assert result.passed is False
+
+    assert result.errors == [
+        'Duplicate project title: "Calculator"',
+        'Duplicate project title: "Todo App"',
+    ]
+
+
+def test_whitespace_only_required_field(tmp_path):
+    """Whitespace-only required fields should fail validation."""
+
+    create_starter_file(
+        tmp_path,
+        "expense_tracker.py",
+    )
+
+    dataset = write_dataset(
+        tmp_path,
+        [
+            create_project(
+                title="   ",
+            ),
+        ],
+    )
+
+    result = run(dataset)
+
+    assert result.passed is False
+
+    assert any(
+        "empty 'title'"
+        in error
+        for error in result.errors
+    )
+
+
+def test_empty_required_list_field(tmp_path):
+    """Empty required list fields should fail validation."""
+
+    create_starter_file(
+        tmp_path,
+        "expense_tracker.py",
+    )
+
+    dataset = write_dataset(
+        tmp_path,
+        [
+            create_project(
+                skills=[],
+            ),
+        ],
+    )
+
+    result = run(dataset)
+
+    assert result.passed is False
+
+    assert any(
+        "empty 'skills'"
+        in error
+        for error in result.errors
+    )
+
+
+def test_multiple_missing_required_fields(tmp_path):
+    """Multiple missing required fields should all be reported."""
+
+    create_starter_file(
+        tmp_path,
+        "expense_tracker.py",
+    )
+
+    project = create_project()
+
+    del project["description"]
+    del project["features"]
+    del project["resources"]
+
+    dataset = write_dataset(
+        tmp_path,
+        [project],
+    )
+
+    result = run(dataset)
+
+    assert result.passed is False
+
+    assert len(result.errors) == 1
+
+    assert (
+        "Project 1 is missing required fields: "
+        "description, features, resources"
+        in result.errors[0]
+    )
+
+
+def test_multiple_validation_failures(tmp_path):
+    """Multiple validation checks should be reported together."""
+
+    create_starter_file(
+        tmp_path,
+        "expense_tracker.py",
+    )
+
+    project_one = create_project(
+        id=1,
+        title="Calculator",
+    )
+
+    project_two = create_project(
+        id=1,
+        title="Calculator",
+        skills=[],
+    )
+
+    del project_two["description"]
+
+    dataset = write_dataset(
+        tmp_path,
+        [
+            project_one,
+            project_two,
+        ],
+    )
+
+    result = run(dataset)
+
+    assert result.passed is False
+
+    assert any(
+        "Duplicate project ID: 1"
+        in error
+        for error in result.errors
+    )
+
+    assert any(
+        'Duplicate project title: "Calculator"'
+        in error
+        for error in result.errors
+    )
+
+    assert any(
+        "missing required fields: description"
+        in error
+        for error in result.errors
+    )
+
+    assert any(
+        "empty 'skills'"
+        in error
+        for error in result.errors
+    )
+
+
+def test_duplicate_values_are_reported_in_sorted_order(tmp_path):
+    """Duplicate IDs and titles should be reported deterministically."""
+
+    create_starter_file(
+        tmp_path,
+        "expense_tracker.py",
+    )
+
+    dataset = write_dataset(
+        tmp_path,
+        [
+            create_project(
+                id=3,
+                title="Zebra App",
+            ),
+            create_project(
+                id=1,
+                title="Alpha App",
+            ),
+            create_project(
+                id=3,
+                title="Zebra App",
+            ),
+            create_project(
+                id=1,
+                title="Alpha App",
+            ),
+        ],
+    )
+
+    result = run(dataset)
+
+    assert result.passed is False
+
+    assert result.errors == [
+        "Duplicate project ID: 1",
+        "Duplicate project ID: 3",
+        'Duplicate project title: "Alpha App"',
+        'Duplicate project title: "Zebra App"',
+    ]

--- a/tests/test_starter_code_validator.py
+++ b/tests/test_starter_code_validator.py
@@ -365,3 +365,297 @@ def test_missing_starter_code_directory(tmp_path):
         in error
         for error in result.errors
     )
+
+
+def test_nested_starter_code_file(tmp_path):
+    """Nested starter code files should be discovered and validated."""
+
+    nested_dir = tmp_path / "starter_code" / "python"
+    nested_dir.mkdir(parents=True)
+
+    file_path = nested_dir / "expense_tracker.py"
+    file_path.write_text(
+        "# starter code",
+        encoding="utf-8",
+    )
+
+    dataset = write_dataset(
+        tmp_path,
+        [
+            create_project(
+                starter_code="starter_code/python/expense_tracker.py",
+            ),
+        ],
+    )
+
+    result = run(
+        dataset_path=dataset,
+        starter_code_dir=tmp_path / "starter_code",
+    )
+
+    assert result.passed is True
+    assert result.errors == []
+    assert result.warnings == []
+
+    assert result.details["checks"]["orphan_files"] == []
+
+    assert result.details["count"] == 1
+
+
+def test_nested_orphan_file(tmp_path):
+    """Nested unreferenced starter code files should be detected."""
+
+    nested_dir = tmp_path / "starter_code" / "python"
+    nested_dir.mkdir(parents=True)
+
+    (nested_dir / "expense_tracker.py").write_text(
+        "# starter code",
+        encoding="utf-8",
+    )
+
+    (nested_dir / "calculator.py").write_text(
+        "# orphan starter code",
+        encoding="utf-8",
+    )
+
+    dataset = write_dataset(
+        tmp_path,
+        [
+            create_project(
+                starter_code="starter_code/python/expense_tracker.py",
+            ),
+        ],
+    )
+
+    result = run(
+        dataset_path=dataset,
+        starter_code_dir=tmp_path / "starter_code",
+    )
+
+    assert result.passed is False
+
+    assert result.details["checks"]["orphan_files"] == [
+        "starter_code/python/calculator.py",
+    ]
+
+    assert any(
+        "Orphan Files"
+        in error
+        for error in result.errors
+    )
+
+
+def test_multiple_empty_files(tmp_path):
+    """Multiple empty starter code files should all be detected."""
+
+    create_starter_file(
+        tmp_path,
+        "expense_tracker.py",
+        content="",
+    )
+
+    create_starter_file(
+        tmp_path,
+        "calculator.py",
+        content="",
+    )
+
+    dataset = write_dataset(
+        tmp_path,
+        [
+            create_project(
+                starter_code="starter_code/expense_tracker.py",
+            ),
+            create_project(
+                id=2,
+                title="Calculator",
+                starter_code="starter_code/calculator.py",
+            ),
+        ],
+    )
+
+    result = run(
+        dataset_path=dataset,
+        starter_code_dir=tmp_path / "starter_code",
+    )
+
+    assert result.passed is False
+
+    assert result.details["checks"]["empty_files"] == [
+        "starter_code/calculator.py",
+        "starter_code/expense_tracker.py",
+    ]
+
+    assert any(
+        "Empty Files"
+        in error
+        for error in result.errors
+    )
+
+
+def test_multiple_hidden_files(tmp_path):
+    """Multiple hidden files should all produce a warning."""
+
+    create_starter_file(
+        tmp_path,
+        ".gitkeep",
+    )
+
+    create_starter_file(
+        tmp_path,
+        ".config",
+    )
+
+    dataset = write_dataset(
+        tmp_path,
+        [create_project()],
+    )
+
+    result = run(
+        dataset_path=dataset,
+        starter_code_dir=tmp_path / "starter_code",
+    )
+
+    assert result.passed is False
+
+    assert len(result.warnings) == 2
+
+    assert result.details["checks"]["hidden_files"] == [
+        "starter_code/.config",
+        "starter_code/.gitkeep",
+    ]
+
+    assert any(
+        "Hidden Files"
+        in warning
+        for warning in result.warnings
+    )
+
+
+def test_multiple_unsupported_extensions(tmp_path):
+    """Multiple unsupported file types should all produce warnings."""
+
+    create_starter_file(
+        tmp_path,
+        "expense_tracker.py",
+    )
+
+    create_starter_file(
+        tmp_path,
+        "notes.pdf",
+    )
+
+    create_starter_file(
+        tmp_path,
+        "archive.zip",
+    )
+
+    dataset = write_dataset(
+        tmp_path,
+        [create_project()],
+    )
+
+    result = run(
+        dataset_path=dataset,
+        starter_code_dir=tmp_path / "starter_code",
+    )
+
+    assert result.passed is False
+
+    assert result.details["checks"]["unsupported_extensions"] == [
+        "starter_code/archive.zip",
+        "starter_code/notes.pdf",
+    ]
+
+    assert any(
+        "Unsupported Extensions"
+        in warning
+        for warning in result.warnings
+    )
+
+
+def test_all_supported_extensions(tmp_path):
+    """All configured supported extensions should pass validation."""
+
+    supported_extensions = [
+        ".py",
+        ".js",
+        ".java",
+        ".html",
+        ".css",
+        ".yml",
+        ".yaml",
+        ".txt",
+        ".md",
+    ]
+
+    starter_dir = tmp_path / "starter_code"
+    starter_dir.mkdir()
+
+    projects = []
+
+    for index, extension in enumerate(supported_extensions, start=1):
+        filename = f"project_{index}{extension}"
+
+        (starter_dir / filename).write_text(
+            "# starter code",
+            encoding="utf-8",
+        )
+
+        projects.append(
+            create_project(
+                id=index,
+                title=f"Project {index}",
+                starter_code=f"starter_code/{filename}",
+            )
+        )
+
+    dataset = write_dataset(
+        tmp_path,
+        projects,
+    )
+
+    result = run(
+        dataset_path=dataset,
+        starter_code_dir=starter_dir,
+    )
+
+    assert result.passed is True
+    assert result.errors == []
+    assert result.warnings == []
+
+    assert result.details["checks"]["unsupported_extensions"] == []
+    assert result.details["checks"]["orphan_files"] == []
+
+    assert result.details["count"] == len(supported_extensions)
+
+
+def test_dataset_must_be_json_array(tmp_path):
+    """A JSON object instead of a project list should fail validation."""
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    dataset = data_dir / "projects.json"
+
+    dataset.write_text(
+        json.dumps(
+            {
+                "project": create_project(),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = run(
+        dataset_path=dataset,
+        starter_code_dir=tmp_path / "starter_code",
+    )
+
+    assert result.passed is False
+
+    assert any(
+        "Dataset must contain a JSON array of projects."
+        in error
+        for error in result.errors
+    )


### PR DESCRIPTION
## Summary

Closes #1916

Expand the automated test coverage for DevPath Sentinel's existing validators with additional edge-case and combined-validation scenarios.

This PR focuses entirely on test coverage and does not change the existing validator behavior.

## Changes

### Dataset Validator

Expanded `tests/test_sentinel_dataset_validator.py` to cover:

- Multiple duplicate project IDs
- Multiple duplicate project titles
- Whitespace-only required fields
- Empty required list fields
- Multiple missing required fields
- Multiple validation failures occurring together
- Deterministic ordering of duplicate validation results

The Dataset Validator test suite now contains 15 tests.

### Starter Code Integrity Validator

Expanded `tests/test_starter_code_validator.py` to cover:

- Nested starter code files
- Nested orphan starter code files
- Multiple empty starter code files
- Multiple hidden files
- Multiple unsupported file extensions
- All configured supported starter code extensions
- Invalid dataset structures where the JSON root is not a project list

The Starter Code Integrity Validator test suite now contains 15 tests.

## Test Coverage

The Sentinel validator test suite now contains:

- 15 Dataset Validator tests
- 15 Starter Code Integrity Validator tests
- 30 Sentinel validator tests in total

All Sentinel validator tests pass successfully.

## Scope

This PR:

- Improves regression coverage
- Covers important edge cases
- Verifies combined validation scenarios
- Preserves the existing validator implementation
- Follows the existing pytest structure and helper patterns

No production validator behavior has been changed.

## Testing

```bash
pytest --noconftest tests/test_sentinel_dataset_validator.py tests/test_starter_code_validator.py -v