### PR TITLE
fix(ui): ensure scroll-to-top button always scrolls to top

### DIFF
--- a/src/static/script.js
+++ b/src/static/script.js
@@ -1476,25 +1476,15 @@ if (typeof RecentlyViewed !== "undefined") {
 
 (function initScrollButton() {
   var button = document.getElementById("scroll-top-btn");
-  var icon = document.getElementById("scroll-btn-icon");
   if (!button) return;
-  var atBottom = false;
-
-  function nearBottom() {
-    return window.innerHeight + window.pageYOffset >= document.body.scrollHeight - 40;
-  }
 
   function update() {
     button.classList.toggle("visible", window.pageYOffset > 200);
-    atBottom = nearBottom();
-    button.setAttribute("aria-label", atBottom ? "Scroll to top" : "Scroll to bottom");
-    button.title = atBottom ? "Scroll to top" : "Scroll to bottom";
-    if (icon) icon.innerHTML = atBottom ? '<polyline points="18 15 12 9 6 15"/>' : '<polyline points="6 9 12 15 18 9"/>';
   }
 
   window.addEventListener("scroll", update, { passive: true });
   button.addEventListener("click", function () {
-    window.scrollTo({ top: atBottom ? 0 : document.body.scrollHeight, behavior: "smooth" });
+    window.scrollTo({ top: 0, behavior: "smooth" });
   });
   update();
 })();

--- a/src/templates/explore.html
+++ b/src/templates/explore.html
@@ -659,11 +659,7 @@
 
   <script src="/static/data/skills.js"></script>
 
-  <button id="scroll-top-btn" aria-label="Scroll to top" title="Scroll to top">
-    <svg id="scroll-btn-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-      <polyline points="18 15 12 9 6 15"/>
-    </svg>
-  </button>
+  {% include 'partials/scroll_top_btn.html' %}
 
   <script src="/static/script.js"></script>
   <script src="/static/bookmarks.js"></script>


### PR DESCRIPTION
## Summary [required]

Fixes an issue where clicking the floating "Scroll to top" button would scroll the page down to the bottom first before scrolling to the top on subsequent clicks. This PR updates `initScrollButton` to unconditionally scroll smoothly to the top of the viewport when clicked and standardizes the explore template to use the shared `scroll_top_btn.html` partial.

## Related Issue [required]

Closes #1924

## Type of Change [required]

- [x] Bug fix — resolves a broken behaviour
- [ ] Feature — adds new functionality
- [ ] Data — adds new projects to `data/projects.json`
- [ ] Documentation — updates docs, README, or code comments only
- [ ] Style — CSS or visual changes only, no logic change
- [ ] Refactor — restructures code without changing behaviour
- [ ] Test — adds or updates tests

## What Was Changed [required]

| File | Change made |
|------|-------------|
| `src/static/script.js` | Updated `initScrollButton` click handler to always execute `window.scrollTo({ top: 0, behavior: 'smooth' })` and removed incorrect dual-scroll toggle logic. |
| `src/templates/explore.html` | Replaced duplicate hardcoded scroll button markup with `{% include 'partials/scroll_top_btn.html' %}` for consistency across pages. |

## How to Test This PR [required]

1. Checkout this branch: `git checkout fix/scroll-top-button-1924`
2. Start the application: `PORT=5001 python src/app.py`
3. Navigate to `http://localhost:5001` (or `/explore`, `/compare`, `/projects/<id>`)
4. Scroll down partway (past 200px) so the floating button appears in the bottom right corner
5. Click the scroll-to-top button and observe that it immediately scrolls smoothly to the top of the page.

## Test Results [required]

```
663 passed, 4 skipped, 1 deselected in 6.60s
```

## Self-Review Checklist [required]

- [x] I have read CONTRIBUTING.md and followed all guidelines
- [x] My branch name follows the convention: `fix/`
- [x] I have run the test suite and all existing tests pass
- [x] I have not introduced any `print()` or `console.log()` debug statements
- [x] I have not modified files outside the scope of the linked issue